### PR TITLE
feat: add /release-cli slash command

### DIFF
--- a/.claude/commands/release-cli.md
+++ b/.claude/commands/release-cli.md
@@ -4,17 +4,23 @@ A release here is just `git tag <version>` followed by `git push origin <version
 
 ## User context
 
-The user may pass one argument controlling the version:
+The user may pass arguments controlling the version and whether to actually release:
 
 > $ARGUMENTS
 
-Resolve `$ARGUMENTS` to a target version using these rules:
+Parse `$ARGUMENTS` for two independent things:
+
+**Version selector** (at most one):
 
 - Empty → defaults to `patch` (bump the patch component of the latest tag by 1, e.g. `v1.0.2` → `v1.0.3`).
 - `patch` → same as the default. Accept it explicitly so users can be unambiguous.
 - `minor` → bump the minor component, reset patch to 0 (e.g. `v1.0.2` → `v1.1.0`).
 - `major` → bump the major component, reset minor and patch to 0 (e.g. `v1.0.2` → `v2.0.0`).
 - A literal version like `v2.2.0` (with or without leading `v` — normalize to include it) → use it verbatim.
+
+**Dry-run flag** (optional, can be combined with any version selector):
+
+- `--dry-run`, `-n`, or the bare word `dry-run` → run all the pre-flight checks and version computation, show what *would* happen, but **do not run `git tag` or `git push`** and do not prompt for confirmation. Examples: `/release-cli --dry-run`, `/release-cli minor --dry-run`, `/release-cli v2.2.0 --dry-run`.
 
 Anything else: stop and ask the user what they meant.
 
@@ -38,16 +44,18 @@ Anything else: stop and ask the user what they meant.
    - Skipping components without zeroing the lower ones (e.g. `v1.0.2` → `v1.2.5`): call that out — `"Current version: <latest>. <version> skips the usual minor reset and is unusual, confirm?"`.
    - Otherwise (literal version that's a clean forward bump): `"Current version: <latest>. This will release version <version>. Confirm before proceeding:"`
 
-   Show the message and **wait for an explicit yes** before continuing. Never tag without confirmation.
+   In **dry-run mode**, prefix the message with `[DRY RUN] ` and **do not** wait for a yes. Print the exact commands that *would* run (`git tag <version>` and `git push origin <version>`) and skip to the report step.
 
-5. **Tag and push** — On confirmation:
+   In normal mode, show the message and **wait for an explicit yes** before continuing. Never tag without confirmation.
+
+5. **Tag and push** — Skip this step entirely in dry-run mode. On confirmation:
    ```
    git tag <version>
    git push origin <version>
    ```
    If the push fails, surface the error verbatim and stop.
 
-6. **Report** — Print the released version and the `git push` output. Mention that the tag is now on `origin` and any downstream release automation will pick it up from there.
+6. **Report** — In dry-run mode, print `[DRY RUN] No tag was created and nothing was pushed. Re-run without --dry-run to release <version>.` and stop. In normal mode, print the released version and the `git push` output, and mention that the tag is now on `origin` and any downstream release automation will pick it up from there.
 
 ## Notes
 

--- a/.claude/commands/release-cli.md
+++ b/.claude/commands/release-cli.md
@@ -10,7 +10,8 @@ The user may pass one argument controlling the version:
 
 Resolve `$ARGUMENTS` to a target version using these rules:
 
-- Empty / `patch` → bump the patch component of the latest tag by 1 (e.g. `v1.0.2` → `v1.0.3`).
+- Empty → defaults to `patch` (bump the patch component of the latest tag by 1, e.g. `v1.0.2` → `v1.0.3`).
+- `patch` → same as the default. Accept it explicitly so users can be unambiguous.
 - `minor` → bump the minor component, reset patch to 0 (e.g. `v1.0.2` → `v1.1.0`).
 - `major` → bump the major component, reset minor and patch to 0 (e.g. `v1.0.2` → `v2.0.0`).
 - A literal version like `v2.2.0` (with or without leading `v` — normalize to include it) → use it verbatim.
@@ -24,18 +25,18 @@ Anything else: stop and ask the user what they meant.
    - `git status --porcelain` is empty (clean working tree).
    - `git fetch origin main` succeeds, then `git rev-list --count HEAD..origin/main` is `0` and `git rev-list --count origin/main..HEAD` is `0` (local main is exactly even with origin/main).
 
-2. **Find the latest tag** — `git tag --sort=-v:refname | head -1`. Parse it as `vMAJOR.MINOR.PATCH`. If there are no existing tags, treat the baseline as `v0.0.0` and warn the user.
+2. **Find the latest tag** — `git tag --sort=-v:refname | head -1`. Parse it as `vMAJOR.MINOR.PATCH`. **Print the current version to the user** (e.g. `Current version: v1.0.2`) so it's visible before they confirm. If there are no existing tags, treat the baseline as `v0.0.0` and tell the user no prior tag was found.
 
 3. **Compute the target version** — Apply the rule from `$ARGUMENTS` to get the new version string. Always include the leading `v`.
 
-4. **Sanity-check the jump** — Compare the target to the latest tag and craft a *semantic* confirmation message:
-   - Normal patch/minor/major bump (one component up by 1, lower components zeroed where appropriate): `"This will create release <version>. Confirm before proceeding:"`
+4. **Sanity-check the jump** — Compare the target to the latest tag and craft a *semantic* confirmation message. Always include both the current and target version in the message so the user can eyeball the jump:
+   - Normal patch/minor/major bump (one component up by 1, lower components zeroed where appropriate): `"Current version: <latest>. This will create release <version>. Confirm before proceeding:"`
    - Target is `<=` latest tag (would re-tag or move backwards): `"WARNING: <version> is not newer than the latest tag <latest>. This will fail or rewrite history. Are you sure?"`
-   - Target tag already exists locally or on origin (`git rev-parse <version>` succeeds, or `git ls-remote --tags origin <version>` returns a row): `"WARNING: tag <version> already exists. Refusing to overwrite — pick a different version."` and stop.
-   - Major jump > 1 (e.g. `v1.x.x` → `v3.0.0`): `"WARNING: this jumps the major version by N. That looks like a large jump and is probably a mistake. Are you sure you want to proceed?"`
-   - Minor jump > 1 within the same major, or patch jump > 1 within the same minor: similar wording, calling out the actual delta.
-   - Skipping components without zeroing the lower ones (e.g. `v1.0.2` → `v1.2.5`): call that out — "this skips the usual minor reset; <version> is unusual, confirm?"
-   - Otherwise (literal version that's a clean forward bump): `"This will release version <version>. Confirm before proceeding:"`
+   - Target tag already exists locally or on origin (`git rev-parse <version>` succeeds, or `git ls-remote --tags origin <version>` returns a row): `"WARNING: tag <version> already exists (current: <latest>). Refusing to overwrite — pick a different version."` and stop.
+   - Major jump > 1 (e.g. `v1.x.x` → `v3.0.0`): `"WARNING: jumping from <latest> to <version> bumps the major version by N. That looks like a large jump and is probably a mistake. Are you sure you want to proceed?"`
+   - Minor jump > 1 within the same major, or patch jump > 1 within the same minor: similar wording, calling out the actual delta and showing both versions.
+   - Skipping components without zeroing the lower ones (e.g. `v1.0.2` → `v1.2.5`): call that out — `"Current version: <latest>. <version> skips the usual minor reset and is unusual, confirm?"`.
+   - Otherwise (literal version that's a clean forward bump): `"Current version: <latest>. This will release version <version>. Confirm before proceeding:"`
 
    Show the message and **wait for an explicit yes** before continuing. Never tag without confirmation.
 

--- a/.claude/commands/release-cli.md
+++ b/.claude/commands/release-cli.md
@@ -1,0 +1,54 @@
+Cut a new release of the omni CLI by tagging `main` and pushing the tag.
+
+A release here is just `git tag <version>` followed by `git push origin <version>`. There is no separate build/upload step — that's wired up downstream from the tag push.
+
+## User context
+
+The user may pass one argument controlling the version:
+
+> $ARGUMENTS
+
+Resolve `$ARGUMENTS` to a target version using these rules:
+
+- Empty / `patch` → bump the patch component of the latest tag by 1 (e.g. `v1.0.2` → `v1.0.3`).
+- `minor` → bump the minor component, reset patch to 0 (e.g. `v1.0.2` → `v1.1.0`).
+- `major` → bump the major component, reset minor and patch to 0 (e.g. `v1.0.2` → `v2.0.0`).
+- A literal version like `v2.2.0` (with or without leading `v` — normalize to include it) → use it verbatim.
+
+Anything else: stop and ask the user what they meant.
+
+## Steps
+
+1. **Pre-flight** — All of these must pass; if any fails, stop and report it. Do not attempt to fix the working tree (no resets, no stashes) without explicit user direction.
+   - `git rev-parse --abbrev-ref HEAD` is `main`.
+   - `git status --porcelain` is empty (clean working tree).
+   - `git fetch origin main` succeeds, then `git rev-list --count HEAD..origin/main` is `0` and `git rev-list --count origin/main..HEAD` is `0` (local main is exactly even with origin/main).
+
+2. **Find the latest tag** — `git tag --sort=-v:refname | head -1`. Parse it as `vMAJOR.MINOR.PATCH`. If there are no existing tags, treat the baseline as `v0.0.0` and warn the user.
+
+3. **Compute the target version** — Apply the rule from `$ARGUMENTS` to get the new version string. Always include the leading `v`.
+
+4. **Sanity-check the jump** — Compare the target to the latest tag and craft a *semantic* confirmation message:
+   - Normal patch/minor/major bump (one component up by 1, lower components zeroed where appropriate): `"This will create release <version>. Confirm before proceeding:"`
+   - Target is `<=` latest tag (would re-tag or move backwards): `"WARNING: <version> is not newer than the latest tag <latest>. This will fail or rewrite history. Are you sure?"`
+   - Target tag already exists locally or on origin (`git rev-parse <version>` succeeds, or `git ls-remote --tags origin <version>` returns a row): `"WARNING: tag <version> already exists. Refusing to overwrite — pick a different version."` and stop.
+   - Major jump > 1 (e.g. `v1.x.x` → `v3.0.0`): `"WARNING: this jumps the major version by N. That looks like a large jump and is probably a mistake. Are you sure you want to proceed?"`
+   - Minor jump > 1 within the same major, or patch jump > 1 within the same minor: similar wording, calling out the actual delta.
+   - Skipping components without zeroing the lower ones (e.g. `v1.0.2` → `v1.2.5`): call that out — "this skips the usual minor reset; <version> is unusual, confirm?"
+   - Otherwise (literal version that's a clean forward bump): `"This will release version <version>. Confirm before proceeding:"`
+
+   Show the message and **wait for an explicit yes** before continuing. Never tag without confirmation.
+
+5. **Tag and push** — On confirmation:
+   ```
+   git tag <version>
+   git push origin <version>
+   ```
+   If the push fails, surface the error verbatim and stop.
+
+6. **Report** — Print the released version and the `git push` output. Mention that the tag is now on `origin` and any downstream release automation will pick it up from there.
+
+## Notes
+
+- This command never amends, force-pushes, or deletes tags. If something looks off (target already exists, tree dirty, branch behind), stop and tell the user — let them decide.
+- Don't run `make build` / `make test` here. The gate for releases is that `main` is already green; this command just publishes a tag.


### PR DESCRIPTION
## Summary
- Adds a `/release-cli` slash command at `.claude/commands/release-cli.md` that cuts a release by tagging `main` and pushing the tag.
- Defaults to a patch bump from the latest tag (currently `v1.0.2` → `v1.0.3`); also accepts `patch`, `minor`, `major`, or a literal version like `v2.2.0`.
- Pre-flight gates require a clean tree on `main` that is even with `origin/main`. Refuses to overwrite an existing tag.
- Confirmation message is tailored to the jump: plain "Confirm before proceeding" for normal bumps, explicit WARNINGs for backwards moves, existing tags, or unusual major/minor/patch jumps.

## Test plan
- [ ] `/release-cli` (no args) on `main` proposes the next patch version and waits for confirmation
- [ ] `/release-cli minor` and `/release-cli major` propose the right bumps
- [ ] `/release-cli v2.2.0` proposes the literal version with the large-jump warning
- [ ] `/release-cli v1.0.2` (existing tag) refuses with a WARNING and stops
- [ ] Refuses to proceed when the working tree is dirty or the branch isn't `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)