### PR TITLE
chore(claude): Ignore worktrees created by claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .env
 .claude/settings.local.json
+.claude/worktrees


### PR DESCRIPTION
Ignores .claude/worktrees/<dir> for use with `claude --worktree`