### PR TITLE
Attest release artifacts with GitHub Artifact Attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -27,6 +29,14 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/omni_*.tar.gz
+            dist/omni_*.zip
+            dist/checksums.txt
 
       - name: Checkout Homebrew tap
         if: ${{ !contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Pre-built binaries for macOS, Linux, and Windows are available on the [Releases 
 | Linux    | amd64, arm64  |
 | Windows  | amd64         |
 
+### Verifying release artifacts
+
+Release archives and `checksums.txt` are signed with [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) (Sigstore under the hood). The install script and Homebrew formula already verify SHA-256 checksums; attestations let you additionally prove the artifact was built by this repo's `release.yml` workflow.
+
+Verify a downloaded archive with the GitHub CLI:
+
+```bash
+gh attestation verify omni_1.2.3_linux_amd64.tar.gz --repo exploreomni/cli
+```
+
 ### Build from source
 
 ```bash


### PR DESCRIPTION
## Summary

Adds [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to the release pipeline so downstream consumers can verify that release archives were built by this repo's `release.yml` (not swapped in by a compromised action or a malicious release manager). Sigstore-backed under the hood — no key management.

Follow-up to #56's audit; mentioned there as out-of-scope.

## Changes

- `release.yml`: add `id-token: write` and `attestations: write` to the job's permissions, plus one `actions/attest-build-provenance` step after GoReleaser. Action pinned to commit SHA.
- `README.md`: short "Verifying release artifacts" section showing `gh attestation verify`.

Subjects attested: all `dist/omni_*.tar.gz`, `dist/omni_*.zip`, and `dist/checksums.txt`.

## On the OIDC token risk

The TanStack postmortem flagged OIDC token theft as one of the three chained primitives. Adding `id-token: write` does mean this job now mints an OIDC token — but the blast radius is different from npm publish:

- The token only authorizes **signing attestations** under `exploreomni/cli`'s identity. It does not grant write access to the release, the repo, the Homebrew tap, or anything else.
- Token lifetime is single-job-scoped (~10 min).
- An attacker who steals it could sign arbitrary content as us, but cannot replace the actual published binaries without separately compromising `GITHUB_TOKEN` (`contents: write`) — which is needed to push to the release regardless.

Net: meaningful provenance gain, marginal new attack surface.

## Test plan

- [ ] Cut a pre-release tag (`v0.0.0-attest-test1`) and confirm the workflow succeeds
- [ ] Download the resulting tarball and run `gh attestation verify <archive> --repo exploreomni/cli` — should succeed
- [ ] Confirm the attestation appears on the [attestations page](https://github.com/exploreomni/cli/attestations) for the repo
- [ ] Delete the test tag/release

🤖 Generated with [Claude Code](https://claude.com/claude-code)