### PR TITLE
feat: add `omni users set-attributes` to edit user attribute values

### DIFF
--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -57,7 +57,7 @@ Set OMNI_API_TOKEN env var, or run: omni config init
   uploads       Upload and manage CSV files
   unstable      Unstable/preview commands (document import/export)
   user-attributes  User attribute definitions
-  users         User and group role management
+  users         User/group role management, set user attribute values
   config        CLI configuration profiles
 
 ## Common Flags
@@ -69,6 +69,7 @@ Set OMNI_API_TOKEN env var, or run: omni config init
 
 ## Tips
 - Use "omni ai generate-query" to answer data questions — it picks fields and filters for you.
+- Set a user's attribute values: omni users set-attributes <user-id> --attr region=us-east
 - Path parameters are positional args: omni dashboards download <dashboard-id>
 - Query parameters are flags: omni models list --pagesize 10
 - Run "omni <group> --help" to see all commands in a group.

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -78,6 +78,7 @@ func main() {
 
 	// Hand-written commands that attach to generated command groups
 	addBranchCommands(root, executeAPICall)
+	addUserCommands(root, executeAPICall)
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/omni/user_commands.go
+++ b/cmd/omni/user_commands.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"sort"
 	"strings"
 
 	"github.com/exploreomni/omni-cli/internal/auth"
@@ -24,7 +23,7 @@ const userAttributePrefix = "urn:omni:params:1.0:UserAttribute"
 // requires the value field on every operation.
 type scimPatchOp struct {
 	Op    string      `json:"op"`
-	Path  string      `json:"path"`
+	Path  string      `json:"path,omitempty"`
 	Value interface{} `json:"value"`
 }
 
@@ -113,22 +112,17 @@ attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
 }
 
 // buildSetAttributesBody assembles a SCIM PatchOp body that sets Omni user
-// attributes. It emits one "replace" operation per attribute, each targeting a
-// dotted sub-attribute path, so only the named attributes are affected and the
-// user's other attributes are preserved.
-//
-// Encoding note: if a live tenant rejects the per-attribute dotted path, the
-// alternative is a single operation replacing the whole map:
-//
-//	{"op":"replace","path":"urn:omni:params:1.0:UserAttribute","value":{...}}
-//
-// That form mirrors the SCIM PUT body but replaces the entire attribute set
-// (clobbering unspecified attributes), so the per-attribute form is preferred.
+// attributes. It uses the "no path" namespaced value-object form (the Okta /
+// RFC 7644 §3.5.2 format the Omni SCIM endpoint expects): a single replace
+// operation whose value nests the attributes under the Omni attribute
+// namespace. The server merges these over the user's existing attributes, so
+// only the named attributes change; an empty --attr value sets the attribute to
+// null, clearing it.
 func buildSetAttributesBody(attrs []string, attrJSON string) ([]byte, error) {
-	ops := make([]scimPatchOp, 0, len(attrs))
+	values := map[string]interface{}{}
 	seen := map[string]bool{}
 
-	addKey := func(key string) error {
+	add := func(key string, v interface{}) error {
 		if key == "" {
 			return fmt.Errorf("empty attribute name")
 		}
@@ -136,6 +130,7 @@ func buildSetAttributesBody(attrs []string, attrJSON string) ([]byte, error) {
 			return fmt.Errorf("attribute %q specified more than once", key)
 		}
 		seen[key] = true
+		values[key] = v
 		return nil
 	}
 
@@ -144,15 +139,13 @@ func buildSetAttributesBody(attrs []string, attrJSON string) ([]byte, error) {
 		if !found {
 			return nil, fmt.Errorf("invalid --attr %q: expected key=value", a)
 		}
-		key = strings.TrimSpace(key)
-		if err := addKey(key); err != nil {
+		var v interface{} // nil → JSON null, which clears the attribute
+		if val != "" {
+			v = val
+		}
+		if err := add(strings.TrimSpace(key), v); err != nil {
 			return nil, err
 		}
-		op := scimPatchOp{Op: "replace", Path: userAttributePrefix + "." + key}
-		if val != "" {
-			op.Value = val
-		} // else leave Value nil → "value": null (clear)
-		ops = append(ops, op)
 	}
 
 	if strings.TrimSpace(attrJSON) != "" {
@@ -160,30 +153,27 @@ func buildSetAttributesBody(attrs []string, attrJSON string) ([]byte, error) {
 		if err := json.Unmarshal([]byte(attrJSON), &m); err != nil {
 			return nil, fmt.Errorf("invalid --attr-json: %w", err)
 		}
-		keys := make([]string, 0, len(m))
-		for k := range m {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys) // deterministic op ordering
-		for _, k := range keys {
-			if err := addKey(strings.TrimSpace(k)); err != nil {
-				return nil, err
-			}
+		for k, raw := range m {
 			var v interface{}
-			if err := json.Unmarshal(m[k], &v); err != nil {
+			if err := json.Unmarshal(raw, &v); err != nil {
 				return nil, fmt.Errorf("invalid --attr-json value for %q: %w", k, err)
 			}
-			ops = append(ops, scimPatchOp{Op: "replace", Path: userAttributePrefix + "." + k, Value: v})
+			if err := add(strings.TrimSpace(k), v); err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	if len(ops) == 0 {
+	if len(values) == 0 {
 		return nil, fmt.Errorf("provide at least one --attr or --attr-json")
 	}
 
 	return json.Marshal(scimPatchBody{
-		Schemas:    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		Operations: ops,
+		Schemas: []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		Operations: []scimPatchOp{{
+			Op:    "replace",
+			Value: map[string]interface{}{userAttributePrefix: values},
+		}},
 	})
 }
 

--- a/cmd/omni/user_commands.go
+++ b/cmd/omni/user_commands.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/exploreomni/omni-cli/internal/auth"
+	"github.com/exploreomni/omni-cli/internal/config"
+	"github.com/exploreomni/omni-cli/internal/openapi"
+	"github.com/spf13/cobra"
+)
+
+// userAttributePrefix is the key under which Omni user attributes live in the
+// SCIM user representation. In a SCIM PATCH operation it is the prefix of the
+// dotted sub-attribute path (e.g. "urn:omni:params:1.0:UserAttribute.region").
+const userAttributePrefix = "urn:omni:params:1.0:UserAttribute"
+
+// scimPatchOp is a single SCIM PatchOp operation. Value has no omitempty so a
+// nil value marshals to "value": null (clearing the attribute) — the schema
+// requires the value field on every operation.
+type scimPatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+type scimPatchBody struct {
+	Schemas    []string      `json:"schemas"`
+	Operations []scimPatchOp `json:"Operations"`
+}
+
+// addUserCommands attaches hand-written user convenience commands to the
+// generated "users" command group. No-op if the group is absent.
+func addUserCommands(root *cobra.Command, exec openapi.Executor) {
+	var usersCmd *cobra.Command
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "users" {
+			usersCmd = cmd
+			break
+		}
+	}
+	if usersCmd == nil {
+		return
+	}
+	usersCmd.AddCommand(setUserAttributesCmd(exec))
+}
+
+func setUserAttributesCmd(exec openapi.Executor) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-attributes <user-id-or-email>",
+		Short: "Set Omni user attribute values on an existing user",
+		Long: `Set Omni user attribute values on an existing user.
+
+The user can be given as either a SCIM user ID (the UUID shown by
+"omni scim users list") or an email address. An email address (any value
+containing "@") is transparently resolved to the user's ID via a SCIM lookup.
+
+Attributes are applied via SCIM PATCH, so only the attributes you name are
+changed; the user's other attributes are left untouched. Values given with
+--attr are sent as strings; an empty value (--attr region=) clears that
+attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			attrs, _ := cmd.Flags().GetStringArray("attr")
+			attrJSON, _ := cmd.Flags().GetString("attr-json")
+
+			body, err := buildSetAttributesBody(attrs, attrJSON)
+			if err != nil {
+				return err
+			}
+
+			userID := args[0]
+			if isEmail(userID) {
+				cfg, err := resolveConfig(cmd)
+				if err != nil {
+					return err
+				}
+				userID, err = lookupUserIDByEmail(cfg, userID)
+				if err != nil {
+					return err
+				}
+			}
+
+			return exec(openapi.APIRequest{
+				Cmd:    cmd,
+				Method: "PATCH",
+				Path:   "/api/scim/v2/Users/" + url.PathEscape(userID),
+				Body:   body,
+			})
+		},
+	}
+
+	cmd.Flags().StringArray("attr", nil, "user attribute as key=value (repeatable); empty value clears the attribute")
+	cmd.Flags().String("attr-json", "", `JSON object of attributes for numeric/array values, e.g. '{"level":3,"regions":["us","eu"]}'`)
+
+	cmd.Example = `  # Set two string attributes (by user ID)
+  omni users set-attributes 550e8400-e29b-41d4-a716-446655440000 --attr region=us-east --attr team=growth
+
+  # Identify the user by email instead of ID
+  omni users set-attributes user@example.com --attr region=us-east
+
+  # Clear an attribute
+  omni users set-attributes user@example.com --attr region=
+
+  # Set numeric / multi-value attributes
+  omni users set-attributes user@example.com --attr-json '{"level":3,"regions":["us","eu"]}'`
+
+	return cmd
+}
+
+// buildSetAttributesBody assembles a SCIM PatchOp body that sets Omni user
+// attributes. It emits one "replace" operation per attribute, each targeting a
+// dotted sub-attribute path, so only the named attributes are affected and the
+// user's other attributes are preserved.
+//
+// Encoding note: if a live tenant rejects the per-attribute dotted path, the
+// alternative is a single operation replacing the whole map:
+//
+//	{"op":"replace","path":"urn:omni:params:1.0:UserAttribute","value":{...}}
+//
+// That form mirrors the SCIM PUT body but replaces the entire attribute set
+// (clobbering unspecified attributes), so the per-attribute form is preferred.
+func buildSetAttributesBody(attrs []string, attrJSON string) ([]byte, error) {
+	ops := make([]scimPatchOp, 0, len(attrs))
+	seen := map[string]bool{}
+
+	addKey := func(key string) error {
+		if key == "" {
+			return fmt.Errorf("empty attribute name")
+		}
+		if seen[key] {
+			return fmt.Errorf("attribute %q specified more than once", key)
+		}
+		seen[key] = true
+		return nil
+	}
+
+	for _, a := range attrs {
+		key, val, found := strings.Cut(a, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid --attr %q: expected key=value", a)
+		}
+		key = strings.TrimSpace(key)
+		if err := addKey(key); err != nil {
+			return nil, err
+		}
+		op := scimPatchOp{Op: "replace", Path: userAttributePrefix + "." + key}
+		if val != "" {
+			op.Value = val
+		} // else leave Value nil → "value": null (clear)
+		ops = append(ops, op)
+	}
+
+	if strings.TrimSpace(attrJSON) != "" {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(attrJSON), &m); err != nil {
+			return nil, fmt.Errorf("invalid --attr-json: %w", err)
+		}
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys) // deterministic op ordering
+		for _, k := range keys {
+			if err := addKey(strings.TrimSpace(k)); err != nil {
+				return nil, err
+			}
+			var v interface{}
+			if err := json.Unmarshal(m[k], &v); err != nil {
+				return nil, fmt.Errorf("invalid --attr-json value for %q: %w", k, err)
+			}
+			ops = append(ops, scimPatchOp{Op: "replace", Path: userAttributePrefix + "." + k, Value: v})
+		}
+	}
+
+	if len(ops) == 0 {
+		return nil, fmt.Errorf("provide at least one --attr or --attr-json")
+	}
+
+	return json.Marshal(scimPatchBody{
+		Schemas:    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		Operations: ops,
+	})
+}
+
+// isEmail reports whether s should be treated as an email address rather than a
+// user ID. SCIM/user IDs are UUIDs and never contain "@", so its presence is a
+// reliable discriminator.
+func isEmail(s string) bool {
+	return strings.Contains(s, "@")
+}
+
+// lookupUserIDByEmail resolves an email address to its SCIM user ID via the
+// SCIM Users list filtered by userName. It errors unless exactly one user
+// matches, so an ambiguous result never silently targets the wrong user.
+func lookupUserIDByEmail(cfg *config.ResolvedConfig, email string) (string, error) {
+	q := url.Values{}
+	q.Set("filter", fmt.Sprintf("userName eq %q", email))
+
+	resp, err := auth.Do(cfg, "GET", "/api/scim/v2/Users?"+q.Encode(), nil)
+	if err != nil {
+		return "", fmt.Errorf("looking up user by email: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading user lookup response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("looking up user by email: %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	var list struct {
+		Resources []struct {
+			ID       string `json:"id"`
+			UserName string `json:"userName"`
+		} `json:"Resources"`
+	}
+	if err := json.Unmarshal(respBody, &list); err != nil {
+		return "", fmt.Errorf("parsing user lookup response: %w", err)
+	}
+
+	// Verify the userName matches exactly (case-insensitive) rather than trusting
+	// the server filter blindly, so a lenient filter can't target the wrong user.
+	var ids []string
+	for _, r := range list.Resources {
+		if strings.EqualFold(r.UserName, email) && r.ID != "" {
+			ids = append(ids, r.ID)
+		}
+	}
+
+	switch len(ids) {
+	case 0:
+		return "", fmt.Errorf("no user found with email %q", email)
+	case 1:
+		return ids[0], nil
+	default:
+		return "", fmt.Errorf("multiple users found with email %q; specify the user ID instead", email)
+	}
+}

--- a/cmd/omni/user_commands_test.go
+++ b/cmd/omni/user_commands_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/exploreomni/omni-cli/internal/openapi"
+	"github.com/spf13/cobra"
+)
+
+type parsedOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+type parsedPatchBody struct {
+	Schemas    []string   `json:"schemas"`
+	Operations []parsedOp `json:"Operations"`
+}
+
+func parseBody(t *testing.T, b []byte) parsedPatchBody {
+	t.Helper()
+	var body parsedPatchBody
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	return body
+}
+
+// TestBuildSetAttributesBody_StringAttrs verifies one replace op per --attr
+// with the correct dotted path, string value, and PatchOp schema.
+func TestBuildSetAttributesBody_StringAttrs(t *testing.T) {
+	b, err := buildSetAttributesBody([]string{"region=us-east", "team=growth"}, "")
+	if err != nil {
+		t.Fatalf("buildSetAttributesBody: %v", err)
+	}
+	body := parseBody(t, b)
+
+	if len(body.Schemas) != 1 || body.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
+		t.Errorf("schemas = %v, want PatchOp", body.Schemas)
+	}
+	if len(body.Operations) != 2 {
+		t.Fatalf("ops = %d, want 2", len(body.Operations))
+	}
+	// order preserved from --attr ordering
+	if got := body.Operations[0]; got.Op != "replace" ||
+		got.Path != "urn:omni:params:1.0:UserAttribute.region" || got.Value != "us-east" {
+		t.Errorf("op[0] = %+v, want replace region=us-east", got)
+	}
+	if got := body.Operations[1]; got.Path != "urn:omni:params:1.0:UserAttribute.team" || got.Value != "growth" {
+		t.Errorf("op[1] = %+v, want replace team=growth", got)
+	}
+}
+
+// TestBuildSetAttributesBody_ClearAttr verifies an empty value clears the
+// attribute via a replace op whose value is explicitly null (not omitted).
+func TestBuildSetAttributesBody_ClearAttr(t *testing.T) {
+	b, err := buildSetAttributesBody([]string{"region="}, "")
+	if err != nil {
+		t.Fatalf("buildSetAttributesBody: %v", err)
+	}
+	body := parseBody(t, b)
+	if len(body.Operations) != 1 {
+		t.Fatalf("ops = %d, want 1", len(body.Operations))
+	}
+	if body.Operations[0].Value != nil {
+		t.Errorf("value = %v, want nil (null)", body.Operations[0].Value)
+	}
+	// the value key must be present and null, not omitted
+	if !strings.Contains(string(b), `"value":null`) {
+		t.Errorf("body should contain explicit null value, got %s", b)
+	}
+}
+
+// TestBuildSetAttributesBody_AttrJSON verifies --attr-json contributes typed
+// (numeric/array) values in deterministic (sorted-key) order.
+func TestBuildSetAttributesBody_AttrJSON(t *testing.T) {
+	b, err := buildSetAttributesBody(nil, `{"regions":["us","eu"],"level":3}`)
+	if err != nil {
+		t.Fatalf("buildSetAttributesBody: %v", err)
+	}
+	body := parseBody(t, b)
+	if len(body.Operations) != 2 {
+		t.Fatalf("ops = %d, want 2", len(body.Operations))
+	}
+	// sorted: "level" before "regions"
+	if body.Operations[0].Path != "urn:omni:params:1.0:UserAttribute.level" {
+		t.Errorf("op[0].path = %q, want level", body.Operations[0].Path)
+	}
+	if v, ok := body.Operations[0].Value.(float64); !ok || v != 3 {
+		t.Errorf("level value = %v (%T), want number 3", body.Operations[0].Value, body.Operations[0].Value)
+	}
+	arr, ok := body.Operations[1].Value.([]interface{})
+	if !ok || len(arr) != 2 || arr[0] != "us" || arr[1] != "eu" {
+		t.Errorf("regions value = %v, want [us eu]", body.Operations[1].Value)
+	}
+}
+
+// TestBuildSetAttributesBody_Errors covers the validation failure modes.
+func TestBuildSetAttributesBody_Errors(t *testing.T) {
+	cases := []struct {
+		name     string
+		attrs    []string
+		attrJSON string
+		wantSub  string
+	}{
+		{"no input", nil, "", "at least one"},
+		{"missing equals", []string{"region"}, "", "key=value"},
+		{"empty key", []string{"=us-east"}, "", "empty attribute name"},
+		{"dup across attrs", []string{"region=a", "region=b"}, "", "more than once"},
+		{"dup across attr and json", []string{"region=a"}, `{"region":"b"}`, "more than once"},
+		{"invalid json", nil, `{not json}`, "invalid --attr-json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildSetAttributesBody(tc.attrs, tc.attrJSON)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestSetUserAttributesCmd_RequestShape verifies the command issues a PATCH to
+// the SCIM user path (with the id URL-escaped) carrying the assembled body.
+func TestSetUserAttributesCmd_RequestShape(t *testing.T) {
+	var captured openapi.APIRequest
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error {
+		captured = req
+		return nil
+	})
+	cmd.SetArgs([]string{"abc/def", "--attr", "region=us-east"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if captured.Method != "PATCH" {
+		t.Errorf("method = %q, want PATCH", captured.Method)
+	}
+	if captured.Path != "/api/scim/v2/Users/abc%2Fdef" {
+		t.Errorf("path = %q, want id URL-escaped", captured.Path)
+	}
+	body := parseBody(t, captured.Body)
+	if len(body.Operations) != 1 || body.Operations[0].Value != "us-east" {
+		t.Errorf("operations = %+v, want single region=us-east", body.Operations)
+	}
+}
+
+func TestIsEmail(t *testing.T) {
+	cases := map[string]bool{
+		"user@example.com":                     true,
+		"first.last+tag@sub.example.co":        true,
+		"550e8400-e29b-41d4-a716-446655440000": false,
+		"abc/def":                              false,
+		"":                                     false,
+	}
+	for in, want := range cases {
+		if got := isEmail(in); got != want {
+			t.Errorf("isEmail(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// scimListServer returns a test server that answers the SCIM Users list with
+// the given resources and records the filter query it received.
+func scimListServer(t *testing.T, resources []map[string]interface{}, gotFilter *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/api/scim/v2/Users" {
+			if gotFilter != nil {
+				*gotFilter = r.URL.Query().Get("filter")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"Resources": resources})
+			return
+		}
+		http.Error(w, "unexpected request", 500)
+	}))
+}
+
+func setEmailLookupEnv(t *testing.T, baseURL string) {
+	t.Helper()
+	t.Setenv("OMNI_API_TOKEN", "test-token")
+	t.Setenv("OMNI_BASE_URL", baseURL)
+	t.Setenv("OMNI_CLI_DANGEROUSLY_ALLOW_INSECURE_REQUESTS", "1")
+}
+
+// TestSetUserAttributesCmd_ResolvesEmail verifies that an email argument is
+// resolved to the user's SCIM id (via a userName filter) before the PATCH, and
+// that the match is case-insensitive.
+func TestSetUserAttributesCmd_ResolvesEmail(t *testing.T) {
+	var gotFilter string
+	ts := scimListServer(t, []map[string]interface{}{
+		{"id": "user-uuid-123", "userName": "User@Example.com"},
+	}, &gotFilter)
+	defer ts.Close()
+	setEmailLookupEnv(t, ts.URL)
+
+	var captured openapi.APIRequest
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error {
+		captured = req
+		return nil
+	})
+	cmd.SetArgs([]string{"user@example.com", "--attr", "region=us-east"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotFilter != `userName eq "user@example.com"` {
+		t.Errorf("filter = %q, want `userName eq \"user@example.com\"`", gotFilter)
+	}
+	if captured.Path != "/api/scim/v2/Users/user-uuid-123" {
+		t.Errorf("path = %q, want /api/scim/v2/Users/user-uuid-123", captured.Path)
+	}
+}
+
+// TestSetUserAttributesCmd_EmailNotFound verifies a clear error (and no PATCH)
+// when no user matches the email.
+func TestSetUserAttributesCmd_EmailNotFound(t *testing.T) {
+	ts := scimListServer(t, []map[string]interface{}{}, nil)
+	defer ts.Close()
+	setEmailLookupEnv(t, ts.URL)
+
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error {
+		t.Fatal("exec must not be called when lookup finds nothing")
+		return nil
+	})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"missing@example.com", "--attr", "region=us-east"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no user found") {
+		t.Fatalf("err = %v, want it to contain 'no user found'", err)
+	}
+}
+
+// TestSetUserAttributesCmd_EmailAmbiguous verifies that multiple matches abort
+// rather than guessing which user to modify.
+func TestSetUserAttributesCmd_EmailAmbiguous(t *testing.T) {
+	ts := scimListServer(t, []map[string]interface{}{
+		{"id": "id-1", "userName": "dup@example.com"},
+		{"id": "id-2", "userName": "dup@example.com"},
+	}, nil)
+	defer ts.Close()
+	setEmailLookupEnv(t, ts.URL)
+
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error {
+		t.Fatal("exec must not be called on an ambiguous lookup")
+		return nil
+	})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"dup@example.com", "--attr", "region=us-east"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "multiple users found") {
+		t.Fatalf("err = %v, want it to contain 'multiple users found'", err)
+	}
+}
+
+// TestSetUserAttributesCmd_RequiresArg verifies the command rejects invocation
+// without a user-id positional argument.
+func TestSetUserAttributesCmd_RequiresArg(t *testing.T) {
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error { return nil })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--attr", "region=us-east"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no user-id provided")
+	}
+}
+
+// TestSetUserAttributesCmd_RequiresAttr verifies an error when neither --attr
+// nor --attr-json is supplied.
+func TestSetUserAttributesCmd_RequiresAttr(t *testing.T) {
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error { return nil })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"user-123"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no attributes provided")
+	}
+}
+
+// TestAddUserCommands_AttachesToUsers verifies addUserCommands finds the
+// generated "users" group and adds set-attributes to it.
+func TestAddUserCommands_AttachesToUsers(t *testing.T) {
+	root := &cobra.Command{Use: "omni"}
+	root.AddCommand(&cobra.Command{Use: "users"})
+
+	addUserCommands(root, func(req openapi.APIRequest) error { return nil })
+
+	usersCmd, _, _ := root.Find([]string{"users"})
+	found := false
+	for _, cmd := range usersCmd.Commands() {
+		if cmd.Name() == "set-attributes" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("set-attributes not found under users command")
+	}
+}
+
+// TestAddUserCommands_NoUsersGroup verifies addUserCommands is a no-op when
+// there's no "users" command group.
+func TestAddUserCommands_NoUsersGroup(t *testing.T) {
+	root := &cobra.Command{Use: "omni"}
+	addUserCommands(root, func(req openapi.APIRequest) error { return nil })
+
+	if len(root.Commands()) != 0 {
+		t.Errorf("expected no commands added, got %d", len(root.Commands()))
+	}
+}

--- a/cmd/omni/user_commands_test.go
+++ b/cmd/omni/user_commands_test.go
@@ -31,72 +31,78 @@ func parseBody(t *testing.T, b []byte) parsedPatchBody {
 	return body
 }
 
-// TestBuildSetAttributesBody_StringAttrs verifies one replace op per --attr
-// with the correct dotted path, string value, and PatchOp schema.
+// patchedAttrs returns the namespaced attribute map from the single replace op,
+// i.e. value["urn:omni:params:1.0:UserAttribute"].
+func patchedAttrs(t *testing.T, b []byte) map[string]interface{} {
+	t.Helper()
+	body := parseBody(t, b)
+	if len(body.Schemas) != 1 || body.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
+		t.Errorf("schemas = %v, want PatchOp", body.Schemas)
+	}
+	if len(body.Operations) != 1 {
+		t.Fatalf("ops = %d, want 1 (no-path object form)", len(body.Operations))
+	}
+	op := body.Operations[0]
+	if op.Op != "replace" || op.Path != "" {
+		t.Errorf("op = {op:%q path:%q}, want replace with no path", op.Op, op.Path)
+	}
+	val, ok := op.Value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("value is %T, want object", op.Value)
+	}
+	attrs, ok := val["urn:omni:params:1.0:UserAttribute"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("value missing urn:omni:params:1.0:UserAttribute object: %v", val)
+	}
+	return attrs
+}
+
+// TestBuildSetAttributesBody_StringAttrs verifies attributes are nested under
+// the Omni namespace in a single no-path replace op.
 func TestBuildSetAttributesBody_StringAttrs(t *testing.T) {
 	b, err := buildSetAttributesBody([]string{"region=us-east", "team=growth"}, "")
 	if err != nil {
 		t.Fatalf("buildSetAttributesBody: %v", err)
 	}
-	body := parseBody(t, b)
-
-	if len(body.Schemas) != 1 || body.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
-		t.Errorf("schemas = %v, want PatchOp", body.Schemas)
+	attrs := patchedAttrs(t, b)
+	if attrs["region"] != "us-east" {
+		t.Errorf("region = %v, want us-east", attrs["region"])
 	}
-	if len(body.Operations) != 2 {
-		t.Fatalf("ops = %d, want 2", len(body.Operations))
-	}
-	// order preserved from --attr ordering
-	if got := body.Operations[0]; got.Op != "replace" ||
-		got.Path != "urn:omni:params:1.0:UserAttribute.region" || got.Value != "us-east" {
-		t.Errorf("op[0] = %+v, want replace region=us-east", got)
-	}
-	if got := body.Operations[1]; got.Path != "urn:omni:params:1.0:UserAttribute.team" || got.Value != "growth" {
-		t.Errorf("op[1] = %+v, want replace team=growth", got)
+	if attrs["team"] != "growth" {
+		t.Errorf("team = %v, want growth", attrs["team"])
 	}
 }
 
-// TestBuildSetAttributesBody_ClearAttr verifies an empty value clears the
-// attribute via a replace op whose value is explicitly null (not omitted).
+// TestBuildSetAttributesBody_ClearAttr verifies an empty value sets the
+// attribute to an explicit null (present in the payload, not omitted).
 func TestBuildSetAttributesBody_ClearAttr(t *testing.T) {
 	b, err := buildSetAttributesBody([]string{"region="}, "")
 	if err != nil {
 		t.Fatalf("buildSetAttributesBody: %v", err)
 	}
-	body := parseBody(t, b)
-	if len(body.Operations) != 1 {
-		t.Fatalf("ops = %d, want 1", len(body.Operations))
+	attrs := patchedAttrs(t, b)
+	if v, ok := attrs["region"]; !ok || v != nil {
+		t.Errorf("region = %v (present=%v), want explicit null", v, ok)
 	}
-	if body.Operations[0].Value != nil {
-		t.Errorf("value = %v, want nil (null)", body.Operations[0].Value)
-	}
-	// the value key must be present and null, not omitted
-	if !strings.Contains(string(b), `"value":null`) {
+	if !strings.Contains(string(b), `"region":null`) {
 		t.Errorf("body should contain explicit null value, got %s", b)
 	}
 }
 
 // TestBuildSetAttributesBody_AttrJSON verifies --attr-json contributes typed
-// (numeric/array) values in deterministic (sorted-key) order.
+// (numeric/array) values.
 func TestBuildSetAttributesBody_AttrJSON(t *testing.T) {
 	b, err := buildSetAttributesBody(nil, `{"regions":["us","eu"],"level":3}`)
 	if err != nil {
 		t.Fatalf("buildSetAttributesBody: %v", err)
 	}
-	body := parseBody(t, b)
-	if len(body.Operations) != 2 {
-		t.Fatalf("ops = %d, want 2", len(body.Operations))
+	attrs := patchedAttrs(t, b)
+	if v, ok := attrs["level"].(float64); !ok || v != 3 {
+		t.Errorf("level = %v (%T), want number 3", attrs["level"], attrs["level"])
 	}
-	// sorted: "level" before "regions"
-	if body.Operations[0].Path != "urn:omni:params:1.0:UserAttribute.level" {
-		t.Errorf("op[0].path = %q, want level", body.Operations[0].Path)
-	}
-	if v, ok := body.Operations[0].Value.(float64); !ok || v != 3 {
-		t.Errorf("level value = %v (%T), want number 3", body.Operations[0].Value, body.Operations[0].Value)
-	}
-	arr, ok := body.Operations[1].Value.([]interface{})
+	arr, ok := attrs["regions"].([]interface{})
 	if !ok || len(arr) != 2 || arr[0] != "us" || arr[1] != "eu" {
-		t.Errorf("regions value = %v, want [us eu]", body.Operations[1].Value)
+		t.Errorf("regions = %v, want [us eu]", attrs["regions"])
 	}
 }
 
@@ -147,9 +153,8 @@ func TestSetUserAttributesCmd_RequestShape(t *testing.T) {
 	if captured.Path != "/api/scim/v2/Users/abc%2Fdef" {
 		t.Errorf("path = %q, want id URL-escaped", captured.Path)
 	}
-	body := parseBody(t, captured.Body)
-	if len(body.Operations) != 1 || body.Operations[0].Value != "us-east" {
-		t.Errorf("operations = %+v, want single region=us-east", body.Operations)
+	if attrs := patchedAttrs(t, captured.Body); attrs["region"] != "us-east" {
+		t.Errorf("region = %v, want us-east", attrs["region"])
 	}
 }
 


### PR DESCRIPTION
## What

Adds `omni users set-attributes <user-id-or-email>` — a hand-written convenience command to set Omni **user attribute values** on an existing user, without hand-crafting a SCIM envelope.

```
omni users set-attributes 550e8400-... --attr region=us-east --attr team=growth
omni users set-attributes user@example.com --attr region=us-east   # resolve by email
omni users set-attributes user@example.com --attr region=          # clear an attribute (null)
omni users set-attributes user@example.com --attr-json '{"level":3,"regions":["us","eu"]}'
```

## Why

The CLI auto-generates commands from the OpenAPI spec, and editing an existing user's attributes is only possible through the SCIM PATCH endpoint, which requires constructing a `PatchOp` envelope by hand. There is no v1 "update user attributes" endpoint. This wraps that into a single ergonomic verb. (Managing attribute *definitions* is out of scope — no API exists for it yet.)

## How

- New `cmd/omni/user_commands.go`: `addUserCommands` attaches `set-attributes` to the generated `users` group (mirrors the `branch_commands.go` pattern); `buildSetAttributesBody` assembles the SCIM PATCH body. Empty `--attr key=` sets the attribute to null (clears); `--attr-json` covers numeric/array values; duplicate keys error.
- **SCIM PATCH encoding:** uses the no-`path` namespaced value-object form (Okta / RFC 7644 §3.5.2) — a single `replace` op whose value nests attributes under `urn:omni:params:1.0:UserAttribute`. This is the format the server's `parseUserPatchOperations` handles and its integration tests assert ("the value must actually be replaced, not silently dropped"). The server merges over existing attributes, so unspecified attributes are preserved.
- Email support: if the argument contains `@`, it's resolved to the SCIM `id` via `GET /api/scim/v2/Users?filter=userName eq \"<email>\"`. The match is verified case-insensitively client-side; **no/ambiguous matches error rather than guessing**. Body validation runs before the lookup (fail fast, no wasted call).
- `main.go` registers `addUserCommands`; `agent_help.go` surfaces the command.

## Testing

- `make build`, `make test`, `go vet`, `gofmt` all clean. Unit tests in `cmd/omni` cover body construction (namespaced object, clear/null, attr-json typed values), dup/validation errors, method/path + URL-escaping, and email resolution (case-insensitive match, not-found, ambiguous), plus group attach/no-op.
- **Verified live against a real tenant:** setting `user_id` both by user ID and by email persists on a fresh GET, while the user's other attributes (e.g. `omni_user_timezone`) are left untouched.

> Note: an earlier revision used a per-attribute dotted `path` (`…UserAttribute.region`), which the server silently dropped (it strips the namespace with a colon, not a dot). Fixed to the value-object form above and confirmed against a live tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)