### PR TITLE
sync spec: add models commit endpoint for git PR push (#53)

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -16,7 +16,7 @@
       "name": "AI"
     },
     {
-      "description": "API token administration. List organization, personal, and MCP tokens.",
+      "description": "API token management",
       "name": "API Tokens"
     },
     {
@@ -1036,6 +1036,41 @@
           "membershipId",
           "name",
           "type"
+        ]
+      },
+      "ApiKeyUpdateBody": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Set to `false` to disable the token, `true` to re-enable it. Only organization-level tokens may be disabled; personal and MCP tokens do not support this.",
+            "example": false
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "additionalProperties": false
+      },
+      "ApiKeyDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the outcome",
+            "example": "API token revoked"
+          },
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always `true` on a successful revocation"
+          }
+        },
+        "required": [
+          "message",
+          "success"
         ]
       },
       "DbtEnvironmentListResponse": {
@@ -2246,7 +2281,8 @@
               "omni-spreadsheet",
               "spreadsheet-tab",
               "summary-value",
-              "omni-table"
+              "omni-table",
+              "app"
             ],
             "description": "Visualization type (e.g. basic, omni-markdown, omni-table)"
           }
@@ -4696,6 +4732,72 @@
             "description": "Publish branch-attached drafts"
           }
         }
+      },
+      "ModelsCommitResponse": {
+        "type": "object",
+        "properties": {
+          "did_sync": {
+            "type": "boolean",
+            "description": "Whether a sync operation was performed against git"
+          },
+          "git_sha": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The git SHA of the commit that was pushed (null if no commit was needed)"
+          },
+          "in_sync": {
+            "type": "boolean",
+            "description": "Whether the branch is in sync with git after the operation"
+          },
+          "pr_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The URL of the pull request (or PR creation page for newly-created PRs). May be null when the underlying git provider is not recognized."
+          }
+        },
+        "required": [
+          "did_sync",
+          "git_sha",
+          "in_sync",
+          "pr_url"
+        ]
+      },
+      "ModelsCommitBody": {
+        "type": "object",
+        "properties": {
+          "allow_branch_exists": {
+            "type": "boolean",
+            "default": true,
+            "description": "If true (default), the commit succeeds whether the git branch already exists or not. If false, the request fails when the git branch already exists — use this to ensure only new pull requests are created. Cannot be false when require_branch_exists is true.",
+            "example": true
+          },
+          "branch_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the branch to commit.",
+            "example": "123e4567-e89b-12d3-a456-426614174001"
+          },
+          "commit_message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Commit message for the git commit.",
+            "example": "Add new orders view"
+          },
+          "require_branch_exists": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, the request fails when the git branch does not already exist — use this to ensure only existing pull requests are updated. Defaults to false. Cannot be true when allow_branch_exists is false.",
+            "example": false
+          }
+        },
+        "required": [
+          "branch_id",
+          "commit_message"
+        ]
       },
       "ModelsCacheResetResponse": {
         "type": "object",
@@ -8566,6 +8668,156 @@
         }
       }
     },
+    "/api/v1/api-keys/{id}": {
+      "get": {
+        "description": "Returns a single API token by id. Requires organization admin permissions.",
+        "operationId": "apiKeysGet",
+        "summary": "Get API token",
+        "tags": [
+          "API Tokens"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Token UUID",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "Token UUID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested API token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `id` (must be a UUID)"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Insufficient permissions"
+          },
+          "404": {
+            "description": "Token not found in this organization"
+          }
+        }
+      },
+      "put": {
+        "description": "Enables or disables an organization-level API token. Personal access tokens and MCP OAuth grants do not support this operation. Requires organization admin permissions.",
+        "operationId": "apiKeysUpdate",
+        "summary": "Enable or disable an organization API token",
+        "tags": [
+          "API Tokens"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Token UUID",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "Token UUID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated API token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body, malformed `id`, target is not an organization token, or missing/malformed `Authorization` header"
+          },
+          "403": {
+            "description": "Invalid bearer token, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Token not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      },
+      "delete": {
+        "description": "Revokes an API token by permanently deleting it. Works for all token types. Requires organization admin permissions.",
+        "operationId": "apiKeysDelete",
+        "summary": "Revoke an API token",
+        "tags": [
+          "API Tokens"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Token UUID",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "Token UUID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The token was revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `id`, or missing/malformed `Authorization` header"
+          },
+          "403": {
+            "description": "Invalid bearer token, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Token not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
     "/api/v1/connections": {
       "get": {
         "operationId": "connectionsList",
@@ -8816,11 +9068,31 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "acceptsLicense": {
+                    "type": "boolean",
+                    "description": "Acceptance of the license terms. Required for Oracle connections.",
+                    "example": true
+                  },
                   "allowsUserSpecificTimezones": {
                     "type": "boolean",
                     "default": false,
                     "description": "Whether to allow users to specify their own timezones",
                     "example": false
+                  },
+                  "alwaysScopeViewNames": {
+                    "type": "boolean",
+                    "description": "Whether to always include schema (and catalog) prefixes in generated view names, even for tables in the default schema. Defaults to true for dialects that support multiple catalogs, false otherwise.",
+                    "example": true
+                  },
+                  "authenticationType": {
+                    "type": "string",
+                    "description": "Authentication type. Applicable for BigQuery, MSSQL, Snowflake, Databricks, and Athena.",
+                    "example": "snowflake-password"
+                  },
+                  "awsRoleArn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN. Applicable for Athena only.",
+                    "example": "arn:aws:iam::123456789012:role/OmniAthenaRole"
                   },
                   "baseRole": {
                     "type": "string",
@@ -8852,13 +9124,16 @@
                       "bigquery",
                       "clickhouse",
                       "databricks",
+                      "databricks_lakebase",
                       "exasol",
                       "mariadb",
                       "motherduck",
                       "mssql",
                       "mysql",
+                      "oracle",
                       "postgres",
                       "redshift",
+                      "sap_hana",
                       "snowflake",
                       "starrocks",
                       "trino"
@@ -8866,10 +9141,43 @@
                     "description": "The database dialect",
                     "example": "snowflake"
                   },
+                  "enableDbSemanticLayerIntegration": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable the dialect-native semantic layer integration. Applicable for Snowflake and Databricks.",
+                    "example": false
+                  },
+                  "enableDbSemanticLayerTopics": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable the dialect-native semantic layer topics. Applicable for Snowflake and Databricks.",
+                    "example": false
+                  },
+                  "externalOauthAudience": {
+                    "type": "string",
+                    "description": "External OAuth audience claim. Applicable for Snowflake."
+                  },
+                  "externalOauthAuthorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth authorization URL (must be HTTPS). Applicable for Snowflake.",
+                    "example": "https://oauth.example.com/authorize"
+                  },
+                  "externalOauthTokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth token URL (must be HTTPS). Applicable for Snowflake.",
+                    "example": "https://oauth.example.com/token"
+                  },
                   "host": {
                     "type": "string",
                     "description": "The hostname or IP address of the database server. For Snowflake, provide only the account identifier.",
                     "example": "myaccount"
+                  },
+                  "hostOverride": {
+                    "type": "string",
+                    "description": "Custom Snowflake host (when not using the account identifier). Mutually exclusive with `host`.",
+                    "example": "myaccount.snowflakecomputing.com"
                   },
                   "includeOtherCatalogs": {
                     "type": "string",
@@ -8881,6 +9189,18 @@
                     "description": "Comma-separated list of schemas to include. Leave empty to include all schemas.",
                     "example": "public,analytics"
                   },
+                  "inferRelationshipsFromColumnNames": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to infer relationships from column-name conventions during schema refresh. Defaults to true.",
+                    "example": true
+                  },
+                  "inferRelationshipsFromForeignKeys": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to infer relationships from declared foreign keys during schema refresh. Currently honored for Postgres and Snowflake.",
+                    "example": false
+                  },
                   "maxBillingBytes": {
                     "type": "string",
                     "description": "Maximum bytes that can be billed for a BigQuery query. Applicable for BigQuery only.",
@@ -8890,6 +9210,31 @@
                     "type": "string",
                     "description": "A descriptive name for the connection",
                     "example": "Production Warehouse"
+                  },
+                  "oauthClientId": {
+                    "type": "string",
+                    "description": "OAuth client ID for admin schema refresh. Applicable for Snowflake and Databricks."
+                  },
+                  "oauthClientSecretUnencrypted": {
+                    "type": "string",
+                    "description": "OAuth client secret for admin schema refresh. Applicable for Snowflake and Databricks."
+                  },
+                  "offloadedSchemas": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Schemas whose tables should be queried via the offloaded engine. Accepts a comma-separated string or an array of schema names.",
+                    "example": [
+                      "analytics_archive"
+                    ]
                   },
                   "passwordUnencrypted": {
                     "type": "string",
@@ -8933,7 +9278,12 @@
                   "trustServerCertificate": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to trust the server certificate. Applicable for MSSQL, Exasol, and ClickHouse.",
+                    "description": "Whether to trust the server certificate. Applicable for MSSQL, Exasol, ClickHouse, Trino, and SAP HANA.",
+                    "example": false
+                  },
+                  "useMachineAuth": {
+                    "type": "boolean",
+                    "description": "Whether to authenticate using machine credentials (OAuth M2M). Applicable for Athena and Databricks.",
                     "example": false
                   },
                   "username": {
@@ -14906,6 +15256,64 @@
           },
           "403": {
             "description": "Permission denied or PR required"
+          },
+          "404": {
+            "description": "Model or branch not found"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/git/commit": {
+      "post": {
+        "description": "Push the branch contents to git and create or update a pull request. The backend automatically detects whether the git branch already exists: if not, it creates a new git branch and opens a PR; if it does, it commits the latest model contents to the existing branch (updating the open PR).",
+        "operationId": "modelsCommit",
+        "summary": "Commit branch to git",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelsCommitBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Branch committed to git and pull request created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsCommitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied or git not configured"
           },
           "404": {
             "description": "Model or branch not found"

--- a/cmd/omni/openapi.json
+++ b/cmd/omni/openapi.json
@@ -16,7 +16,7 @@
       "name": "AI"
     },
     {
-      "description": "API token administration. List organization, personal, and MCP tokens.",
+      "description": "API token management",
       "name": "API Tokens"
     },
     {
@@ -1036,6 +1036,41 @@
           "membershipId",
           "name",
           "type"
+        ]
+      },
+      "ApiKeyUpdateBody": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Set to `false` to disable the token, `true` to re-enable it. Only organization-level tokens may be disabled; personal and MCP tokens do not support this.",
+            "example": false
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "additionalProperties": false
+      },
+      "ApiKeyDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the outcome",
+            "example": "API token revoked"
+          },
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always `true` on a successful revocation"
+          }
+        },
+        "required": [
+          "message",
+          "success"
         ]
       },
       "DbtEnvironmentListResponse": {
@@ -2246,7 +2281,8 @@
               "omni-spreadsheet",
               "spreadsheet-tab",
               "summary-value",
-              "omni-table"
+              "omni-table",
+              "app"
             ],
             "description": "Visualization type (e.g. basic, omni-markdown, omni-table)"
           }
@@ -4696,6 +4732,72 @@
             "description": "Publish branch-attached drafts"
           }
         }
+      },
+      "ModelsCommitResponse": {
+        "type": "object",
+        "properties": {
+          "did_sync": {
+            "type": "boolean",
+            "description": "Whether a sync operation was performed against git"
+          },
+          "git_sha": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The git SHA of the commit that was pushed (null if no commit was needed)"
+          },
+          "in_sync": {
+            "type": "boolean",
+            "description": "Whether the branch is in sync with git after the operation"
+          },
+          "pr_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The URL of the pull request (or PR creation page for newly-created PRs). May be null when the underlying git provider is not recognized."
+          }
+        },
+        "required": [
+          "did_sync",
+          "git_sha",
+          "in_sync",
+          "pr_url"
+        ]
+      },
+      "ModelsCommitBody": {
+        "type": "object",
+        "properties": {
+          "allow_branch_exists": {
+            "type": "boolean",
+            "default": true,
+            "description": "If true (default), the commit succeeds whether the git branch already exists or not. If false, the request fails when the git branch already exists — use this to ensure only new pull requests are created. Cannot be false when require_branch_exists is true.",
+            "example": true
+          },
+          "branch_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the branch to commit.",
+            "example": "123e4567-e89b-12d3-a456-426614174001"
+          },
+          "commit_message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Commit message for the git commit.",
+            "example": "Add new orders view"
+          },
+          "require_branch_exists": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, the request fails when the git branch does not already exist — use this to ensure only existing pull requests are updated. Defaults to false. Cannot be true when allow_branch_exists is false.",
+            "example": false
+          }
+        },
+        "required": [
+          "branch_id",
+          "commit_message"
+        ]
       },
       "ModelsCacheResetResponse": {
         "type": "object",
@@ -8566,6 +8668,156 @@
         }
       }
     },
+    "/api/v1/api-keys/{id}": {
+      "get": {
+        "description": "Returns a single API token by id. Requires organization admin permissions.",
+        "operationId": "apiKeysGet",
+        "summary": "Get API token",
+        "tags": [
+          "API Tokens"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Token UUID",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "Token UUID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested API token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `id` (must be a UUID)"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Insufficient permissions"
+          },
+          "404": {
+            "description": "Token not found in this organization"
+          }
+        }
+      },
+      "put": {
+        "description": "Enables or disables an organization-level API token. Personal access tokens and MCP OAuth grants do not support this operation. Requires organization admin permissions.",
+        "operationId": "apiKeysUpdate",
+        "summary": "Enable or disable an organization API token",
+        "tags": [
+          "API Tokens"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Token UUID",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "Token UUID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated API token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body, malformed `id`, target is not an organization token, or missing/malformed `Authorization` header"
+          },
+          "403": {
+            "description": "Invalid bearer token, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Token not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      },
+      "delete": {
+        "description": "Revokes an API token by permanently deleting it. Works for all token types. Requires organization admin permissions.",
+        "operationId": "apiKeysDelete",
+        "summary": "Revoke an API token",
+        "tags": [
+          "API Tokens"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Token UUID",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "Token UUID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The token was revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `id`, or missing/malformed `Authorization` header"
+          },
+          "403": {
+            "description": "Invalid bearer token, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Token not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
     "/api/v1/connections": {
       "get": {
         "operationId": "connectionsList",
@@ -8816,11 +9068,31 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "acceptsLicense": {
+                    "type": "boolean",
+                    "description": "Acceptance of the license terms. Required for Oracle connections.",
+                    "example": true
+                  },
                   "allowsUserSpecificTimezones": {
                     "type": "boolean",
                     "default": false,
                     "description": "Whether to allow users to specify their own timezones",
                     "example": false
+                  },
+                  "alwaysScopeViewNames": {
+                    "type": "boolean",
+                    "description": "Whether to always include schema (and catalog) prefixes in generated view names, even for tables in the default schema. Defaults to true for dialects that support multiple catalogs, false otherwise.",
+                    "example": true
+                  },
+                  "authenticationType": {
+                    "type": "string",
+                    "description": "Authentication type. Applicable for BigQuery, MSSQL, Snowflake, Databricks, and Athena.",
+                    "example": "snowflake-password"
+                  },
+                  "awsRoleArn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN. Applicable for Athena only.",
+                    "example": "arn:aws:iam::123456789012:role/OmniAthenaRole"
                   },
                   "baseRole": {
                     "type": "string",
@@ -8852,13 +9124,16 @@
                       "bigquery",
                       "clickhouse",
                       "databricks",
+                      "databricks_lakebase",
                       "exasol",
                       "mariadb",
                       "motherduck",
                       "mssql",
                       "mysql",
+                      "oracle",
                       "postgres",
                       "redshift",
+                      "sap_hana",
                       "snowflake",
                       "starrocks",
                       "trino"
@@ -8866,10 +9141,43 @@
                     "description": "The database dialect",
                     "example": "snowflake"
                   },
+                  "enableDbSemanticLayerIntegration": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable the dialect-native semantic layer integration. Applicable for Snowflake and Databricks.",
+                    "example": false
+                  },
+                  "enableDbSemanticLayerTopics": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable the dialect-native semantic layer topics. Applicable for Snowflake and Databricks.",
+                    "example": false
+                  },
+                  "externalOauthAudience": {
+                    "type": "string",
+                    "description": "External OAuth audience claim. Applicable for Snowflake."
+                  },
+                  "externalOauthAuthorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth authorization URL (must be HTTPS). Applicable for Snowflake.",
+                    "example": "https://oauth.example.com/authorize"
+                  },
+                  "externalOauthTokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth token URL (must be HTTPS). Applicable for Snowflake.",
+                    "example": "https://oauth.example.com/token"
+                  },
                   "host": {
                     "type": "string",
                     "description": "The hostname or IP address of the database server. For Snowflake, provide only the account identifier.",
                     "example": "myaccount"
+                  },
+                  "hostOverride": {
+                    "type": "string",
+                    "description": "Custom Snowflake host (when not using the account identifier). Mutually exclusive with `host`.",
+                    "example": "myaccount.snowflakecomputing.com"
                   },
                   "includeOtherCatalogs": {
                     "type": "string",
@@ -8881,6 +9189,18 @@
                     "description": "Comma-separated list of schemas to include. Leave empty to include all schemas.",
                     "example": "public,analytics"
                   },
+                  "inferRelationshipsFromColumnNames": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to infer relationships from column-name conventions during schema refresh. Defaults to true.",
+                    "example": true
+                  },
+                  "inferRelationshipsFromForeignKeys": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to infer relationships from declared foreign keys during schema refresh. Currently honored for Postgres and Snowflake.",
+                    "example": false
+                  },
                   "maxBillingBytes": {
                     "type": "string",
                     "description": "Maximum bytes that can be billed for a BigQuery query. Applicable for BigQuery only.",
@@ -8890,6 +9210,31 @@
                     "type": "string",
                     "description": "A descriptive name for the connection",
                     "example": "Production Warehouse"
+                  },
+                  "oauthClientId": {
+                    "type": "string",
+                    "description": "OAuth client ID for admin schema refresh. Applicable for Snowflake and Databricks."
+                  },
+                  "oauthClientSecretUnencrypted": {
+                    "type": "string",
+                    "description": "OAuth client secret for admin schema refresh. Applicable for Snowflake and Databricks."
+                  },
+                  "offloadedSchemas": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Schemas whose tables should be queried via the offloaded engine. Accepts a comma-separated string or an array of schema names.",
+                    "example": [
+                      "analytics_archive"
+                    ]
                   },
                   "passwordUnencrypted": {
                     "type": "string",
@@ -8933,7 +9278,12 @@
                   "trustServerCertificate": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to trust the server certificate. Applicable for MSSQL, Exasol, and ClickHouse.",
+                    "description": "Whether to trust the server certificate. Applicable for MSSQL, Exasol, ClickHouse, Trino, and SAP HANA.",
+                    "example": false
+                  },
+                  "useMachineAuth": {
+                    "type": "boolean",
+                    "description": "Whether to authenticate using machine credentials (OAuth M2M). Applicable for Athena and Databricks.",
                     "example": false
                   },
                   "username": {
@@ -14906,6 +15256,64 @@
           },
           "403": {
             "description": "Permission denied or PR required"
+          },
+          "404": {
+            "description": "Model or branch not found"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/git/commit": {
+      "post": {
+        "description": "Push the branch contents to git and create or update a pull request. The backend automatically detects whether the git branch already exists: if not, it creates a new git branch and opens a PR; if it does, it commits the latest model contents to the existing branch (updating the open PR).",
+        "operationId": "modelsCommit",
+        "summary": "Commit branch to git",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelsCommitBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Branch committed to git and pull request created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsCommitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied or git not configured"
           },
           "404": {
             "description": "Model or branch not found"


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/models/{modelId}/git/commit` (`modelsCommit`) — pushes branch model contents to git, creating a new branch + PR if one does not exist, or updating the existing PR otherwise. Surfaces as `omni models commit <modelId> --body '{...}'`. Body fields: `branch_id` (required, uuid), `commit_message` (required), `allow_branch_exists` (default true), `require_branch_exists` (default false). Mirrors the create/update PR button in the Omni UI.
- Side-effect changes pulled in by the full sync:
  - New API tokens CRUD: `GET`/`PUT`/`DELETE /api/v1/api-keys/{id}` (`apiKeysGet`, `apiKeysUpdate`, `apiKeysDelete`) — surfaces as `omni api-tokens api-keys-{get,update,delete} <id>`. PUT enable/disable takes a request body.
  - `visualization type` enum gains `"app"`.

Fixes #53

## Test plan

- [x] `make build` succeeds
- [x] `make test` — all packages pass
- [x] `./bin/omni models commit --help` shows the new command with `<modelid>` positional and `--body` flag
- [x] `./bin/omni api-tokens api-keys-{get,update,delete} --help` all show new commands wired up correctly
- [ ] Live verification of `models commit` against a real Omni instance (deferred — no profile configured for this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)