### PR TITLE
Add downstream notification for omni-agent-skills

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,0 +1,24 @@
+name: Notify Downstream Repos
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger omni-agent-skills sync
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SKILLS_REPO_TOKEN }}
+          repository: exploreomni/omni-agent-skills
+          event-type: cli-update
+          client-payload: >-
+            {
+              "pr_number": "${{ github.event.pull_request.number }}",
+              "pr_title": "${{ github.event.pull_request.title }}",
+              "pr_url": "${{ github.event.pull_request.html_url }}"
+            }

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,13 +1,11 @@
 name: Notify Downstream Repos
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   notify:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Trigger omni-agent-skills sync
@@ -18,7 +16,7 @@ jobs:
           event-type: cli-update
           client-payload: >-
             {
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "pr_title": "${{ github.event.pull_request.title }}",
-              "pr_url": "${{ github.event.pull_request.html_url }}"
+              "release_tag": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}",
+              "commit_sha": "${{ github.sha }}"
             }


### PR DESCRIPTION
## Summary
- Adds a workflow that fires a `repository_dispatch` event to `exploreomni/omni-agent-skills` whenever a PR merges to main
- The skills repo receives this event and runs Claude Code to automatically update skill docs to match CLI changes

## Setup required
- Add a `SKILLS_REPO_TOKEN` secret to this repo — a GitHub PAT with `repo` scope on `exploreomni/omni-agent-skills`

## How it works
```
CLI PR merges → notify-downstream.yml fires → omni-agent-skills receives dispatch → Claude Code analyzes diff → creates PR with skill updates
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)