### PR TITLE
Fix invalid dashboard command example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export OMNI_API_TOKEN=omni_osk_...
 
 ```bash
 omni models list
-omni dashboards list
+omni documents list
 omni --help
 ```
 


### PR DESCRIPTION
## Summary
- Replace `omni dashboards list` with `omni documents list` in the README quick start section
- The `dashboards` command group exists but has no `list` subcommand; `documents list` is valid

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)