### PR TITLE
Harden CI workflows and install.sh against supply-chain attacks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -9,6 +9,8 @@ on:
       - "**/*.md"
       - "!.github/**"
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger mintlify-omni docs sync
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.DOCS_REPO_TOKEN }}
           repository: exploreomni/mintlify-omni

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger omni-agent-skills sync
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.SKILLS_REPO_TOKEN }}
           repository: exploreomni/omni-agent-skills

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser (release artifacts only)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean
@@ -30,7 +30,7 @@ jobs:
 
       - name: Checkout Homebrew tap
         if: ${{ !contains(github.ref_name, '-') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: exploreomni/homebrew-tap
           ref: main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 

--- a/install.sh
+++ b/install.sh
@@ -99,8 +99,8 @@ verify_checksum() {
     elif command -v shasum >/dev/null 2>&1; then
         actual=$(shasum -a 256 "${dir}/${file}" | awk '{print $1}')
     else
-        echo "Warning: No sha256 tool found, skipping checksum verification" >&2
-        return
+        echo "Error: No sha256 tool found (need sha256sum or shasum); refusing to install without checksum verification" >&2
+        exit 1
     fi
 
     if [ "$expected" != "$actual" ]; then


### PR DESCRIPTION
## Summary

Motivated by the [TanStack npm supply-chain compromise postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem). After auditing this repo against the three primitives in that attack (`pull_request_target` running fork code, Actions cache poisoning across trust boundaries, OIDC token theft), none applied directly. But several adjacent hardening items did. This PR addresses the three lowest-effort, highest-leverage ones.

- **Pin third-party actions to commit SHAs.** Floating major-version tags (`@v4`, `@v5`, `@v6`, `@v3`) move silently if the upstream action is compromised, which would grant attackers `contents: write` plus access to `HOMEBREW_TAP_GITHUB_TOKEN`, `DOCS_REPO_TOKEN`, and `SKILLS_REPO_TOKEN` in a single run. Pinned to current SHAs with the version in a trailing comment for human readability.
- **Add top-level `permissions:` blocks.** `lint.yml` and `test.yml` get `contents: read`; the two notify workflows get `{}` (they only use a PAT for `repository-dispatch`). `release.yml` already declared `contents: write`.
- **Make `install.sh` fail closed on missing sha256 tool.** Was a soft warning + continue, now hard error. Users without `sha256sum`/`shasum` are an edge case but the silent fallback turned the installer into an unverified `curl | sh`.

## Out of scope / follow-ups

Findings from the same audit that were left for separate PRs:
- Add Sigstore / GitHub Artifact Attestations to GoReleaser config so the published checksums file is itself verifiable.
- Migrate the three cross-repo PATs to a GitHub App or fine-grained scoped tokens with rotation.
- Pin GoReleaser binary version (currently `~> v2`).
- Add Dependabot + `govulncheck` in CI.

## Test plan

- [x] `lint.yml` succeeds on this PR (uses the newly pinned SHAs)
- [x] `test.yml` succeeds on this PR
- [x] Confirm permissions blocks don't break anything that was relying on implicit `GITHUB_TOKEN` scope
- [x] Manual: run `install.sh` in a container without `sha256sum`/`shasum` and verify it exits non-zero
- [ ] Next release-tag push verifies `release.yml` still produces artifacts and updates the Homebrew tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)