### PR TITLE
docs: document shell completion install

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,55 @@ omni documents list
 omni --help
 ```
 
+## Shell completions
+
+`omni` supports tab completion for bash, zsh, fish, and PowerShell. Pick your shell below and run the snippet once — tab completion works on every new shell thereafter.
+
+### zsh
+
+Source on every shell start (simplest):
+
+```bash
+echo 'source <(omni completion zsh)' >> ~/.zshrc
+```
+
+Or install into your fpath for faster startup:
+
+```bash
+omni completion zsh > "${fpath[1]}/_omni"
+# ensure `autoload -U compinit && compinit` runs in your .zshrc
+```
+
+### bash
+
+Requires the `bash-completion` package.
+
+```bash
+echo 'source <(omni completion bash)' >> ~/.bashrc
+```
+
+System-wide install (Linux):
+
+```bash
+omni completion bash | sudo tee /etc/bash_completion.d/omni > /dev/null
+```
+
+### fish
+
+```bash
+omni completion fish > ~/.config/fish/completions/omni.fish
+```
+
+### PowerShell
+
+```powershell
+omni completion powershell | Out-String | Invoke-Expression
+```
+
+Add that line to your PowerShell profile to persist it across sessions.
+
+After installing, restart your shell and try: `omni <TAB>`, `omni ai <TAB>`, `omni ai sea<TAB>` → `omni ai search-omni-docs`.
+
 ## How it works
 
 The CLI embeds the OpenAPI spec (`api/openapi.json`) into the binary. At startup it parses the spec and generates cobra subcommands for every operation. Each API tag becomes a command group, path params become positional args, query params become flags, and request bodies are passed via `--body` or stdin.


### PR DESCRIPTION
## Summary
- Cobra 1.10.2 already auto-registers `omni completion {bash,zsh,fish,powershell}` and completion works against the dynamically-generated OpenAPI command tree (verified: `omni __complete "ai" "sea"` → `search-omni-docs`).
- Adds a "Shell completions" README section with one-shot install snippets for each shell so users can actually discover and enable it.
- No code changes.

## Test plan
- [x] `./bin/omni __complete "ai" "sea"` returns `search-omni-docs`
- [x] `zsh -c 'source <(./bin/omni completion zsh); type _omni'` loads the `_omni` function
- [x] `bash -c 'source <(./bin/omni completion bash); complete -p omni'` prints the registered completion
- [ ] Interactive check: in a fresh zsh session, `source <(omni completion zsh)` then `omni ai sea<TAB>` expands to `omni ai search-omni-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)