### PR TITLE
feat: add v2 documents commands

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -16015,9 +16015,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16119,9 +16116,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16265,9 +16259,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16343,9 +16334,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16424,9 +16412,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16543,9 +16528,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16617,9 +16599,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16710,9 +16689,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16741,9 +16717,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -16815,9 +16788,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -16938,9 +16908,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -16999,9 +16966,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -17055,9 +17019,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -17158,9 +17119,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -17202,7 +17160,7 @@
                 ]
               }
             ],
-            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.). Visibility is determined by placement in the filter-bar container."
           },
           "map": {
             "type": "object",
@@ -17277,7 +17235,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/QueryPresentationPatchExternal"
             },
-            "description": "Query presentations keyed by tab ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete. Capped at 48 entries per patch."
+            "description": "Query presentations keyed by tab ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete. Capped at 48 entries per patch. When the request carries no `containers` and the document has a dashboard layout, dashboard-eligible tiles added at new keys are auto-placed on the dashboard's first page (non-renderable types such as CSV / dataset / query-view / dbt tabs are stored but not placed), and containers created by auto-placement are removed when their tile is deleted — containers placed via an explicit `containers` write are left in the layout. When `containers` is present it fully defines the layout; on a workbook-only document (no layout yet) tiles are stored without placement."
           },
           "order": {
             "type": "array",
@@ -20156,9 +20114,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20260,9 +20215,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20406,9 +20358,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20484,9 +20433,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20565,9 +20511,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20684,9 +20627,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20758,9 +20698,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20851,9 +20788,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20882,9 +20816,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -20956,9 +20887,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -21079,9 +21007,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -21140,9 +21065,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -21196,9 +21118,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -21299,9 +21218,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -21343,7 +21259,7 @@
                 ]
               }
             ],
-            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.). Visibility is determined by placement in the filter-bar container."
           },
           "map": {
             "type": "object",
@@ -24194,7 +24110,7 @@
                 "$ref": "#/components/schemas/Containers"
               },
               {
-                "description": "Container layout. When present, fully replaces the existing layout."
+                "description": "Container layout. When present, fully replaces the existing layout and disables automatic tile placement for the request."
               }
             ]
           },
@@ -24816,6 +24732,524 @@
         },
         "required": [
           "prompt_set"
+        ]
+      },
+      "EvalRunsListResponse": {
+        "type": "object",
+        "properties": {
+          "runs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalRunListItem"
+            },
+            "description": "Runs for the prompt set, newest first, filtered to those whose model the caller can access."
+          }
+        },
+        "required": [
+          "runs"
+        ]
+      },
+      "EvalRunListItem": {
+        "type": "object",
+        "properties": {
+          "branch_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional branch ID the run was executed against. Null when run against the main shared model.",
+            "example": null
+          },
+          "branch_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name for the branch, if `branch_id` is set.",
+            "example": null
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run reached a terminal state.",
+            "example": null
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description for the run.",
+            "example": null
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the run.",
+            "example": "660e8400-e29b-41d4-a716-446655440001"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the run has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this run was executed against.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "prompt_set_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The prompt set this run was created from.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "run_number": {
+            "type": "integer",
+            "description": "Sequential, per-prompt-set run number.",
+            "example": 3
+          },
+          "stats": {
+            "$ref": "#/components/schemas/EvalRunStats"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "COMPLETE",
+              "CANCELLED"
+            ],
+            "description": "Run-level lifecycle. Flips to a terminal state (COMPLETE or CANCELLED) exactly once.",
+            "example": "RUNNING"
+          }
+        },
+        "required": [
+          "branch_id",
+          "branch_name",
+          "completed_at",
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "prompt_set_id",
+          "run_number",
+          "stats",
+          "status"
+        ]
+      },
+      "EvalRunStats": {
+        "type": "object",
+        "properties": {
+          "terminal": {
+            "type": "integer",
+            "description": "Number of per-prompt jobs that have reached a terminal state (COMPLETE, FAILED, or CANCELLED).",
+            "example": 8
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of per-prompt jobs in the run.",
+            "example": 12
+          }
+        },
+        "required": [
+          "terminal",
+          "total"
+        ]
+      },
+      "EvalRunsCreateResponse": {
+        "type": "object",
+        "properties": {
+          "job_count": {
+            "type": "integer",
+            "description": "Number of per-prompt agentic jobs created for this run (one per prompt that fanned out successfully). Enqueue onto the work queue happens after creation and is best-effort, so this count reflects jobs created, not necessarily those successfully enqueued.",
+            "example": 12
+          },
+          "run": {
+            "$ref": "#/components/schemas/EvalRunDetail"
+          }
+        },
+        "required": [
+          "job_count",
+          "run"
+        ]
+      },
+      "EvalRunDetail": {
+        "type": "object",
+        "properties": {
+          "branch_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional branch ID the run was executed against. Null when run against the main shared model.",
+            "example": null
+          },
+          "branch_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name for the branch, if `branch_id` is set.",
+            "example": null
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run reached a terminal state.",
+            "example": null
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description for the run.",
+            "example": null
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the run.",
+            "example": "660e8400-e29b-41d4-a716-446655440001"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the run has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this run was executed against.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "prompt_set_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The prompt set this run was created from.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalRunResult"
+            },
+            "description": "Per-prompt results for this run, ordered by their creation order in the prompt set."
+          },
+          "run_number": {
+            "type": "integer",
+            "description": "Sequential, per-prompt-set run number.",
+            "example": 3
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "COMPLETE",
+              "CANCELLED"
+            ],
+            "description": "Run-level lifecycle. Flips to a terminal state (COMPLETE or CANCELLED) exactly once.",
+            "example": "RUNNING"
+          }
+        },
+        "required": [
+          "branch_id",
+          "branch_name",
+          "completed_at",
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "prompt_set_id",
+          "results",
+          "run_number",
+          "status"
+        ],
+        "description": "The newly created run with its initial results."
+      },
+      "EvalRunResult": {
+        "type": "object",
+        "properties": {
+          "agentic_job": {
+            "$ref": "#/components/schemas/EvalRunResultAgenticJob"
+          },
+          "cost": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Total LLM cost (USD) for this prompt, if available.",
+            "example": 0.0021
+          },
+          "error_reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Failure reason string for prompts whose underlying job failed.",
+            "example": null
+          },
+          "expectation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The prompt's expectation as of run creation (snapshotted, so later prompt edits don't change past runs), or null when none was set. The analysis judge scores the analysis against it.",
+            "example": "The top product by revenue should be Aniseed Syrup."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the run result row.",
+            "example": "aa0e8400-e29b-41d4-a716-446655440005"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "The prompt text that was evaluated.",
+            "example": "What are the top 5 products by revenue?"
+          },
+          "score": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Numeric judge score for this prompt result, if scoring ran.",
+            "example": 0.9
+          },
+          "scoring_cost": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Total LLM cost (USD) for scoring this prompt result.",
+            "example": 0.0004
+          },
+          "timing_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Wall-clock duration of the underlying job in milliseconds.",
+            "example": 4321
+          }
+        },
+        "required": [
+          "agentic_job",
+          "cost",
+          "error_reason",
+          "expectation",
+          "id",
+          "prompt",
+          "score",
+          "scoring_cost",
+          "timing_ms"
+        ]
+      },
+      "EvalRunResultAgenticJob": {
+        "type": "object",
+        "properties": {
+          "conversation_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Conversation the agentic job belongs to.",
+            "example": "770e8400-e29b-41d4-a716-446655440002"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Agentic job identifier.",
+            "example": "990e8400-e29b-41d4-a716-446655440004"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "CANCELLED",
+              "COMPLETE",
+              "DELIVERING",
+              "EXECUTING",
+              "FAILED",
+              "QUEUED"
+            ],
+            "description": "Current state of the agentic job that ran this prompt.",
+            "example": "COMPLETE"
+          }
+        },
+        "required": [
+          "conversation_id",
+          "id",
+          "state"
+        ]
+      },
+      "EvalApiError429": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Too many active runs; wait for an in-flight run to finish"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 429
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError503": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "AI eval is paused for this organization"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 503
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalRunsCreateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024,
+            "description": "Optional human-readable description for the run. Pass `null` to clear (or omit). Max 1024 characters.",
+            "example": "Re-running after switching to gpt-4o for query generation"
+          },
+          "prompt_set_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The prompt set to execute.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "run_config": {
+            "type": "object",
+            "properties": {
+              "branch_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Optional branch ID to run against. Must be a branch of the prompt set's model.",
+                "example": "440e8400-e29b-41d4-a716-446655440006"
+              }
+            },
+            "description": "Per-run configuration. Optional — omit if no overrides."
+          }
+        },
+        "required": [
+          "prompt_set_id"
+        ]
+      },
+      "EvalRunsGetResponse": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/EvalRunDetail"
+          }
+        },
+        "required": [
+          "run"
+        ]
+      },
+      "EvalRunsDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "is_archived": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always `true` on success — the run has been archived."
+          }
+        },
+        "required": [
+          "is_archived"
+        ]
+      },
+      "EvalRunsCancelResponse": {
+        "type": "object",
+        "properties": {
+          "cancelled": {
+            "type": "integer",
+            "description": "Number of per-prompt agentic jobs that were cancelled by this request.",
+            "example": 4
+          },
+          "run": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvalRunDetail"
+              },
+              {
+                "description": "The cancelled run. `status: CANCELLED` and `is_archived: true` after this call."
+              }
+            ]
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of per-prompt jobs in the run.",
+            "example": 12
+          }
+        },
+        "required": [
+          "cancelled",
+          "run",
+          "total"
+        ]
+      },
+      "EvalRunsUnarchiveResponse": {
+        "type": "object",
+        "properties": {
+          "is_archived": {
+            "type": "boolean",
+            "enum": [
+              false
+            ],
+            "description": "Always `false` on success — the run has been unarchived."
+          }
+        },
+        "required": [
+          "is_archived"
         ]
       },
       "FoldersListResponse": {
@@ -34096,7 +34530,8 @@
         }
       },
       "put": {
-        "description": "Updates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
+        "deprecated": true,
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
         "operationId": "documentsPut",
         "summary": "Replace document (full replacement)",
         "tags": [
@@ -34153,7 +34588,8 @@
         }
       },
       "patch": {
-        "description": "Updates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
+        "deprecated": true,
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
         "operationId": "documentsUpdate",
         "summary": "Rename document",
         "tags": [
@@ -35383,7 +35819,7 @@
     },
     "/api/v2/documents": {
       "post": {
-        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
+        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nWhen `containers` is omitted, every dashboard-eligible tile is auto-placed in a default layout. When `containers` is present, it fully defines the layout — tiles it does not reference are stored but not rendered.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
         "operationId": "documentsV2Create",
         "summary": "Create document",
         "tags": [
@@ -36236,6 +36672,489 @@
           },
           "404": {
             "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs": {
+      "get": {
+        "description": "List runs for a prompt set, newest first, filtered to runs whose model the caller can access. The `prompt_set_id` query parameter is required.",
+        "operationId": "aiEvalRunsList",
+        "summary": "List eval runs",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When `true`, returns archived runs instead of active ones. Defaults to `false`.",
+              "example": "false"
+            },
+            "required": false,
+            "description": "When `true`, returns archived runs instead of active ones. Defaults to `false`.",
+            "name": "archived",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Required — the prompt set whose runs should be listed.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Required — the prompt set whose runs should be listed.",
+            "name": "prompt_set_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of runs for the prompt set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid `prompt_set_id`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create and start a new run against an existing prompt set. The run enqueues one agentic job per prompt and begins executing immediately. Returns the newly created run with its initial per-prompt result rows.",
+        "operationId": "aiEvalRunsCreate",
+        "summary": "Start an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalRunsCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Run created and jobs enqueued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions. The caller must have at least the Querier role on the prompt set's model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The prompt set was not found, or `run_config.branch_id` does not match an existing branch in the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "`run_config.branch_id` does not belong to the prompt set's model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError422"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-user active-run cap reached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError429"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Run created and jobs enqueued, but it could not be re-read for the response. The run exists — list runs for the prompt set to find it rather than retrying, since a retry starts a duplicate run.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "AI eval is paused for this organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError503"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs/{runId}": {
+      "get": {
+        "description": "Get an eval run with every per-prompt result row, including the underlying agentic job state and any scoring data.",
+        "operationId": "aiEvalRunsGet",
+        "summary": "Get an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run detail.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsGetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Archive (soft-delete) an eval run. Any non-terminal per-prompt agentic jobs are cancelled as part of the archive (best-effort), and a still-RUNNING run is flipped to CANCELLED before archival. The call is idempotent; archiving an already-terminal or already-archived run is a no-op.",
+        "operationId": "aiEvalRunsArchive",
+        "summary": "Archive an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run archived successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsDeleteResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "A still-running run may already be flipped to CANCELLED and archived even though the rest of the cascade failed — safe to retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs/{runId}/cancel": {
+      "post": {
+        "description": "Cancel an in-flight eval run. Any non-terminal per-prompt jobs are cancelled and the run is archived — the response returns the updated run inline (`status: CANCELLED`, `is_archived: true`); use `/unarchive` to surface it in the default `archived=false` list again.",
+        "operationId": "aiEvalRunsCancel",
+        "summary": "Cancel an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancellation processed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsCancelResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The run was cancelled and archived, but could not be re-read for the response — safe to retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs/{runId}/unarchive": {
+      "post": {
+        "description": "Restore an archived eval run.",
+        "operationId": "aiEvalRunsUnarchive",
+        "summary": "Restore an archived eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run restored successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsUnarchiveResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
             "content": {
               "application/json": {
                 "schema": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -16,6 +16,10 @@
       "name": "AI"
     },
     {
+      "description": "AI evaluation: manage prompt sets and runs used to score AI quality against curated prompt suites.",
+      "name": "AI Eval"
+    },
+    {
       "description": "API token management",
       "name": "API Tokens"
     },
@@ -118,9 +122,412 @@
         "description": "Update an existing variable by ID. Variable names cannot be changed after creation.",
         "title": "DbtEnvironmentVariableUpdate"
       },
+      "CompositeFilter": {
+        "type": "object",
+        "properties": {
+          "cancel_query_filter": {
+            "type": "boolean"
+          },
+          "ignore_if_unjoinable": {
+            "type": "boolean"
+          },
+          "conjunction": {
+            "type": "string",
+            "enum": [
+              "OR",
+              "AND"
+            ]
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "appliedLabels": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "case_insensitive": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "CONTAINS",
+                        "ENDS_WITH",
+                        "STARTS_WITH",
+                        "EQUALS",
+                        "IS_EMPTY",
+                        "SQL_LIKE"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string"
+                      ]
+                    },
+                    "values": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "type",
+                    "values"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "is_inclusive": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "LESS_THAN",
+                        "GREATER_THAN",
+                        "EQUALS",
+                        "BETWEEN"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "number"
+                      ]
+                    },
+                    "values": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "type",
+                    "values"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "isFiscal": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "IS_ON_DAY_OF_WEEK",
+                        "IS_ON_DAY_OF_QUARTER",
+                        "IS_IN_MONTH_OF_YEAR",
+                        "IS_ON_DAY_OF_YEAR",
+                        "IS_AT_HOUR_OF_DAY",
+                        "IS_IN_QUARTER_OF_YEAR",
+                        "IS_IN_WEEK_OF_YEAR",
+                        "IS_ON_DAY_OF_MONTH",
+                        "BETWEEN",
+                        "ON_OR_AFTER",
+                        "BEFORE",
+                        "TIME_FOR_INTERVAL_DURATION",
+                        "TIME_FOR_UNIT_DURATION",
+                        "QUERY_OFFSET"
+                      ]
+                    },
+                    "left_side": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "offset_interval_string": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "right_side": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "date"
+                      ]
+                    },
+                    "ui_type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "ANY_TIME",
+                        "BEFORE",
+                        "BETWEEN",
+                        "MONTH_OF_YEAR",
+                        "PAST",
+                        "YEAR",
+                        "DAY",
+                        "IS_ON_DAY_OF_WEEK",
+                        "ON_OR_AFTER",
+                        "IS_IN_THE_MONTH",
+                        "IS_IN_THE_QUARTER",
+                        "IS_IN_THE_FISCAL_QUARTER",
+                        "IS_IN_THE_FISCAL_YEAR",
+                        "TIME_FOR_INTERVAL_DURATION",
+                        "TIME_FOR_UNIT_DURATION",
+                        "CUSTOM",
+                        null
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "treat_nulls_as_false": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "boolean"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "disregard_limit": {
+                      "type": "boolean"
+                    },
+                    "field_name": {
+                      "type": "string"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "query_id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "query"
+                      ]
+                    },
+                    "view_query": {
+                      "type": "object",
+                      "properties": {
+                        "fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "filters": {
+                          "type": "object",
+                          "additionalProperties": {},
+                          "default": {}
+                        },
+                        "limit": {
+                          "type": "number"
+                        },
+                        "sorts": {
+                          "type": "array",
+                          "items": {},
+                          "default": []
+                        },
+                        "table": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fields"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "user_attribute"
+                      ]
+                    },
+                    "user_attribute_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "user_attribute_name"
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/CompositeFilter"
+                }
+              ]
+            },
+            "description": "Child filters — each a simple filter or another composite filter. Recursive; see the dashboard-filters reference for the full grammar."
+          },
+          "is_negative": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "composite"
+            ]
+          }
+        },
+        "required": [
+          "conjunction",
+          "filters",
+          "type"
+        ]
+      },
       "AiGenerateQueryResponse": {
         "type": "object",
         "properties": {
+          "baseView": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The base view name used for query generation when queryAllViews surfaced a non-topic view. Mutually exclusive with `topic` — exactly one is non-null when a query was generated.",
+            "example": null
+          },
+          "downgradedModelTier": {
+            "type": "string",
+            "description": "Present only when the organization is over its AI downgrade threshold, signaling the query was generated on a downgraded (cheaper) model tier (e.g. 'haiku') to conserve credits. Advisory and best-effort — the call still succeeds, and clients may surface that a downgraded model was used. Absent when no downgrade applied.",
+            "example": "haiku"
+          },
           "error": {
             "type": [
               "object",
@@ -153,8 +560,11 @@
             "description": "Query execution results as a JSON object. Only present when runQuery is true (the default) and the query executed successfully. The structure contains the query result data."
           },
           "topic": {
-            "type": "string",
-            "description": "The topic name that was used for query generation.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic name used for query generation. Mutually exclusive with `baseView` — exactly one is non-null when a query was generated.",
             "example": "order_items"
           },
           "workbookUrl": {
@@ -268,6 +678,34 @@
           }
         },
         "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "AiCreditShutoffError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "shutoff"
+            ],
+            "description": "Stable reason code identifying an AI-credit shutoff.",
+            "example": "shutoff"
+          },
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "The AI agent is currently unavailable. Contact your administrator to re-enable."
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 402
+          }
+        },
+        "required": [
+          "code",
           "detail",
           "status"
         ]
@@ -936,7 +1374,48 @@
           "error"
         ]
       },
-      "ApiKeyListResponse": {
+      "AiBrandingResponse": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Body / description copy shown beneath the headline on AI helper landing surfaces.",
+            "example": "Ask a data question to get started. I can help refine answers, adjust charts, or surface new areas to explore."
+          },
+          "headline": {
+            "type": "string",
+            "description": "Short headline shown on AI helper landing surfaces.",
+            "example": "What would you like to know?"
+          },
+          "logoUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "Absolute URL to a custom AI helper logo. `null` when the org has not configured a custom logo — clients should render their default avatar (e.g. Blobby).",
+            "example": "https://example.com/blobby.png"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name for the AI helper. Defaults to `Omni Agent` when no custom branding is set.",
+            "example": "Blobby"
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "Placeholder text for the AI helper's prompt input.",
+            "example": "Ask a question about your data..."
+          }
+        },
+        "required": [
+          "body",
+          "headline",
+          "logoUrl",
+          "name",
+          "placeholder"
+        ]
+      },
+      "AiConversationsListResponse": {
         "type": "object",
         "properties": {
           "pageInfo": {
@@ -945,8 +1424,9 @@
           "records": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ApiKey"
-            }
+              "$ref": "#/components/schemas/AiConversation"
+            },
+            "description": "Conversations ordered by updatedAt descending."
           }
         },
         "required": [
@@ -984,6 +1464,157 @@
           "totalRecords"
         ]
       },
+      "AiConversation": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the conversation was started.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Conversation ID. Pass as conversationId on subsequent /api/v1/ai/jobs submissions to continue this conversation.",
+            "example": "660e8400-e29b-41d4-a716-446655440001"
+          },
+          "lastPrompt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The most recent user prompt in this conversation, useful for displaying a one-line summary in a list.",
+            "example": "What were our top products last week?"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Conversation title. Set by the AI after the first turn; null on brand-new sessions.",
+            "example": "Top products last week"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the conversation was last touched (most recent prompt or AI activity).",
+            "example": "2025-01-15T10:01:30.000Z"
+          }
+        },
+        "required": [
+          "createdAt",
+          "id",
+          "lastPrompt",
+          "name",
+          "updatedAt"
+        ]
+      },
+      "AiConversationDetailResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiConversationMessage"
+            },
+            "description": "Messages in chronological order. Alternating user / assistant turns."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "createdAt",
+          "id",
+          "messages",
+          "name",
+          "updatedAt"
+        ]
+      },
+      "AiConversationMessage": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this turn was recorded.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "jobId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The agentic job that produced this assistant turn. Only set for assistant messages — clients use it to fetch the rendered chart via GET /api/v1/ai/jobs/{jobId}/vis. Null when the turn predates jobs or when we could not associate one.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "omniChatUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "Deep link to the assistant turn in the Omni chat UI. Null for user turns, and for assistant turns produced outside the Agentic API (where no AgenticJob row exists).",
+            "example": "https://my-org.omni.co/chat/660e8400-e29b-41d4-a716-446655440001"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant"
+            ],
+            "description": "Speaker — `user` for prompts the user submitted, `assistant` for Blobby's responses.",
+            "example": "user"
+          },
+          "text": {
+            "type": "string",
+            "description": "Markdown content of the message. For assistant turns this is the same string returned by /api/v1/ai/jobs/{jobId}/result#message.",
+            "example": "What were our top products last week?"
+          }
+        },
+        "required": [
+          "createdAt",
+          "jobId",
+          "omniChatUrl",
+          "role",
+          "text"
+        ]
+      },
+      "ApiKeyListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKey"
+            }
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
       "ApiKey": {
         "type": "object",
         "properties": {
@@ -995,7 +1626,7 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether the token can currently authenticate. Organization tokens may be disabled by admins; personal and MCP tokens are always `true` (revocation deletes them).",
+            "description": "Whether the token can currently authenticate. A disabled token cannot authenticate but remains visible until deleted.",
             "example": true
           },
           "id": {
@@ -1043,7 +1674,7 @@
         "properties": {
           "enabled": {
             "type": "boolean",
-            "description": "Set to `false` to disable the token, `true` to re-enable it. Only organization-level tokens may be disabled; personal and MCP tokens do not support this.",
+            "description": "Set to `false` to disable the token, `true` to re-enable it.",
             "example": false
           }
         },
@@ -1103,6 +1734,10 @@
             "type": "boolean",
             "description": "Whether this is the default environment"
           },
+          "isDeferralEnabled": {
+            "type": "boolean",
+            "description": "Whether dbt deferral is enabled for this environment. Always false for the default (production) environment — the backend rejects enabling it there."
+          },
           "name": {
             "type": "string",
             "description": "Environment name"
@@ -1150,6 +1785,7 @@
         "required": [
           "id",
           "isDefaultEnvironment",
+          "isDeferralEnabled",
           "name",
           "ownerId",
           "targetDatabase",
@@ -1193,6 +1829,12 @@
       "DbtEnvironmentCreateBody": {
         "type": "object",
         "properties": {
+          "isDeferralEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to enable dbt deferral for this environment. Ignored (forced to false) for the default (production) environment.",
+            "example": false
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -1281,6 +1923,12 @@
       "DbtEnvironmentUpdateBody": {
         "type": "object",
         "properties": {
+          "isDeferralEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to enable dbt deferral for this environment. Ignored (forced to false) for the default (production) environment.",
+            "example": false
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -1619,6 +2267,10 @@
           "folder": {
             "$ref": "#/components/schemas/InternalFolder"
           },
+          "hasApp": {
+            "type": "boolean",
+            "description": "Whether document has an app"
+          },
           "hasDashboard": {
             "type": "boolean",
             "description": "Whether document has a dashboard"
@@ -1652,7 +2304,7 @@
           },
           "url": {
             "type": "string",
-            "description": "URL to view the document. Returns dashboard URL if document has a dashboard, otherwise workbook URL.",
+            "description": "URL to view the document. Returns the dashboard URL if it has a dashboard, the app URL if it has an app, otherwise the workbook URL.",
             "example": "https://org.omni.co/dashboards/abc123"
           },
           "visits": {
@@ -1670,6 +2322,7 @@
           "connectionId",
           "deleted",
           "folder",
+          "hasApp",
           "hasDashboard",
           "identifier",
           "updatedAt",
@@ -1949,6 +2602,10 @@
           "folder": {
             "$ref": "#/components/schemas/DocumentFolder"
           },
+          "hasApp": {
+            "type": "boolean",
+            "description": "Whether the document has an associated app"
+          },
           "hasDashboard": {
             "type": "boolean",
             "description": "Whether the document has an associated dashboard"
@@ -1997,7 +2654,7 @@
           },
           "url": {
             "type": "string",
-            "description": "URL to view the document. Returns dashboard URL if document has a dashboard, otherwise workbook URL.",
+            "description": "URL to view the document. Returns the dashboard URL if it has a dashboard, the app URL if it has an app, otherwise the workbook URL.",
             "example": "https://org.omni.co/dashboards/abc123"
           }
         },
@@ -2180,10 +2837,13 @@
                 },
                 "description": {
                   "type": "string",
+                  "maxLength": 500,
                   "description": "Query presentation description"
                 },
                 "name": {
                   "type": "string",
+                  "minLength": 1,
+                  "maxLength": 144,
                   "description": "Query presentation name"
                 },
                 "prefersChart": {
@@ -2217,11 +2877,16 @@
                 },
                 "subTitle": {
                   "type": "string",
+                  "maxLength": 250,
                   "description": "Subtitle"
                 },
                 "topicName": {
-                  "type": "string",
-                  "description": "Topic name"
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "maxLength": 256,
+                  "description": "Topic name. Omit or pass null for raw-SQL tiles or any tile with no semantic topic."
                 },
                 "visConfig": {
                   "$ref": "#/components/schemas/ApiVisConfig"
@@ -2247,7 +2912,10 @@
         "description": "Optional document identifier. If omitted, an identifier is auto-generated. Must be unique within the organization."
       },
       "ApiVisConfig": {
-        "type": "object",
+        "type": [
+          "object",
+          "null"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -2517,10 +3185,13 @@
           },
           "description": {
             "type": "string",
+            "maxLength": 500,
             "description": "Description"
           },
           "name": {
             "type": "string",
+            "minLength": 1,
+            "maxLength": 144,
             "description": "Query presentation name"
           },
           "prefersChart": {
@@ -2530,16 +3201,26 @@
           "query": {
             "description": "Query definition"
           },
+          "queryIdentifierMapKey": {
+            "type": "string",
+            "pattern": "^[1-9][0-9]*$",
+            "description": "Round-trip preservation hint. When the value matches an existing key on the document, the tile keeps its map key (and dashboard containers stay attached). Omit for new tiles. Must be a positive integer string (e.g. \"1\", \"2\", \"10\")."
+          },
           "resultConfig": {
             "description": "Result config"
           },
           "subTitle": {
             "type": "string",
+            "maxLength": 250,
             "description": "Subtitle"
           },
           "topicName": {
-            "type": "string",
-            "description": "Topic name"
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256,
+            "description": "Topic name. Omit or pass null for raw-SQL tiles or any tile with no semantic topic."
           },
           "visConfig": {
             "$ref": "#/components/schemas/ApiVisConfig"
@@ -2720,6 +3401,10 @@
             "type": "boolean",
             "description": "Allow using dashboard AI"
           },
+          "canUseTimezoneOverride": {
+            "type": "boolean",
+            "description": "Allow timezone override"
+          },
           "canViewWorkbook": {
             "type": "boolean",
             "description": "Allow viewing workbook"
@@ -2888,6 +3573,118 @@
           }
         }
       },
+      "DocumentsListDraftsResponse": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ApiDraft"
+        }
+      },
+      "ApiDraft": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "$ref": "#/components/schemas/ApiDraftBranch"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the draft was created"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/ApiDraftActor"
+          },
+          "draftOutOfDate": {
+            "type": "boolean",
+            "description": "True when the published document was published more recently than the draft was created (the draft is based on a stale baseline)"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Draft workbook identifier — use this to address the draft"
+          },
+          "lastEditedBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiDraftActor"
+              },
+              {
+                "description": "User who most recently edited the draft"
+              }
+            ]
+          },
+          "publishedIdentifier": {
+            "type": "string",
+            "description": "Identifier of the published document the draft is for"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ApiDraftStatus"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Most recent edit time on the draft workbook"
+          },
+          "workbookModelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "omni_model ID for the draft workbook"
+          }
+        },
+        "required": [
+          "branch",
+          "createdAt",
+          "createdBy",
+          "draftOutOfDate",
+          "identifier",
+          "lastEditedBy",
+          "publishedIdentifier",
+          "status",
+          "updatedAt",
+          "workbookModelId"
+        ]
+      },
+      "ApiDraftBranch": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Branch (omni model) ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Branch name"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "description": "Branch the draft is attached to, or null for a draft on main"
+      },
+      "ApiDraftActor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "description": "User who created the draft"
+      },
+      "ApiDraftStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "archived"
+        ],
+        "description": "Lifecycle status: \"active\" for current drafts, \"archived\" for soft-deleted drafts (retained ~7 days)"
+      },
       "DocumentsDuplicateResponse": {
         "type": "object",
         "properties": {
@@ -3017,6 +3814,20445 @@
           "principals"
         ]
       },
+      "DocumentsListFavoritesResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageInfo"
+              },
+              {
+                "description": "Pagination information"
+              }
+            ]
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentFavoriteUser"
+            },
+            "description": "Users who favorited this document"
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "DocumentFavoriteUser": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Favoriting user's email. Null when the user has no resolvable email — e.g. an embed-SSO favoriter whose embed session did not provide one."
+          },
+          "favoritedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp when the user favorited the document"
+          },
+          "name": {
+            "type": "string",
+            "description": "Favoriting user's display name"
+          },
+          "userId": {
+            "type": "string",
+            "description": "Membership ID of the user who favorited the document (use with other v1 endpoints' userId parameter)"
+          }
+        },
+        "required": [
+          "email",
+          "favoritedAt",
+          "name",
+          "userId"
+        ]
+      },
+      "DocumentsV2CreateResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Identifier of the newly created document."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "description",
+          "identifier",
+          "name"
+        ]
+      },
+      "DocumentsV2CreateBody": {
+        "type": "object",
+        "properties": {
+          "containers": {
+            "$ref": "#/components/schemas/Containers"
+          },
+          "controls": {
+            "$ref": "#/components/schemas/ControlsPatchExternal"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "folderId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Folder to create the document in. When omitted, defaults to the caller’s personal \"My documents\" (requires permission to save personal content — otherwise the request is rejected)."
+          },
+          "identifier": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DocumentIdentifier"
+              },
+              {
+                "description": "Identifier for the new document. Must be unique within the organization. Auto-generated when omitted."
+              }
+            ]
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Base workbook model the document is built on — a SHARED model, or a SHARED_EXTENSION with `allowAsWorkbookBase = true`."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 254,
+            "description": "Document name."
+          },
+          "queryPresentations": {
+            "$ref": "#/components/schemas/QueryPresentationsPatchExternal"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsPatchExternal"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Caller-supplied note describing the create, written to the history audit trail. Defaults to \"Created document\" when omitted."
+          }
+        },
+        "required": [
+          "modelId",
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "Containers": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/components/schemas/GridContainer"
+            },
+            {
+              "$ref": "#/components/schemas/PageContainer"
+            },
+            {
+              "$ref": "#/components/schemas/StackContainer"
+            }
+          ]
+        },
+        "description": "Container layout array (grid / stack / page / reference containers, recursively nested). The server validates the full structure on apply."
+      },
+      "GridContainer": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Optional description for the container, providing additional context or information"
+          },
+          "instanceKey": {
+            "type": "string",
+            "description": "Unique identifier for this container. Used to reference the container when adding, moving, or removing children."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the container, used for easier reference in logic and design"
+          },
+          "aspectRatio": {
+            "type": "string"
+          },
+          "fillSpace": {
+            "type": "boolean"
+          },
+          "height": {
+            "type": "string"
+          },
+          "maxHeight": {
+            "type": "string"
+          },
+          "maxWidth": {
+            "type": "string"
+          },
+          "minHeight": {
+            "type": "string"
+          },
+          "minWidth": {
+            "type": "string"
+          },
+          "width": {
+            "type": "string"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "before": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ReferenceContainer"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/StackContainer"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GridContainer"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "chart",
+                                "result",
+                                "ai",
+                                "metadata"
+                              ],
+                              "description": "Render mode: \"chart\" for visualization, \"result\" for data table, \"ai\" for AI summary, \"metadata\" for query metadata"
+                            },
+                            "format": {
+                              "type": "string",
+                              "enum": [
+                                "subtitle",
+                                "description",
+                                "name"
+                              ],
+                              "description": "Display format when as is \"ai\" or \"metadata\": \"name\" (metadata only), \"subtitle\", or \"description\""
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^[1-9][0-9]*$",
+                              "description": "The query presentation ID this content item references"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Display name for this query item"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "query"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "appearance": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "inline"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tooltip"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                }
+                              ],
+                              "description": "Display mode: \"inline\" renders directly, \"tooltip\" shows on hover"
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The text content to display (supports markdown)"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Display name for this text item (e.g., title, subtitle)"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "textAlign": {
+                              "type": "string",
+                              "enum": [
+                                "start",
+                                "center",
+                                "end"
+                              ],
+                              "description": "Text alignment: \"start\", \"center\", or \"end\""
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-text"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "content",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "appearance": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tabs"
+                                      ]
+                                    },
+                                    "variant": {
+                                      "type": "string",
+                                      "enum": [
+                                        "underline",
+                                        "bordered"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "buttons"
+                                      ]
+                                    },
+                                    "variant": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segment",
+                                        "toggle",
+                                        "pills"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "list"
+                                      ]
+                                    },
+                                    "description": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "dropdown"
+                                      ]
+                                    },
+                                    "description": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                }
+                              ]
+                            },
+                            "options": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "disabled": {
+                                    "type": "boolean"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "includeControls": {
+                                    "type": "boolean"
+                                  },
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "target": {
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-page-switcher"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "UUID of the rich text content block"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "text"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "control"
+                              ]
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "filter"
+                              ]
+                            },
+                            "appearance": {
+                              "type": "object",
+                              "properties": {
+                                "control": {
+                                  "type": "string",
+                                  "enum": [
+                                    "buttonToggle",
+                                    "dropdown"
+                                  ]
+                                },
+                                "display": {
+                                  "type": "string",
+                                  "enum": [
+                                    "inline",
+                                    "popover"
+                                  ]
+                                },
+                                "options": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "value"
+                                    ]
+                                  }
+                                },
+                                "value": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ],
+                          "additionalProperties": {}
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "grid"
+            ]
+          },
+          "gridPosition": {
+            "type": "object",
+            "properties": {
+              "h": {
+                "type": "number",
+                "description": "Height in grid units (default: 36 for charts)"
+              },
+              "w": {
+                "type": "number",
+                "description": "Width in grid columns on a 24-column grid. Common widths: 24 (full), 12 (half), 8 (third), 6 (quarter). x + w must not exceed 24."
+              },
+              "x": {
+                "type": "number",
+                "description": "X position on a 24-column grid (0=left edge, 12=middle). Items side-by-side share the same y with complementary x values."
+              },
+              "y": {
+                "type": "number",
+                "description": "Y position in grid units (0=top, higher values=lower on page)"
+              }
+            },
+            "required": [
+              "h",
+              "w",
+              "x",
+              "y"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "attachedQueryKey": {
+                "type": "string",
+                "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              }
+            },
+            "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
+          },
+          "padding": {
+            "anyOf": [
+              {
+                "type": "number",
+                "enum": [
+                  0
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  0.5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  2
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  3
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  4
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  6
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  7
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  8
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "style": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          }
+        },
+        "required": [
+          "instanceKey",
+          "children",
+          "containerType"
+        ],
+        "description": "Grid container — children are positioned on a grid (each carries a gridPosition)."
+      },
+      "StackContainer": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Optional description for the container, providing additional context or information"
+          },
+          "instanceKey": {
+            "type": "string",
+            "description": "Unique identifier for this container. Used to reference the container when adding, moving, or removing children."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the container, used for easier reference in logic and design"
+          },
+          "aspectRatio": {
+            "type": "string"
+          },
+          "fillSpace": {
+            "type": "boolean"
+          },
+          "height": {
+            "type": "string"
+          },
+          "maxHeight": {
+            "type": "string"
+          },
+          "maxWidth": {
+            "type": "string"
+          },
+          "minHeight": {
+            "type": "string"
+          },
+          "minWidth": {
+            "type": "string"
+          },
+          "width": {
+            "type": "string"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "align": {
+            "type": "string",
+            "enum": [
+              "flex-start",
+              "flex-end",
+              "center",
+              "stretch"
+            ],
+            "description": "Cross-axis alignment of children (e.g., center, stretch)"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "as": {
+                      "type": "string",
+                      "enum": [
+                        "chart",
+                        "result",
+                        "ai",
+                        "metadata"
+                      ],
+                      "description": "Render mode: \"chart\" for visualization, \"result\" for data table, \"ai\" for AI summary, \"metadata\" for query metadata"
+                    },
+                    "format": {
+                      "type": "string",
+                      "enum": [
+                        "subtitle",
+                        "description",
+                        "name"
+                      ],
+                      "description": "Display format when as is \"ai\" or \"metadata\": \"name\" (metadata only), \"subtitle\", or \"description\""
+                    },
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[1-9][0-9]*$",
+                      "description": "The query presentation ID this content item references"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Display name for this query item"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "query"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "appearance": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "inline"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "tooltip"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        }
+                      ],
+                      "description": "Display mode: \"inline\" renders directly, \"tooltip\" shows on hover"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "The text content to display (supports markdown)"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Display name for this text item (e.g., title, subtitle)"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "textAlign": {
+                      "type": "string",
+                      "enum": [
+                        "start",
+                        "center",
+                        "end"
+                      ],
+                      "description": "Text alignment: \"start\", \"center\", or \"end\""
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-text"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "content",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "appearance": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "tabs"
+                              ]
+                            },
+                            "variant": {
+                              "type": "string",
+                              "enum": [
+                                "underline",
+                                "bordered"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "buttons"
+                              ]
+                            },
+                            "variant": {
+                              "type": "string",
+                              "enum": [
+                                "segment",
+                                "toggle",
+                                "pills"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "list"
+                              ]
+                            },
+                            "description": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "dropdown"
+                              ]
+                            },
+                            "description": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        }
+                      ]
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "includeControls": {
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "type": "string"
+                          },
+                          "uri": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-page-switcher"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "UUID of the rich text content block"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "text"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "control"
+                      ]
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "filter"
+                      ]
+                    },
+                    "appearance": {
+                      "type": "object",
+                      "properties": {
+                        "control": {
+                          "type": "string",
+                          "enum": [
+                            "buttonToggle",
+                            "dropdown"
+                          ]
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "inline",
+                            "popover"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          }
+                        },
+                        "value": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ],
+                  "additionalProperties": {}
+                },
+                {
+                  "$ref": "#/components/schemas/ReferenceContainer"
+                },
+                {
+                  "$ref": "#/components/schemas/GridContainer"
+                },
+                {
+                  "$ref": "#/components/schemas/StackContainer"
+                }
+              ]
+            }
+          },
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "stack"
+            ],
+            "description": "Stack containers lay out children sequentially in a direction (column or row)"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "column",
+              "row"
+            ],
+            "description": "Layout direction: \"row\" lays out horizontally, \"column\" stacks vertically (default if not specified)"
+          },
+          "gap": {
+            "anyOf": [
+              {
+                "type": "number",
+                "enum": [
+                  0
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  0.5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  2
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  3
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  4
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  6
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  7
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  8
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  9
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  10
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  11
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  12
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  13
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  14
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  15
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  16
+                ]
+              }
+            ],
+            "description": "Space between children (CSS size value)"
+          },
+          "justify": {
+            "type": "string",
+            "enum": [
+              "flex-start",
+              "flex-end",
+              "center",
+              "space-between"
+            ],
+            "description": "Main-axis alignment of children (e.g., start, center, end)"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "attachedQueryKey": {
+                "type": "string",
+                "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              }
+            },
+            "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
+          },
+          "padding": {
+            "anyOf": [
+              {
+                "type": "number",
+                "enum": [
+                  0
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  0.5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  2
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  3
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  4
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  6
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  7
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  8
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "style": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "wrap": {
+            "type": "string",
+            "enum": [
+              "nowrap",
+              "wrap"
+            ],
+            "description": "Whether flex items should wrap to new lines (defaults to nowrap if not specified)"
+          }
+        },
+        "required": [
+          "instanceKey",
+          "children",
+          "containerType"
+        ],
+        "description": "Stack container — an ordered list of nested children (content, grid, stack, or reference)."
+      },
+      "ReferenceContainer": {
+        "type": "object",
+        "properties": {
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "reference"
+            ]
+          },
+          "instanceKey": {
+            "type": "string"
+          },
+          "referenceKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "containerType",
+          "instanceKey",
+          "referenceKey"
+        ],
+        "description": "Reference container — points at another container in the collection by its instanceKey."
+      },
+      "PageContainer": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Optional description for the container, providing additional context or information"
+          },
+          "instanceKey": {
+            "type": "string",
+            "description": "Unique identifier for this container. Used to reference the container when adding, moving, or removing children."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the container, used for easier reference in logic and design"
+          },
+          "breakpoint": {
+            "type": "string",
+            "enum": [
+              "desktop",
+              "mobile"
+            ]
+          },
+          "container": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridContainer"
+              },
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "page"
+            ]
+          },
+          "media": {
+            "type": "string",
+            "enum": [
+              "screen",
+              "print"
+            ]
+          }
+        },
+        "required": [
+          "instanceKey",
+          "container",
+          "containerType"
+        ],
+        "description": "Page container — a top-level page wrapping a single grid, stack, or reference container, optionally per breakpoint/media."
+      },
+      "ControlsPatchExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ControlPatchExternal"
+            },
+            "description": "Controls keyed by control ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Display order for controls. When present, replaces the existing order."
+          }
+        }
+      },
+      "ControlPatchExternal": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "config": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "case_insensitive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "CONTAINS",
+                      "ENDS_WITH",
+                      "STARTS_WITH",
+                      "EQUALS",
+                      "IS_EMPTY",
+                      "SQL_LIKE"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_inclusive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "LESS_THAN",
+                      "GREATER_THAN",
+                      "EQUALS",
+                      "BETWEEN"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "number"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "isFiscal": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "IS_ON_DAY_OF_WEEK",
+                      "IS_ON_DAY_OF_QUARTER",
+                      "IS_IN_MONTH_OF_YEAR",
+                      "IS_ON_DAY_OF_YEAR",
+                      "IS_AT_HOUR_OF_DAY",
+                      "IS_IN_QUARTER_OF_YEAR",
+                      "IS_IN_WEEK_OF_YEAR",
+                      "IS_ON_DAY_OF_MONTH",
+                      "BETWEEN",
+                      "ON_OR_AFTER",
+                      "BEFORE",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "QUERY_OFFSET"
+                    ]
+                  },
+                  "left_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "offset_interval_string": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "right_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "date"
+                    ]
+                  },
+                  "ui_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANY_TIME",
+                      "BEFORE",
+                      "BETWEEN",
+                      "MONTH_OF_YEAR",
+                      "PAST",
+                      "YEAR",
+                      "DAY",
+                      "IS_ON_DAY_OF_WEEK",
+                      "ON_OR_AFTER",
+                      "IS_IN_THE_MONTH",
+                      "IS_IN_THE_QUARTER",
+                      "IS_IN_THE_FISCAL_QUARTER",
+                      "IS_IN_THE_FISCAL_YEAR",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "CUSTOM",
+                      null
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "null"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "treat_nulls_as_false": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "boolean"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "disregard_limit": {
+                    "type": "boolean"
+                  },
+                  "field_name": {
+                    "type": "string"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "query_id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "query"
+                    ]
+                  },
+                  "view_query": {
+                    "type": "object",
+                    "properties": {
+                      "fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "filters": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "default": {}
+                      },
+                      "limit": {
+                        "type": "number"
+                      },
+                      "sorts": {
+                        "type": "array",
+                        "items": {},
+                        "default": []
+                      },
+                      "table": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "additionalProperties": {}
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "user_attribute"
+                    ]
+                  },
+                  "user_attribute_name": {
+                    "type": "string"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type",
+                  "user_attribute_name"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR",
+                      "AND"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CompositeFilter"
+                    }
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "composite"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "conjunction",
+                  "filters",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD",
+                      "TIMEFRAME"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_SELECTION"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "field",
+                  "kind",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "selectionMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_SELECTION"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "selectionMap",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "computations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "isDynamicPreviousPeriod": {
+                          "type": "boolean"
+                        },
+                        "periodsAgo": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "timeUnitName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "periodsAgo",
+                        "timeUnitName"
+                      ]
+                    }
+                  },
+                  "filterFieldName": {
+                    "type": "string"
+                  },
+                  "filterId": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "PERIOD_OVER_PERIOD"
+                    ]
+                  }
+                },
+                "required": [
+                  "computations",
+                  "filterFieldName",
+                  "id",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_PICKER"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filter": {
+                          "$ref": "#/components/schemas/JsonValue"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fieldName",
+                        "filter",
+                        "id"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "conjunction",
+                  "filters",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "fieldSelection": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "full-model"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "mode"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "auto"
+                            ]
+                          },
+                          "topics": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "mode",
+                          "topics"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "fields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "fieldName": {
+                                  "type": "string"
+                                },
+                                "topicName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldName"
+                              ]
+                            }
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "specific"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fields",
+                          "mode"
+                        ]
+                      }
+                    ]
+                  },
+                  "includeViewNameInLabels": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "DYNAMIC_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "fieldSelection",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "defaultValue": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "max": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "min": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "TOP_N"
+                    ]
+                  },
+                  "value": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "id",
+                  "defaultValue",
+                  "field",
+                  "type",
+                  "value"
+                ]
+              }
+            ],
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+          },
+          "map": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ]
+                }
+              ]
+            },
+            "description": "Per-tile field overrides keyed by tab ID. Values are a field name (override) or false (exclude tile from control)."
+          }
+        },
+        "required": [
+          "config"
+        ]
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "description": "Arbitrary JSON value (string, number, boolean, null, object, or array)."
+      },
+      "QueryPresentationsPatchExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/QueryPresentationPatchExternal"
+            },
+            "description": "Query presentations keyed by tab ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete. Capped at 48 entries per patch."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "description": "Tab display order. When present, replaces the existing order."
+          }
+        }
+      },
+      "QueryPresentationPatchExternal": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "aiConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "description": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "subTitle": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "description": "AI-generated metadata config (subtitle/description auto-generation settings)."
+          },
+          "automaticVis": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "When true, the system automatically selects the best visualization type."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 500,
+            "description": "User-provided tab description."
+          },
+          "editingModelObjectName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Model object (view/topic) currently being edited via the dataset/query-view editor. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "editingModelObjectNameChange": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "filterOrder": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ordered list of filter field names controlling display order on this tab."
+          },
+          "isSql": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this tab is in raw SQL mode."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 144,
+            "description": "User-provided tab name."
+          },
+          "prefersChart": {
+            "type": "boolean",
+            "description": "When true, the chart view is shown by default instead of the data table."
+          },
+          "query": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "aiGenerated": {
+                "type": "boolean",
+                "description": "True when AI generated this query’s SQL; the AI SQL is shown in the advanced SQL box."
+              },
+              "branch_id": {
+                "type": "string",
+                "description": "Branch model ID when querying against a model branch."
+              },
+              "calculations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "allow_refs_to_unselected_fields": {
+                      "type": "boolean",
+                      "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
+                    },
+                    "calc_name": {
+                      "type": "string",
+                      "description": "Internal identifier for the calculation, used as the column alias."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of the calculation."
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "Number/date format string (e.g. \"#,##0.00\")."
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label shown in the UI."
+                    },
+                    "original_formula": {
+                      "type": "string",
+                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                    },
+                    "outside_pivot": {
+                      "type": "boolean",
+                      "description": "When true, the calculation is evaluated outside the pivot grouping."
+                    },
+                    "pushdown": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Per-calc override for whether to evaluate before the row limit. `null` defers to the model-level default."
+                    },
+                    "sql": {
+                      "type": "string",
+                      "description": "Compiled SQL string produced from the formula."
+                    },
+                    "sql_expression": {
+                      "description": "Parsed SQL expression tree (serialized)."
+                    },
+                    "swallow_errors": {
+                      "type": "boolean",
+                      "description": "When true, calculation errors are silently swallowed instead of surfaced."
+                    }
+                  },
+                  "required": [
+                    "calc_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Table calculations attached to this query."
+              },
+              "column_limit": {
+                "type": "number",
+                "description": "Max number of pivot columns to return."
+              },
+              "column_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Column-level aggregation totals, keyed by field name."
+              },
+              "controls": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD",
+                            "TIMEFRAME"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_SELECTION"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "field",
+                        "kind",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "selectionMap": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_SELECTION"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "selectionMap",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "computations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "filterId": {
+                                "type": "string"
+                              },
+                              "isDynamicPreviousPeriod": {
+                                "type": "boolean"
+                              },
+                              "periodsAgo": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "timeUnitName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "periodsAgo",
+                              "timeUnitName"
+                            ]
+                          }
+                        },
+                        "filterFieldName": {
+                          "type": "string"
+                        },
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "PERIOD_OVER_PERIOD"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "computations",
+                        "filterFieldName",
+                        "id",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_PICKER"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fieldName": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "$ref": "#/components/schemas/JsonValue"
+                              },
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldName",
+                              "filter",
+                              "id"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "fieldSelection": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "full-model"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "mode"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "auto"
+                                  ]
+                                },
+                                "topics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "mode",
+                                "topics"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fields": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "fieldName": {
+                                        "type": "string"
+                                      },
+                                      "topicName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldName"
+                                    ]
+                                  }
+                                },
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "specific"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fields",
+                                "mode"
+                              ]
+                            }
+                          ]
+                        },
+                        "includeViewNameInLabels": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "DYNAMIC_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "fieldSelection",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "defaultValue": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "max": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "min": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "TOP_N"
+                          ]
+                        },
+                        "value": {
+                          "type": "integer",
+                          "minimum": 1
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "defaultValue",
+                        "field",
+                        "type",
+                        "value"
+                      ]
+                    }
+                  ]
+                },
+                "description": "Interactive controls (field selectors, PoP controls) attached to this query."
+              },
+              "cube_metadata": {
+                "type": "object",
+                "properties": {
+                  "cube_name": {
+                    "type": "string"
+                  },
+                  "hash_key": {
+                    "type": "string"
+                  },
+                  "topic_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cube_name",
+                  "hash_key",
+                  "topic_name"
+                ],
+                "additionalProperties": {},
+                "description": "Cube-specific metadata (topic name, cube name, hash key) for cube-backed queries."
+              },
+              "custom_summary_types": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Per-field custom summary functions (e.g. SUM, AVG, COUNT)."
+              },
+              "dbtFileName": {
+                "type": "string",
+                "description": "dbt file name when this query is backed by a dbt model."
+              },
+              "dbtMode": {
+                "type": "boolean",
+                "description": "Whether this query is in dbt mode."
+              },
+              "default_group_by": {
+                "type": "boolean",
+                "description": "When true, all dimensions are implicitly included in GROUP BY."
+              },
+              "dimensionIndex": {
+                "type": "number",
+                "description": "Index of the primary dimension used for result ordering."
+              },
+              "executableSQL": {
+                "type": "string",
+                "description": "Server-compiled SQL string (read-only, set by the backend)."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model field names selected for the query (dimensions + measures)."
+              },
+              "fill_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields whose missing date/time values should be filled with nulls to create continuous series."
+              },
+              "filters": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Query filters keyed by filter ID."
+              },
+              "filtersUsedInSql": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Filters that were embedded directly in raw SQL (read-only)."
+              },
+              "join_paths_from_topic_name": {
+                "type": "string",
+                "description": "Topic name that determines join path precedence for parsed SQL queries."
+              },
+              "join_via_map": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "description": "Virtual topic join path overrides, keyed by view name to ordered join path."
+              },
+              "limit": {
+                "type": "number",
+                "description": "Row limit for the query."
+              },
+              "manualSort": {
+                "type": "boolean",
+                "description": "When true, the user has explicitly set a custom sort order."
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "order": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "description": "Per-field display metadata (format, label, order)."
+              },
+              "offset": {
+                "type": "number",
+                "description": "Row offset for pagination."
+              },
+              "parsed": {
+                "type": "boolean",
+                "description": "Whether this raw SQL query has been parsed into a semantic query."
+              },
+              "periodOverPeriodTransposed": {
+                "type": "boolean",
+                "description": "Whether the period-over-period comparison columns are transposed."
+              },
+              "period_over_period_computations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "date_filter_field_name": {
+                      "type": "string",
+                      "description": "The date dimension field this comparison is anchored to."
+                    },
+                    "date_filter_id": {
+                      "type": "string",
+                      "description": "ID of the date filter being offset (if backed by a dashboard filter)."
+                    },
+                    "is_dynamic_previous_period": {
+                      "type": "boolean",
+                      "description": "When true, the previous period is calculated dynamically relative to the current filter range."
+                    },
+                    "periods_ago": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "How many periods back to compare (e.g. 1 = previous period). Null if not set."
+                    },
+                    "time_unit_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Time grain for the offset (e.g. \"month\", \"year\"). Null if not set."
+                    }
+                  },
+                  "required": [
+                    "date_filter_field_name",
+                    "periods_ago",
+                    "time_unit_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Period-over-period comparison configurations."
+              },
+              "pivots": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names to pivot on (columns become values)."
+              },
+              "rewriteSql": {
+                "type": "boolean",
+                "description": "When true, the backend should rewrite/optimize the SQL."
+              },
+              "row_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Row-level aggregation totals, keyed by field name."
+              },
+              "sorts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "column_name": {
+                      "type": "string",
+                      "description": "The model field name to sort by."
+                    },
+                    "is_column_sort": {
+                      "type": "boolean",
+                      "description": "When true, this sort targets a pivoted column rather than a row dimension."
+                    },
+                    "pivot_value_map": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": "Maps pivot field names to specific pivot values, scoping the sort to a single pivot column."
+                    },
+                    "sort_descending": {
+                      "type": "boolean",
+                      "description": "When true, sort order is descending."
+                    },
+                    "subtotal_sort": {
+                      "type": "string",
+                      "description": "Field name whose subtotal row should be used as the sort key."
+                    }
+                  },
+                  "required": [
+                    "column_name",
+                    "sort_descending"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Sort clauses applied to the query result set."
+              },
+              "sqlSortsEnabled": {
+                "type": "boolean",
+                "description": "Whether user-created sorts are enabled on a raw SQL query."
+              },
+              "staticQueryReferences": {
+                "type": "object",
+                "additionalProperties": {},
+                "description": "Pre-computed query references for AI chat context. Inner shape is `OmniQuery & { model_id: string }`; left as `unknown` to avoid a recursive zod schema. Validated structurally by consumers when they execute the referenced sub-queries."
+              },
+              "table": {
+                "type": "string",
+                "description": "Base view (table) name in the model."
+              },
+              "transposed_measures": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Measure field names that have been transposed into rows."
+              },
+              "userEditedSQL": {
+                "type": "string",
+                "description": "User-authored raw SQL (empty string when not in SQL mode)."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for migration support."
+              }
+            },
+            "required": [
+              "calculations",
+              "column_totals",
+              "fields",
+              "fill_fields",
+              "filters",
+              "pivots",
+              "row_totals",
+              "sorts",
+              "table",
+              "userEditedSQL"
+            ],
+            "additionalProperties": {},
+            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). Omitted on a no-op replay; the server anchors new/changed tiles to the draft."
+          },
+          "resultConfig": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Result display configuration (column widths, frozen columns, conditional formatting, number formatting, etc.)."
+          },
+          "subTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 250,
+            "description": "User-provided tab subtitle."
+          },
+          "topicName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic (explore) this query is built on."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "blank",
+              "csv",
+              "query",
+              "dataset",
+              "spreadsheet",
+              "sql",
+              "dbt",
+              "query-view",
+              "linked",
+              "app"
+            ],
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+          },
+          "visConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "chartType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "auto",
+                  "area",
+                  "areaStacked",
+                  "areaStackedPercentage",
+                  "bar",
+                  "barLine",
+                  "barGrouped",
+                  "barStacked",
+                  "barStackedPercentage",
+                  "boxplot",
+                  "code",
+                  "column",
+                  "columnGrouped",
+                  "columnStacked",
+                  "columnStackedPercentage",
+                  "heatmap",
+                  "kpi",
+                  "line",
+                  "lineColor",
+                  "map",
+                  "regionMap",
+                  "markdown",
+                  "omni-ai-summary-markdown",
+                  "pie",
+                  "funnel",
+                  "sankey",
+                  "point",
+                  "pointColor",
+                  "pointSize",
+                  "pointSizeColor",
+                  "singleRecord",
+                  "omni-spreadsheet",
+                  "summaryValue",
+                  "svgMap",
+                  "table",
+                  null
+                ],
+                "description": "High-level chart type (e.g. \"bar\", \"line\", \"area\")."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names used in the visualization axes/series."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for vis config migration."
+              },
+              "visConfig": {
+                "type": "object",
+                "properties": {
+                  "visType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "vegalite",
+                      "omni-ai-summary-markdown",
+                      "basic",
+                      "omni-kpi",
+                      "map",
+                      "omni-markdown",
+                      "funnel",
+                      "sankey",
+                      "single-record",
+                      "svg-map",
+                      "omni-spreadsheet",
+                      "spreadsheet-tab",
+                      "summary-value",
+                      "omni-table",
+                      "app",
+                      null
+                    ],
+                    "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
+                  }
+                },
+                "additionalProperties": {},
+                "description": "Inner visualization config — structure varies by visType."
+              }
+            },
+            "additionalProperties": {},
+            "description": "Visualization configuration for the tile."
+          },
+          "sourceQueryPresentationKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[1-9][0-9]*$",
+            "description": "For LINKED-type tabs, the record key — the same identifier used as a `queryPresentations.data` key — of the source tile whose query this tab reuses. Null for all other tab types. This is a tile record key, NOT a positional index into `order`."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      },
+      "SettingsPatchExternal": {
+        "type": "object",
+        "properties": {
+          "crossfilterEnabled": {
+            "type": "boolean",
+            "description": "When true, clicking a value in one tile filters all other tiles on the dashboard."
+          },
+          "customText": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "queryError": {
+                "type": "string",
+                "description": "Custom text shown when a query errors, replacing the default error text."
+              },
+              "queryNoResults": {
+                "type": "string",
+                "description": "Custom text shown when a query returns no results, replacing the default empty state."
+              }
+            },
+            "description": "Custom text replacing default UI strings on the dashboard, e.g. when queries error or return no results."
+          },
+          "facetFilters": {
+            "type": "boolean",
+            "description": "When true, dashboard filters are applied per-facet when faceting is active."
+          },
+          "refreshInterval": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Auto-refresh interval in seconds. Null disables auto-refresh."
+          },
+          "runQueriesOn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "current-page",
+              "all-pages",
+              null
+            ],
+            "description": "Controls whether dashboard queries execute on the visible page or across all pages."
+          }
+        },
+        "description": "Document settings. Shallow-merged with the existing settings."
+      },
+      "DocumentsV2ReadResponse": {
+        "type": "object",
+        "properties": {
+          "containers": {
+            "$ref": "#/components/schemas/Containers"
+          },
+          "controls": {
+            "$ref": "#/components/schemas/ControlsReadExternal"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 254,
+            "description": "Document name."
+          },
+          "queryPresentations": {
+            "$ref": "#/components/schemas/QueryPresentationsReadExternal"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsReadExternal"
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "queryPresentations"
+        ]
+      },
+      "ControlsReadExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ControlReadExternal"
+            },
+            "description": "Controls keyed by control ID."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Display order for controls."
+          }
+        },
+        "required": [
+          "data",
+          "order"
+        ]
+      },
+      "ControlReadExternal": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "case_insensitive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "CONTAINS",
+                      "ENDS_WITH",
+                      "STARTS_WITH",
+                      "EQUALS",
+                      "IS_EMPTY",
+                      "SQL_LIKE"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_inclusive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "LESS_THAN",
+                      "GREATER_THAN",
+                      "EQUALS",
+                      "BETWEEN"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "number"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "isFiscal": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "IS_ON_DAY_OF_WEEK",
+                      "IS_ON_DAY_OF_QUARTER",
+                      "IS_IN_MONTH_OF_YEAR",
+                      "IS_ON_DAY_OF_YEAR",
+                      "IS_AT_HOUR_OF_DAY",
+                      "IS_IN_QUARTER_OF_YEAR",
+                      "IS_IN_WEEK_OF_YEAR",
+                      "IS_ON_DAY_OF_MONTH",
+                      "BETWEEN",
+                      "ON_OR_AFTER",
+                      "BEFORE",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "QUERY_OFFSET"
+                    ]
+                  },
+                  "left_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "offset_interval_string": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "right_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "date"
+                    ]
+                  },
+                  "ui_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANY_TIME",
+                      "BEFORE",
+                      "BETWEEN",
+                      "MONTH_OF_YEAR",
+                      "PAST",
+                      "YEAR",
+                      "DAY",
+                      "IS_ON_DAY_OF_WEEK",
+                      "ON_OR_AFTER",
+                      "IS_IN_THE_MONTH",
+                      "IS_IN_THE_QUARTER",
+                      "IS_IN_THE_FISCAL_QUARTER",
+                      "IS_IN_THE_FISCAL_YEAR",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "CUSTOM",
+                      null
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "null"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "treat_nulls_as_false": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "boolean"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "disregard_limit": {
+                    "type": "boolean"
+                  },
+                  "field_name": {
+                    "type": "string"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "query_id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "query"
+                    ]
+                  },
+                  "view_query": {
+                    "type": "object",
+                    "properties": {
+                      "fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "filters": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "default": {}
+                      },
+                      "limit": {
+                        "type": "number"
+                      },
+                      "sorts": {
+                        "type": "array",
+                        "items": {},
+                        "default": []
+                      },
+                      "table": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "additionalProperties": {}
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "user_attribute"
+                    ]
+                  },
+                  "user_attribute_name": {
+                    "type": "string"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type",
+                  "user_attribute_name"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR",
+                      "AND"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CompositeFilter"
+                    }
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "composite"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "conjunction",
+                  "filters",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD",
+                      "TIMEFRAME"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_SELECTION"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "field",
+                  "kind",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "selectionMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_SELECTION"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "selectionMap",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "computations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "isDynamicPreviousPeriod": {
+                          "type": "boolean"
+                        },
+                        "periodsAgo": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "timeUnitName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "periodsAgo",
+                        "timeUnitName"
+                      ]
+                    }
+                  },
+                  "filterFieldName": {
+                    "type": "string"
+                  },
+                  "filterId": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "PERIOD_OVER_PERIOD"
+                    ]
+                  }
+                },
+                "required": [
+                  "computations",
+                  "filterFieldName",
+                  "id",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_PICKER"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filter": {
+                          "$ref": "#/components/schemas/JsonValue"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fieldName",
+                        "filter",
+                        "id"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "conjunction",
+                  "filters",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "fieldSelection": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "full-model"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "mode"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "auto"
+                            ]
+                          },
+                          "topics": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "mode",
+                          "topics"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "fields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "fieldName": {
+                                  "type": "string"
+                                },
+                                "topicName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldName"
+                              ]
+                            }
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "specific"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fields",
+                          "mode"
+                        ]
+                      }
+                    ]
+                  },
+                  "includeViewNameInLabels": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "DYNAMIC_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "fieldSelection",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "defaultValue": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "max": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "min": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "TOP_N"
+                    ]
+                  },
+                  "value": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "id",
+                  "defaultValue",
+                  "field",
+                  "type",
+                  "value"
+                ]
+              }
+            ],
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+          },
+          "map": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ]
+                }
+              ]
+            },
+            "description": "Per-tile field overrides keyed by tab ID. Values are a field name (override) or false (exclude tile from control)."
+          }
+        },
+        "required": [
+          "config"
+        ]
+      },
+      "QueryPresentationsReadExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/QueryPresentationReadExternal"
+            },
+            "description": "Query presentations keyed by tab ID."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "description": "Tab display order."
+          }
+        },
+        "required": [
+          "data",
+          "order"
+        ]
+      },
+      "QueryPresentationReadExternal": {
+        "type": "object",
+        "properties": {
+          "aiConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "description": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "subTitle": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "description": "AI-generated metadata config (subtitle/description auto-generation settings)."
+          },
+          "automaticVis": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "When true, the system automatically selects the best visualization type."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 500,
+            "description": "User-provided tab description."
+          },
+          "editingModelObjectName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Model object (view/topic) currently being edited via the dataset/query-view editor. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "editingModelObjectNameChange": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "filterOrder": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ordered list of filter field names controlling display order on this tab."
+          },
+          "isSql": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this tab is in raw SQL mode."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 144,
+            "description": "User-provided tab name."
+          },
+          "prefersChart": {
+            "type": "boolean",
+            "description": "When true, the chart view is shown by default instead of the data table."
+          },
+          "query": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "aiGenerated": {
+                "type": "boolean",
+                "description": "True when AI generated this query’s SQL; the AI SQL is shown in the advanced SQL box."
+              },
+              "branch_id": {
+                "type": "string",
+                "description": "Branch model ID when querying against a model branch."
+              },
+              "calculations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "allow_refs_to_unselected_fields": {
+                      "type": "boolean",
+                      "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
+                    },
+                    "calc_name": {
+                      "type": "string",
+                      "description": "Internal identifier for the calculation, used as the column alias."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of the calculation."
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "Number/date format string (e.g. \"#,##0.00\")."
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label shown in the UI."
+                    },
+                    "original_formula": {
+                      "type": "string",
+                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                    },
+                    "outside_pivot": {
+                      "type": "boolean",
+                      "description": "When true, the calculation is evaluated outside the pivot grouping."
+                    },
+                    "pushdown": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Per-calc override for whether to evaluate before the row limit. `null` defers to the model-level default."
+                    },
+                    "sql": {
+                      "type": "string",
+                      "description": "Compiled SQL string produced from the formula."
+                    },
+                    "sql_expression": {
+                      "description": "Parsed SQL expression tree (serialized)."
+                    },
+                    "swallow_errors": {
+                      "type": "boolean",
+                      "description": "When true, calculation errors are silently swallowed instead of surfaced."
+                    }
+                  },
+                  "required": [
+                    "calc_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Table calculations attached to this query."
+              },
+              "column_limit": {
+                "type": "number",
+                "description": "Max number of pivot columns to return."
+              },
+              "column_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Column-level aggregation totals, keyed by field name."
+              },
+              "controls": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD",
+                            "TIMEFRAME"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_SELECTION"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "field",
+                        "kind",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "selectionMap": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_SELECTION"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "selectionMap",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "computations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "filterId": {
+                                "type": "string"
+                              },
+                              "isDynamicPreviousPeriod": {
+                                "type": "boolean"
+                              },
+                              "periodsAgo": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "timeUnitName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "periodsAgo",
+                              "timeUnitName"
+                            ]
+                          }
+                        },
+                        "filterFieldName": {
+                          "type": "string"
+                        },
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "PERIOD_OVER_PERIOD"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "computations",
+                        "filterFieldName",
+                        "id",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_PICKER"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fieldName": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "$ref": "#/components/schemas/JsonValue"
+                              },
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldName",
+                              "filter",
+                              "id"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "fieldSelection": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "full-model"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "mode"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "auto"
+                                  ]
+                                },
+                                "topics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "mode",
+                                "topics"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fields": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "fieldName": {
+                                        "type": "string"
+                                      },
+                                      "topicName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldName"
+                                    ]
+                                  }
+                                },
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "specific"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fields",
+                                "mode"
+                              ]
+                            }
+                          ]
+                        },
+                        "includeViewNameInLabels": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "DYNAMIC_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "fieldSelection",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "defaultValue": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "max": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "min": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "TOP_N"
+                          ]
+                        },
+                        "value": {
+                          "type": "integer",
+                          "minimum": 1
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "defaultValue",
+                        "field",
+                        "type",
+                        "value"
+                      ]
+                    }
+                  ]
+                },
+                "description": "Interactive controls (field selectors, PoP controls) attached to this query."
+              },
+              "cube_metadata": {
+                "type": "object",
+                "properties": {
+                  "cube_name": {
+                    "type": "string"
+                  },
+                  "hash_key": {
+                    "type": "string"
+                  },
+                  "topic_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cube_name",
+                  "hash_key",
+                  "topic_name"
+                ],
+                "additionalProperties": {},
+                "description": "Cube-specific metadata (topic name, cube name, hash key) for cube-backed queries."
+              },
+              "custom_summary_types": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Per-field custom summary functions (e.g. SUM, AVG, COUNT)."
+              },
+              "dbtFileName": {
+                "type": "string",
+                "description": "dbt file name when this query is backed by a dbt model."
+              },
+              "dbtMode": {
+                "type": "boolean",
+                "description": "Whether this query is in dbt mode."
+              },
+              "default_group_by": {
+                "type": "boolean",
+                "description": "When true, all dimensions are implicitly included in GROUP BY."
+              },
+              "dimensionIndex": {
+                "type": "number",
+                "description": "Index of the primary dimension used for result ordering."
+              },
+              "executableSQL": {
+                "type": "string",
+                "description": "Server-compiled SQL string (read-only, set by the backend)."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model field names selected for the query (dimensions + measures)."
+              },
+              "fill_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields whose missing date/time values should be filled with nulls to create continuous series."
+              },
+              "filters": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Query filters keyed by filter ID."
+              },
+              "filtersUsedInSql": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Filters that were embedded directly in raw SQL (read-only)."
+              },
+              "join_paths_from_topic_name": {
+                "type": "string",
+                "description": "Topic name that determines join path precedence for parsed SQL queries."
+              },
+              "join_via_map": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "description": "Virtual topic join path overrides, keyed by view name to ordered join path."
+              },
+              "limit": {
+                "type": "number",
+                "description": "Row limit for the query."
+              },
+              "manualSort": {
+                "type": "boolean",
+                "description": "When true, the user has explicitly set a custom sort order."
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "order": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "description": "Per-field display metadata (format, label, order)."
+              },
+              "offset": {
+                "type": "number",
+                "description": "Row offset for pagination."
+              },
+              "parsed": {
+                "type": "boolean",
+                "description": "Whether this raw SQL query has been parsed into a semantic query."
+              },
+              "periodOverPeriodTransposed": {
+                "type": "boolean",
+                "description": "Whether the period-over-period comparison columns are transposed."
+              },
+              "period_over_period_computations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "date_filter_field_name": {
+                      "type": "string",
+                      "description": "The date dimension field this comparison is anchored to."
+                    },
+                    "date_filter_id": {
+                      "type": "string",
+                      "description": "ID of the date filter being offset (if backed by a dashboard filter)."
+                    },
+                    "is_dynamic_previous_period": {
+                      "type": "boolean",
+                      "description": "When true, the previous period is calculated dynamically relative to the current filter range."
+                    },
+                    "periods_ago": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "How many periods back to compare (e.g. 1 = previous period). Null if not set."
+                    },
+                    "time_unit_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Time grain for the offset (e.g. \"month\", \"year\"). Null if not set."
+                    }
+                  },
+                  "required": [
+                    "date_filter_field_name",
+                    "periods_ago",
+                    "time_unit_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Period-over-period comparison configurations."
+              },
+              "pivots": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names to pivot on (columns become values)."
+              },
+              "rewriteSql": {
+                "type": "boolean",
+                "description": "When true, the backend should rewrite/optimize the SQL."
+              },
+              "row_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Row-level aggregation totals, keyed by field name."
+              },
+              "sorts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "column_name": {
+                      "type": "string",
+                      "description": "The model field name to sort by."
+                    },
+                    "is_column_sort": {
+                      "type": "boolean",
+                      "description": "When true, this sort targets a pivoted column rather than a row dimension."
+                    },
+                    "pivot_value_map": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": "Maps pivot field names to specific pivot values, scoping the sort to a single pivot column."
+                    },
+                    "sort_descending": {
+                      "type": "boolean",
+                      "description": "When true, sort order is descending."
+                    },
+                    "subtotal_sort": {
+                      "type": "string",
+                      "description": "Field name whose subtotal row should be used as the sort key."
+                    }
+                  },
+                  "required": [
+                    "column_name",
+                    "sort_descending"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Sort clauses applied to the query result set."
+              },
+              "sqlSortsEnabled": {
+                "type": "boolean",
+                "description": "Whether user-created sorts are enabled on a raw SQL query."
+              },
+              "staticQueryReferences": {
+                "type": "object",
+                "additionalProperties": {},
+                "description": "Pre-computed query references for AI chat context. Inner shape is `OmniQuery & { model_id: string }`; left as `unknown` to avoid a recursive zod schema. Validated structurally by consumers when they execute the referenced sub-queries."
+              },
+              "table": {
+                "type": "string",
+                "description": "Base view (table) name in the model."
+              },
+              "transposed_measures": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Measure field names that have been transposed into rows."
+              },
+              "userEditedSQL": {
+                "type": "string",
+                "description": "User-authored raw SQL (empty string when not in SQL mode)."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for migration support."
+              }
+            },
+            "required": [
+              "calculations",
+              "column_totals",
+              "fields",
+              "fill_fields",
+              "filters",
+              "pivots",
+              "row_totals",
+              "sorts",
+              "table",
+              "userEditedSQL"
+            ],
+            "additionalProperties": {},
+            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). For LINKED-type tabs this field is read-only."
+          },
+          "resultConfig": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Result display configuration (column widths, frozen columns, conditional formatting, number formatting, etc.)."
+          },
+          "subTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 250,
+            "description": "User-provided tab subtitle."
+          },
+          "topicName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic (explore) this query is built on."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "blank",
+              "csv",
+              "query",
+              "dataset",
+              "spreadsheet",
+              "sql",
+              "dbt",
+              "query-view",
+              "linked",
+              "app"
+            ],
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+          },
+          "visConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "chartType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "auto",
+                  "area",
+                  "areaStacked",
+                  "areaStackedPercentage",
+                  "bar",
+                  "barLine",
+                  "barGrouped",
+                  "barStacked",
+                  "barStackedPercentage",
+                  "boxplot",
+                  "code",
+                  "column",
+                  "columnGrouped",
+                  "columnStacked",
+                  "columnStackedPercentage",
+                  "heatmap",
+                  "kpi",
+                  "line",
+                  "lineColor",
+                  "map",
+                  "regionMap",
+                  "markdown",
+                  "omni-ai-summary-markdown",
+                  "pie",
+                  "funnel",
+                  "sankey",
+                  "point",
+                  "pointColor",
+                  "pointSize",
+                  "pointSizeColor",
+                  "singleRecord",
+                  "omni-spreadsheet",
+                  "summaryValue",
+                  "svgMap",
+                  "table",
+                  null
+                ],
+                "description": "High-level chart type (e.g. \"bar\", \"line\", \"area\")."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names used in the visualization axes/series."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for vis config migration."
+              },
+              "visConfig": {
+                "type": "object",
+                "properties": {
+                  "visType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "vegalite",
+                      "omni-ai-summary-markdown",
+                      "basic",
+                      "omni-kpi",
+                      "map",
+                      "omni-markdown",
+                      "funnel",
+                      "sankey",
+                      "single-record",
+                      "svg-map",
+                      "omni-spreadsheet",
+                      "spreadsheet-tab",
+                      "summary-value",
+                      "omni-table",
+                      "app",
+                      null
+                    ],
+                    "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
+                  }
+                },
+                "additionalProperties": {},
+                "description": "Inner visualization config — structure varies by visType."
+              }
+            },
+            "additionalProperties": {},
+            "description": "Visualization configuration for the tile."
+          },
+          "sourceQueryPresentationKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[1-9][0-9]*$",
+            "description": "For LINKED-type tabs, the record key — the same identifier used as a `queryPresentations.data` key — of the source tile whose query this tab reuses. Null for all other tab types. This is a tile record key, NOT a positional index into `order`."
+          }
+        },
+        "required": [
+          "aiConfig",
+          "automaticVis",
+          "description",
+          "filterOrder",
+          "isSql",
+          "name",
+          "prefersChart",
+          "query",
+          "resultConfig",
+          "subTitle",
+          "topicName",
+          "type",
+          "visConfig",
+          "sourceQueryPresentationKey"
+        ]
+      },
+      "SettingsReadExternal": {
+        "type": "object",
+        "properties": {
+          "crossfilterEnabled": {
+            "type": "boolean",
+            "description": "When true, clicking a value in one tile filters all other tiles on the dashboard."
+          },
+          "customText": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "queryError": {
+                "type": "string",
+                "description": "Custom text shown when a query errors, replacing the default error text."
+              },
+              "queryNoResults": {
+                "type": "string",
+                "description": "Custom text shown when a query returns no results, replacing the default empty state."
+              }
+            },
+            "description": "Custom text replacing default UI strings on the dashboard, e.g. when queries error or return no results."
+          },
+          "facetFilters": {
+            "type": "boolean",
+            "description": "When true, dashboard filters are applied per-facet when faceting is active."
+          },
+          "refreshInterval": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Auto-refresh interval in seconds. Null disables auto-refresh."
+          },
+          "runQueriesOn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "current-page",
+              "all-pages",
+              null
+            ],
+            "description": "Controls whether dashboard queries execute on the visible page or across all pages."
+          }
+        },
+        "required": [
+          "crossfilterEnabled",
+          "customText",
+          "facetFilters",
+          "refreshInterval",
+          "runQueriesOn"
+        ]
+      },
+      "DocumentsV2PatchDraftResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "draftIdentifier": {
+            "type": "string",
+            "description": "Identifier of the draft the patch was applied to."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Published document identifier the draft targets."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "description",
+          "draftIdentifier",
+          "identifier",
+          "name"
+        ]
+      },
+      "DocumentsV2CreateDraftBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DocumentsV2PatchDraftBody"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "branchId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Branch the draft is created on. Omit for a draft on the main (unpublished) workspace."
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "DocumentsV2PatchDraftBody": {
+        "type": "object",
+        "properties": {
+          "containers": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Containers"
+              },
+              {
+                "description": "Container layout. When present, fully replaces the existing layout."
+              }
+            ]
+          },
+          "controls": {
+            "$ref": "#/components/schemas/ControlsPatchExternal"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 254,
+            "description": "Document name."
+          },
+          "queryPresentations": {
+            "$ref": "#/components/schemas/QueryPresentationsPatchExternal"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsPatchExternal"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Caller-supplied description of what this patch changes, written to the history audit trail. When absent, the server generates one from the touched sections."
+          }
+        },
+        "additionalProperties": false
+      },
+      "DocumentsV2PublishDraftResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Published document identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "description",
+          "identifier",
+          "name"
+        ]
+      },
       "EmbedSsoGenerateSessionResponse": {
         "type": "object",
         "properties": {
@@ -3062,6 +24298,524 @@
         "required": [
           "externalId",
           "name"
+        ]
+      },
+      "EvalPromptSetsListResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_sets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalPromptSetListItem"
+            },
+            "description": "Prompt sets matching the query, sorted alphabetically by name."
+          }
+        },
+        "required": [
+          "prompt_sets"
+        ]
+      },
+      "EvalPromptSetListItem": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description of the prompt set.",
+            "example": "Regression suite for the orders topic"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the prompt set.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the prompt set has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this prompt set is bound to.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the prompt set.",
+            "example": "Orders regression"
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe identifier for the prompt set. Unique per `model_id`.",
+            "example": "orders-regression"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was last updated.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "latest_run_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp of the most recent run on this prompt set, if any.",
+            "example": "2025-01-15T10:05:00.000Z"
+          },
+          "prompt_count": {
+            "type": "integer",
+            "description": "Number of prompts in the set.",
+            "example": 12
+          }
+        },
+        "required": [
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "name",
+          "slug",
+          "updated_at",
+          "latest_run_at",
+          "prompt_count"
+        ]
+      },
+      "EvalApiError400": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Bad Request: name: Required"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 400
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError401": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Unauthorized: Missing or invalid API key"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 401
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError403": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "AI eval requires at least Querier access on the model"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 403
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError404": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Prompt set not found"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 404
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalPromptSetsCreateResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
+        ]
+      },
+      "EvalPromptSet": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description of the prompt set.",
+            "example": "Regression suite for the orders topic"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the prompt set.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the prompt set has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this prompt set is bound to.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the prompt set.",
+            "example": "Orders regression"
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalPrompt"
+            },
+            "description": "Prompts that make up the set."
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe identifier for the prompt set. Unique per `model_id`.",
+            "example": "orders-regression"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was last updated.",
+            "example": "2025-01-15T10:00:00.000Z"
+          }
+        },
+        "required": [
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "name",
+          "prompts",
+          "slug",
+          "updated_at"
+        ]
+      },
+      "EvalPrompt": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "expectation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The expectation the analysis judge scores the analysis against, or null when none was set.",
+            "example": "The top product by revenue should be Aniseed Syrup."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the prompt.",
+            "example": "770e8400-e29b-41d4-a716-446655440002"
+          },
+          "prompt_text": {
+            "type": "string",
+            "description": "The natural language prompt text the AI is evaluated on.",
+            "example": "What are the top 5 products by revenue?"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt was last updated.",
+            "example": "2025-01-15T10:00:00.000Z"
+          }
+        },
+        "required": [
+          "created_at",
+          "expectation",
+          "id",
+          "prompt_text",
+          "updated_at"
+        ]
+      },
+      "EvalPromptSetsCreateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024,
+            "description": "Optional human-readable description of the prompt set. Max 1024 characters.",
+            "example": "Regression suite for the orders topic"
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this prompt set is bound to.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Human-readable name for the prompt set. 255 characters or fewer.",
+            "example": "Orders regression"
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "expectation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "maxLength": 16000,
+                  "description": "Optional expectation the analysis judge scores the analysis against. Max 16000 characters.",
+                  "example": "The top product by revenue should be Aniseed Syrup."
+                },
+                "prompt_text": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 8000,
+                  "description": "The natural language prompt text. Max 8000 characters.",
+                  "example": "What are the top 5 products by revenue?"
+                }
+              },
+              "required": [
+                "prompt_text"
+              ]
+            },
+            "maxItems": 25,
+            "default": [],
+            "description": "Initial prompts for the set. Defaults to an empty list. At most 25 prompts."
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 255,
+            "pattern": "^[a-z][a-z0-9-]*$",
+            "description": "URL-safe identifier for the prompt set. Must be unique per `model_id` and match `^[a-z][a-z0-9-]*$`. Max 255 characters.",
+            "example": "orders-regression"
+          }
+        },
+        "required": [
+          "model_id",
+          "name",
+          "slug"
+        ]
+      },
+      "EvalPromptSetsGetResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
+        ]
+      },
+      "EvalPromptSetsUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
+        ]
+      },
+      "EvalApiError422": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "A prompt being updated does not belong to this prompt set"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 422
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalPromptSetsUpdateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024,
+            "description": "New description for the prompt set. Pass `null` to clear. Max 1024 characters."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "New human-readable name for the prompt set. 255 characters or fewer."
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "expectation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "maxLength": 16000,
+                  "description": "Optional expectation the analysis judge scores the analysis against. Pass `null` to clear. Max 16000 characters.",
+                  "example": "The top product by revenue should be Aniseed Syrup."
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Existing prompt id. When provided, updates that prompt; when omitted, a new prompt is created. Prompts not included in this list are removed."
+                },
+                "prompt_text": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 8000,
+                  "description": "Updated or new prompt text. Max 8000 characters.",
+                  "example": "What are the top 10 products by revenue this quarter?"
+                }
+              },
+              "required": [
+                "prompt_text"
+              ]
+            },
+            "maxItems": 25,
+            "description": "Full desired set of prompts after the update. Prompts omitted from this list are deleted; new prompts (no `id`) are appended in body order. Existing prompts retain their original position — reordering is not supported on this endpoint. At most 25 prompts total."
+          }
+        }
+      },
+      "EvalPromptSetsDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "cancelled_job_count": {
+            "type": "integer",
+            "description": "Number of in-flight agentic jobs associated with this prompt set that were cancelled as part of the archive.",
+            "example": 0
+          },
+          "is_archived": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always `true` on success — archives the prompt set."
+          }
+        },
+        "required": [
+          "cancelled_job_count",
+          "is_archived"
+        ]
+      },
+      "EvalApiError500": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Archive committed but a run-cancellation failed; retry to complete"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 500
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalPromptSetsUnarchiveResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
         ]
       },
       "FoldersListResponse": {
@@ -4405,7 +26159,24 @@
         "properties": {
           "aggregateType": {
             "type": "string",
-            "description": "Aggregate type for measures"
+            "enum": [
+              "AVERAGE",
+              "COUNT",
+              "COUNT_DISTINCT",
+              "LIST",
+              "MAX",
+              "MIN",
+              "SUM",
+              "MEDIAN",
+              "PERCENTILE",
+              "AVERAGE_DISTINCT_ON",
+              "SUM_DISTINCT_ON",
+              "MEDIAN_DISTINCT_ON",
+              "PERCENTILE_DISTINCT_ON",
+              "SEMANTIC_VIEW_AGG"
+            ],
+            "description": "Aggregate type for measures. Setting this property promotes the field to a measure (written under `measures:`); omit it to create a dimension (written under `dimensions:`). Values must be uppercase canonical names.",
+            "example": "SUM"
           },
           "aiContext": {
             "type": "string",
@@ -4456,7 +26227,8 @@
         "required": [
           "fieldName",
           "viewName"
-        ]
+        ],
+        "additionalProperties": false
       },
       "ModelsRefreshResponse": {
         "type": "object",
@@ -4541,6 +26313,11 @@
           "commitMessage": {
             "type": "string",
             "description": "Commit message for git sync"
+          },
+          "deleteViewsAndTopicsMissingFromSource": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), views and topics in the target model that are missing from the migrated source are deleted (the source is treated as the complete model). When false, they are kept (inherited) instead — useful when the source git ref may be missing objects that exist in omni but not in git, e.g. a newly synced schema."
           },
           "gitRef": {
             "type": "string",
@@ -5482,6 +27259,11 @@
             "type": "string",
             "description": "Optional branch ID"
           },
+          "creator_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Restrict replacement to documents created by this user (user ID). Unknown IDs return 400."
+          },
           "find": {
             "type": "string",
             "minLength": 1,
@@ -5580,7 +27362,7 @@
               "extension",
               "staged",
               "merged",
-              "history"
+              "fully-resolved"
             ],
             "default": "combined",
             "description": "IDE mode for YAML operations"
@@ -5612,6 +27394,50 @@
           "yaml"
         ],
         "additionalProperties": false
+      },
+      "AiAgentActionsResponse": {
+        "type": "object",
+        "properties": {
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiAgentAction"
+            },
+            "description": "AI agent actions in display order: sample queries first, then skills. Topic-level entries follow model-level ones, and skills are deduped by id with topic skills winning over model skills."
+          }
+        },
+        "required": [
+          "records"
+        ]
+      },
+      "AiAgentAction": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "sample",
+              "skill"
+            ],
+            "description": "Source of the entry: `sample` for `sample_queries` (model- or topic-level) and `skill` for `skills` (model- or topic-level).",
+            "example": "skill"
+          },
+          "label": {
+            "type": "string",
+            "description": "Short, human-readable name for the action — chip text in client UIs and the visible \"prompt\" on the answer card.",
+            "example": "Revenue trends"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Submit this string verbatim as the `prompt` on `POST /api/v1/ai/jobs`. For sample queries this is the raw prompt; for skills it is a pre-formatted wrapper around the skill's input.",
+            "example": "Skill:\nShow me the recent revenue trends grouped by month…"
+          }
+        },
+        "required": [
+          "kind",
+          "label",
+          "prompt"
+        ]
       },
       "QueryRunResponse": {
         "type": "object",
@@ -5710,7 +27536,7 @@
           "userId": {
             "type": "string",
             "format": "uuid",
-            "description": "User ID to execute the query as (for row-level security). Only valid for org-scoped API keys.",
+            "description": "Alternate location for the `?userId=` query parameter. Prefer the query parameter — this body field exists for backwards compatibility. Supplying both forms results in a 400. Only valid for org-scoped API keys; when set, the user's attributes are applied for row-level security and connection-environment switching.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           }
         }
@@ -5926,7 +27752,7 @@
             "example": false
           },
           "filterConfig": {
-            "description": "Applied dashboard filter configuration"
+            "description": "The effective dashboard filter configuration that the schedule will run with: the dashboard's current default filters merged under the schedule's persisted overrides, with any keys no longer present on the dashboard dropped. This matches what is shown when the schedule is opened in the Edit Delivery panel, and may differ from the schedule's persisted filter configuration."
           },
           "id": {
             "type": "string",
@@ -6632,6 +28458,76 @@
                     {
                       "type": "object",
                       "properties": {
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                }
+                              },
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {}
+                              }
+                            ]
+                          }
+                        },
+                        "urn:omni:params:1.0:UserAttribute": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                }
+                              },
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {}
+                              }
+                            ]
+                          }
+                        },
                         "active": {
                           "type": "boolean"
                         },
@@ -7412,6 +29308,7 @@
           }
         },
         "required": [
+          "file",
           "modelId"
         ]
       },
@@ -7981,7 +29878,7 @@
         },
         "responses": {
           "200": {
-            "description": "Query generated successfully. If runQuery is true (default), includes execution results. Check the error field — a 200 response may still contain a partial error if the query was generated but execution failed.",
+            "description": "Query generated successfully. If runQuery is true (default), includes execution results. Check the error field — a 200 response may still contain a partial error if the query was generated but execution failed. When the organization is over its AI downgrade threshold the response also carries `downgradedModelTier` naming the cheaper tier the query was generated with.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8006,6 +29903,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "AI is unavailable because the organization is over its AI credit limit. The body carries the stable reason code `shutoff`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditShutoffError"
                 }
               }
             }
@@ -8188,6 +30095,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -8565,6 +30473,191 @@
         }
       }
     },
+    "/api/v1/ai/branding": {
+      "get": {
+        "description": "Returns the organization's AI helper branding — display name, optional custom logo URL, and copy used on AI helper landing surfaces (headline, body, prompt placeholder). Falls back to Omni's defaults when the organization hasn't configured custom branding, so the response is always populated. Used by client apps (iOS, embeds) to render the AI helper with the org's chosen identity.",
+        "operationId": "aiBranding",
+        "summary": "Get AI helper branding",
+        "tags": [
+          "AI"
+        ],
+        "responses": {
+          "200": {
+            "description": "AI branding retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiBrandingResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI access is required to view AI helper branding (no model in the org grants USE_AI to the caller).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/conversations": {
+      "get": {
+        "description": "List the user's recent AI conversations, ordered by most-recent activity. Each record includes the conversation id (pass it back as `conversationId` on subsequent /api/v1/ai/jobs submissions to continue the thread), an optional name, and a one-line summary of the most recent prompt for display. Paginated via opaque `pageInfo.nextCursor` — pass it back as `cursor` to fetch the next page.",
+        "operationId": "aiConversationsList",
+        "summary": "List AI conversations",
+        "tags": [
+          "AI"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of conversations.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiConversationsListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/conversations/{conversationId}": {
+      "get": {
+        "description": "Return a conversation with its full message history (alternating user / assistant turns). Used by clients (iOS app, embed widgets) to restore a prior conversation in their UI.",
+        "operationId": "aiConversationDetail",
+        "summary": "Get AI conversation with messages",
+        "tags": [
+          "AI"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "conversationId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation with messages in chronological order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiConversationDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI access is required to view chat conversations (no model in the org grants USE_AI to the caller).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found. User-scoped keys also get 404 (not 403) when the conversation exists but belongs to a different user — existence of another user's conversations is not disclosed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/api-keys": {
       "get": {
         "description": "Returns all API tokens in the organization, including organization-level keys, personal access tokens, and MCP OAuth grants. Secrets are never returned. Requires organization admin permissions.",
@@ -8587,15 +30680,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -8716,9 +30809,9 @@
         }
       },
       "put": {
-        "description": "Enables or disables an organization-level API token. Personal access tokens and MCP OAuth grants do not support this operation. Requires organization admin permissions.",
+        "description": "Enables or disables an API token. Requires organization admin permissions.",
         "operationId": "apiKeysUpdate",
-        "summary": "Enable or disable an organization API token",
+        "summary": "Enable or disable an API token",
         "tags": [
           "API Tokens"
         ],
@@ -8758,7 +30851,7 @@
             }
           },
           "400": {
-            "description": "Invalid body, malformed `id`, target is not an organization token, or missing/malformed `Authorization` header"
+            "description": "Invalid body, malformed `id`, or missing/malformed `Authorization` header"
           },
           "403": {
             "description": "Invalid bearer token, or caller lacks organization admin permissions"
@@ -8931,6 +31024,11 @@
                             "description": "Whether branch environments override user attributes",
                             "example": false
                           },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "Timestamp when connection was created (ISO 8601)",
+                            "example": "2024-01-15T10:30:00Z"
+                          },
                           "database": {
                             "type": [
                               "string",
@@ -8996,7 +31094,12 @@
                             "description": "Connection display name",
                             "example": "Production Snowflake"
                           },
-                          "userAttributeNameForConnectionsEnvironments": {
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "Timestamp when connection was last updated (ISO 8601)",
+                            "example": "2024-01-15T10:30:00Z"
+                          },
+                          "userAttributeNameForConnectionEnvironments": {
                             "type": [
                               "string",
                               "null"
@@ -9022,6 +31125,7 @@
                         "required": [
                           "baseRole",
                           "branchConnectionEnvironmentOverridesUserAttr",
+                          "createdAt",
                           "database",
                           "defaultSchema",
                           "deletedAt",
@@ -9029,7 +31133,8 @@
                           "environmentConnectionSwitchesSchemaModel",
                           "id",
                           "name",
-                          "userAttributeNameForConnectionsEnvironments",
+                          "updatedAt",
+                          "userAttributeNameForConnectionEnvironments",
                           "userAttributeValuesForDefaultEnvironment"
                         ],
                         "description": "Connection object",
@@ -9351,6 +31456,191 @@
       }
     },
     "/api/v1/connections/{id}": {
+      "get": {
+        "description": "Fetch a single connection by ID.",
+        "operationId": "connectionsGet",
+        "summary": "Get connection",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Connection ID",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Connection ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "connection": {
+                      "type": "object",
+                      "properties": {
+                        "baseRole": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Default role for users on this connection",
+                          "example": "QUERIER"
+                        },
+                        "branchConnectionEnvironmentOverridesUserAttr": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether branch environments override user attributes",
+                          "example": false
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "description": "Timestamp when connection was created (ISO 8601)",
+                          "example": "2024-01-15T10:30:00Z"
+                        },
+                        "database": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Database name",
+                          "example": "analytics_db"
+                        },
+                        "defaultSchema": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Default schema for the connection",
+                          "example": "public"
+                        },
+                        "deletedAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Timestamp when connection was deleted (ISO 8601)",
+                          "example": null
+                        },
+                        "dialect": {
+                          "type": "string",
+                          "enum": [
+                            "snowflake",
+                            "bigquery",
+                            "redshift",
+                            "postgres",
+                            "mysql",
+                            "mariadb",
+                            "databricks",
+                            "databricks_lakebase",
+                            "trino",
+                            "athena",
+                            "duckdb",
+                            "motherduck",
+                            "sqlserver",
+                            "clickhouse",
+                            "singlestore"
+                          ],
+                          "description": "Database dialect type",
+                          "example": "snowflake"
+                        },
+                        "environmentConnectionSwitchesSchemaModel": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether environment connections switch schema model",
+                          "example": false
+                        },
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Unique connection identifier",
+                          "example": "550e8400-e29b-41d4-a716-446655440000"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Connection display name",
+                          "example": "Production Snowflake"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "description": "Timestamp when connection was last updated (ISO 8601)",
+                          "example": "2024-01-15T10:30:00Z"
+                        },
+                        "userAttributeNameForConnectionEnvironments": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "User attribute name used for connection environments",
+                          "example": "region"
+                        },
+                        "userAttributeValuesForDefaultEnvironment": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Default user attribute values for the base environment",
+                          "example": [
+                            "us-east",
+                            "us-west"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "baseRole",
+                        "branchConnectionEnvironmentOverridesUserAttr",
+                        "createdAt",
+                        "database",
+                        "defaultSchema",
+                        "deletedAt",
+                        "dialect",
+                        "environmentConnectionSwitchesSchemaModel",
+                        "id",
+                        "name",
+                        "updatedAt",
+                        "userAttributeNameForConnectionEnvironments",
+                        "userAttributeValuesForDefaultEnvironment"
+                      ],
+                      "description": "Connection object",
+                      "title": "Connection"
+                    }
+                  },
+                  "required": [
+                    "connection"
+                  ],
+                  "description": "Get connection response",
+                  "title": "ConnectionsGetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied — caller lacks READ on the connection"
+          },
+          "404": {
+            "description": "Connection does not exist"
+          }
+        }
+      },
       "patch": {
         "description": "Update connection settings including base role, environment user attributes, and credentials.\n\nCredential fields:\n- `passwordUnencrypted`: Update password (all dialects) or service account JSON (BigQuery)\n- `privateKey`: Add/rotate RSA keypair for Snowflake keypair authentication\n\nNote: Credentials are encrypted at rest and never returned in API responses.",
         "operationId": "connectionsUpdate",
@@ -9470,6 +31760,70 @@
           },
           "404": {
             "description": "Connection not found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Archive a connection (move to trash). Archived connections can be restored from the trash in the connection settings UI.\n\nA connection that is already archived returns 410.",
+        "operationId": "connectionsDelete",
+        "summary": "Delete connection",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Connection ID",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Connection ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection moved to trash",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Status message describing the result",
+                      "example": "Connection moved to trash."
+                    },
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when the connection was archived",
+                      "example": true
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "success"
+                  ],
+                  "description": "Archive connection response",
+                  "title": "ConnectionsDeleteResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied - connection admin role required"
+          },
+          "404": {
+            "description": "Connection not found"
+          },
+          "410": {
+            "description": "Connection has already been archived"
           }
         }
       }
@@ -9852,15 +32206,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -10174,6 +32528,11 @@
                             "description": "Timestamp when schedule was disabled (ISO 8601)",
                             "example": null
                           },
+                          "hardRefresh": {
+                            "type": "boolean",
+                            "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                            "example": false
+                          },
                           "schedule": {
                             "type": "string",
                             "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10201,6 +32560,7 @@
                           "createdAt",
                           "description",
                           "disabledAt",
+                          "hardRefresh",
                           "schedule",
                           "scheduleId",
                           "timezone",
@@ -10258,6 +32618,12 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "hardRefresh": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false (the default), it performs a soft refresh that merges newly generated views with the existing model.",
+                    "example": false
+                  },
                   "schedule": {
                     "type": "string",
                     "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10311,6 +32677,11 @@
                       "description": "Timestamp when schedule was disabled (ISO 8601)",
                       "example": null
                     },
+                    "hardRefresh": {
+                      "type": "boolean",
+                      "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                      "example": false
+                    },
                     "schedule": {
                       "type": "string",
                       "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10338,6 +32709,7 @@
                     "createdAt",
                     "description",
                     "disabledAt",
+                    "hardRefresh",
                     "schedule",
                     "scheduleId",
                     "timezone",
@@ -10429,6 +32801,11 @@
                       "description": "Timestamp when schedule was disabled (ISO 8601)",
                       "example": null
                     },
+                    "hardRefresh": {
+                      "type": "boolean",
+                      "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                      "example": false
+                    },
                     "schedule": {
                       "type": "string",
                       "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10456,6 +32833,7 @@
                     "createdAt",
                     "description",
                     "disabledAt",
+                    "hardRefresh",
                     "schedule",
                     "scheduleId",
                     "timezone",
@@ -10516,6 +32894,12 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "hardRefresh": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false (the default), it performs a soft refresh that merges newly generated views with the existing model.",
+                    "example": false
+                  },
                   "schedule": {
                     "type": "string",
                     "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10569,6 +32953,11 @@
                       "description": "Timestamp when schedule was disabled (ISO 8601)",
                       "example": null
                     },
+                    "hardRefresh": {
+                      "type": "boolean",
+                      "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                      "example": false
+                    },
                     "schedule": {
                       "type": "string",
                       "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10596,6 +32985,7 @@
                     "createdAt",
                     "description",
                     "disabledAt",
+                    "hardRefresh",
                     "schedule",
                     "scheduleId",
                     "timezone",
@@ -11048,15 +33438,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -11194,6 +33584,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11276,6 +33667,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11339,6 +33731,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11382,6 +33775,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11433,6 +33827,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11900,7 +34295,7 @@
       }
     },
     "/api/v1/documents/{identifier}/move": {
-      "post": {
+      "put": {
         "operationId": "documentsMove",
         "summary": "Move document",
         "tags": [
@@ -12321,6 +34716,64 @@
           },
           "404": {
             "description": "Document or draft not found"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{identifier}/drafts": {
+      "get": {
+        "description": "Lists drafts for a document with branch context. By default only active drafts are returned; pass `include=archived` to also include soft-deleted drafts (retained ~7 days). Results are sorted by `createdAt` descending.",
+        "operationId": "documentsListDrafts",
+        "summary": "List document drafts",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier (either document ID or identifier slug)",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier (either document ID or identifier slug)",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated list of additional drafts to include. Only \"archived\" is recognized — when present, soft-deleted drafts (retained ~7 days) are returned alongside active drafts.",
+              "example": "archived"
+            },
+            "required": false,
+            "description": "Comma-separated list of additional drafts to include. Only \"archived\" is recognized — when present, soft-deleted drafts (retained ~7 days) are returned alongside active drafts.",
+            "name": "include",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of drafts for the document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsListDraftsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Insufficient permissions to view the document"
+          },
+          "404": {
+            "description": "Document not found"
           }
         }
       }
@@ -12750,15 +35203,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -12840,6 +35293,438 @@
         }
       }
     },
+    "/api/v1/documents/{identifier}/favorites": {
+      "get": {
+        "description": "Lists users who have favorited the document, paginated and sorted by favoritedAt. Document-centric counterpart to GET /api/v1/documents?include=onlyFavorites: useful for migration scripts that need to preserve favorites when replacing documents, without iterating every user in the organization.",
+        "operationId": "documentsListFavorites",
+        "summary": "List users who favorited the document",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier (either document ID or identifier slug)",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier (either document ID or identifier slug)",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc",
+              "description": "Sort direction by favoritedAt (default: asc — oldest first)",
+              "example": "desc"
+            },
+            "required": false,
+            "description": "Sort direction by favoritedAt (default: asc — oldest first)",
+            "name": "sortDirection",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of users who favorited the document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsListFavoritesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied — caller lacks MANAGER on the document, or used a user-scoped (personal access token) API key (org-scoped only)"
+          },
+          "404": {
+            "description": "Document not found"
+          }
+        }
+      }
+    },
+    "/api/v2/documents": {
+      "post": {
+        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
+        "operationId": "documentsV2Create",
+        "summary": "Create document",
+        "tags": [
+          "Documents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2CreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Document created and published successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2CreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or schema validation error (e.g. unknown top-level field, name too long, query presentation cap exceeded), or the `identifier` is already in use."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to create a document on this model."
+          },
+          "404": {
+            "description": "Base model or branch not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}": {
+      "get": {
+        "description": "Read the document's current draft state (or the published state if no draft exists). Returns the full `DocumentsV2ReadResponse` shape.\n\nThe response is structured so a caller can take it verbatim and submit it as the body of the draft PATCH routes. Tiles in `queryPresentations.data` are keyed by a stable record key (e.g. `\"1\"`, `\"2\"`) — the server uses that key to identify existing tiles for updates, so callers do not need to track or send any other identifier. Control IDs and container `instanceKey` / `referenceKey` values also round-trip unchanged.",
+        "operationId": "documentsV2Get",
+        "summary": "Read document state",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document state. A workbook-only document (no dashboard layout yet) returns only the workbook-scoped fields (`name`, `description`, `queryPresentations`); the dashboard-scoped `containers`, `controls`, and `settings` are omitted until a layout exists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2ReadResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to read the document."
+          },
+          "404": {
+            "description": "Document not found."
+          },
+          "422": {
+            "description": "The document cannot be read as a dashboard: a classic-layout dashboard (upgrade to the advanced layout first) or an app document."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft": {
+      "patch": {
+        "description": "Create a new draft on the published document and apply the patch. No auto-publish — the response includes the new `draftIdentifier` for follow-up calls.\n\nPass an optional `branchId` to attach the draft to a branch; omit it for a draft on the main (unpublished) workspace.",
+        "operationId": "documentsV2PatchDraft",
+        "summary": "Create draft and patch document",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2CreateDraftBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Draft created and patch applied successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or schema validation error (e.g. unknown top-level field, name too long, query presentation cap exceeded)."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the document."
+          },
+          "404": {
+            "description": "Document or branch not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document (drafts only attach to published documents), or a concurrent request just created the layout for this document — retry."
+          },
+          "422": {
+            "description": "The document cannot satisfy the patch: a classic-layout dashboard (upgrade to the advanced layout first), an app document, or a workbook-only document patched without a `containers` payload (or with an empty one)."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft/{draftIdentifier}": {
+      "get": {
+        "description": "Read the named draft's state. Returns the full `DocumentsV2ReadResponse` shape — same as the live-state read endpoint.\n\nThe response is structured so a caller can take it verbatim and submit it as the body of the draft PATCH routes. Tiles in `queryPresentations.data` are keyed by a stable record key (e.g. `\"1\"`, `\"2\"`) — the server uses that key to identify existing tiles for updates, so callers do not need to track or send any other identifier. Control IDs and container `instanceKey` / `referenceKey` values also round-trip unchanged.",
+        "operationId": "documentsV2GetDraft",
+        "summary": "Read draft state",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2ReadResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to read the draft."
+          },
+          "404": {
+            "description": "Document or draft not found."
+          },
+          "422": {
+            "description": "The draft cannot be read as a dashboard: a classic-layout dashboard (upgrade to the advanced layout first) or an app document."
+          }
+        }
+      },
+      "patch": {
+        "description": "Apply the patch to an existing draft addressed by `draftIdentifier`. Pure apply — no draft creation, no publish.",
+        "operationId": "documentsV2PatchDraftByIdentifier",
+        "summary": "Patch draft",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2PatchDraftBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Patch applied to draft successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or schema validation error (e.g. unknown top-level field, name too long, query presentation cap exceeded)."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the draft."
+          },
+          "404": {
+            "description": "Document or draft not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document (drafts only attach to published documents), or a concurrent request just created the layout for this document — retry."
+          },
+          "422": {
+            "description": "The draft cannot satisfy the patch: a classic-layout dashboard (upgrade to the advanced layout first), an app document, or a workbook-only draft patched without a `containers` payload (or with an empty one)."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft/publish": {
+      "post": {
+        "description": "Publish the document's current main (non-branch) draft, promoting it to the published version. No request body — the draft is consumed, so the response echoes the now-published document metadata.\n\nOnly the main draft is publishable here; a branch-attached draft is published by merging its branch (`POST /api/v1/models/{modelId}/branch/{branchName}/merge`), so a document with no main draft returns 404. Documents that require a pull request to publish return 400.",
+        "operationId": "documentsV2PublishDraft",
+        "summary": "Publish draft",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft published successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PublishDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The document requires a pull request to publish (response detail: \"Can't publish because this document can only be edited through a branch\")."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to publish the draft."
+          },
+          "404": {
+            "description": "Document not found, or it has no main draft to publish (a branch-attached draft is published by merging its branch)."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document."
+          }
+        }
+      }
+    },
     "/api/v1/embed/sso/generate-session": {
       "post": {
         "operationId": "embedSsoGenerateSession",
@@ -12875,6 +35760,489 @@
           },
           "403": {
             "description": "Permission denied - embed not enabled"
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/prompt-sets": {
+      "get": {
+        "description": "List eval prompt sets, sorted alphabetically by name. When `model_ids` is omitted, returns prompt sets for every shared model the caller can access. Requires at least the Querier role on each requested model.",
+        "operationId": "aiEvalPromptSetsList",
+        "summary": "List eval prompt sets",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When `true`, returns archived prompt sets instead of active ones. Defaults to `false`.",
+              "example": "false"
+            },
+            "required": false,
+            "description": "When `true`, returns archived prompt sets instead of active ones. Defaults to `false`.",
+            "name": "archived",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "description": "Optional list of model IDs to filter prompt sets by. When omitted, returns prompt sets for every model the caller can access. Supply multiple times to filter by more than one model (e.g., `?model_ids=A&model_ids=B`)."
+            },
+            "required": false,
+            "description": "Optional list of model IDs to filter prompt sets by. When omitted, returns prompt sets for every model the caller can access. Supply multiple times to filter by more than one model (e.g., `?model_ids=A&model_ids=B`).",
+            "name": "model_ids",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of prompt sets, sorted alphabetically by name.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query params (e.g. `model_ids` contains a non-UUID, or `archived` is not `true`/`false`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions. The caller must have at least the Querier role on each requested model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No eval-accessible models for this caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new eval prompt set bound to a shared model. Initial prompts can be supplied; additional prompts can be added later via PATCH.",
+        "operationId": "aiEvalPromptSetsCreate",
+        "summary": "Create an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalPromptSetsCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Prompt set created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions. The caller must have at least the Querier role on the model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/prompt-sets/{promptSetId}": {
+      "get": {
+        "description": "Get a single prompt set with all of its prompts.",
+        "operationId": "aiEvalPromptSetsGet",
+        "summary": "Get an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt set details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsGetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `promptSetId` — must be a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a prompt set's name, description, and/or prompts. When `prompts` is supplied, it fully replaces the existing list — existing prompts omitted from the list are deleted, entries without an `id` are created, and entries with a matching `id` are updated in place.",
+        "operationId": "aiEvalPromptSetsUpdate",
+        "summary": "Update an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalPromptSetsUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prompt set updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsUpdateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "A `prompts[].id` in the request does not belong to this prompt set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError422"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Archive (soft-delete) a prompt set. As part of the archive, Omni attempts to cancel every in-flight agentic job associated with the set; the returned `cancelled_job_count` reports how many were cancelled. The archive is committed before run cancellations start. Cancellation is best-effort — the database cancel is authoritative, but the Redis stop-signal that halts a running worker can lag. If the archive itself or a whole run-cancellation fails, the endpoint returns 500, but the prompt set is already archived. The call is idempotent — retrying drains any remaining runs.",
+        "operationId": "aiEvalPromptSetsArchive",
+        "summary": "Archive an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt set archived successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `promptSetId` — must be a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Archive committed but a run-cancellation failed; the set is already archived — safe to retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/prompt-sets/{promptSetId}/unarchive": {
+      "post": {
+        "description": "Restore an archived prompt set.",
+        "operationId": "aiEvalPromptSetsUnarchive",
+        "summary": "Restore an archived eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt set restored successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsUnarchiveResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `promptSetId` — must be a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
           }
         }
       }
@@ -13437,6 +36805,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -13540,6 +36909,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -13606,6 +36976,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -14811,6 +38182,43 @@
             "description": "Branch ID for branch-based schema refresh. Required when branch-based schema refresh is enabled for the connection. Must not be provided when branch-based schema refresh is not enabled.",
             "name": "branch_id",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When true (the default), performs a hard refresh that fully discards and rebuilds the schema model. When false, performs a soft refresh that merges newly generated views with the existing model. Must be set to false when `schemas` or `tables` filters are provided.",
+              "example": "false"
+            },
+            "required": false,
+            "description": "When true (the default), performs a hard refresh that fully discards and rebuilds the schema model. When false, performs a soft refresh that merges newly generated views with the existing model. Must be set to false when `schemas` or `tables` filters are provided.",
+            "name": "hard_refresh",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional comma-separated list of schemas to refresh selectively. Only the listed schemas are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+              "example": "public,analytics"
+            },
+            "required": false,
+            "description": "Optional comma-separated list of schemas to refresh selectively. Only the listed schemas are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+            "name": "schemas",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional comma-separated list of tables to refresh selectively. Only the listed tables are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+              "example": "public.orders,public.customers"
+            },
+            "required": false,
+            "description": "Optional comma-separated list of tables to refresh selectively. Only the listed tables are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+            "name": "tables",
+            "in": "query"
           }
         ],
         "responses": {
@@ -14825,7 +38233,7 @@
             }
           },
           "400": {
-            "description": "Bad request - branch_id required when branch-based schema refresh is enabled, or branch_id not allowed when it is not enabled"
+            "description": "Bad request - branch_id required when branch-based schema refresh is enabled, branch_id not allowed when it is not enabled, or hard refresh requested with selective schemas/tables filters"
           },
           "401": {
             "description": "Authentication required"
@@ -15050,15 +38458,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -15691,6 +39099,17 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
+              "description": "Filter to documents created by this user (user ID). Unknown IDs return 400."
+            },
+            "required": false,
+            "description": "Filter to documents created by this user (user ID). Unknown IDs return 400.",
+            "name": "creator_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "minLength": 1,
               "description": "Optional value to find. Used with find_type to scope validation to a single view, field, or topic. Requires find_type to be provided."
             },
@@ -15805,6 +39224,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -15897,7 +39317,7 @@
                 "extension",
                 "staged",
                 "merged",
-                "history"
+                "fully-resolved"
               ],
               "default": "combined",
               "description": "IDE mode for YAML operations"
@@ -16084,7 +39504,7 @@
                 "extension",
                 "staged",
                 "merged",
-                "history"
+                "fully-resolved"
               ],
               "default": "combined",
               "description": "IDE mode for YAML operations"
@@ -16124,12 +39544,70 @@
         }
       }
     },
+    "/api/v1/models/{modelId}/ai-agent-actions": {
+      "get": {
+        "description": "Returns the AI agent actions configured for this model — a unified list of sample queries and skills suitable for surfacing as suggested prompts above an AI prompt input. Sample queries come from both `model.sample_queries` and each topic's `sample_queries`; skills come from `model.skills` and each topic's `skills`, deduped by id with topic skills overriding model skills. Each entry's `prompt` is ready to submit verbatim to `POST /api/v1/ai/jobs`.",
+        "operationId": "modelAiAgentActions",
+        "summary": "Get model AI agent actions",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI agent actions in display order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiAgentActionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          },
+          "403": {
+            "description": "Caller cannot read the model."
+          },
+          "404": {
+            "description": "Model not found."
+          }
+        }
+      }
+    },
     "/api/v1/query/run": {
       "post": {
         "operationId": "queryRun",
         "summary": "Execute a semantic query",
         "tags": [
           "Query"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
         ],
         "requestBody": {
           "content": {
@@ -16248,15 +39726,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -17118,7 +40596,7 @@
             "description": "Schedule not found"
           },
           "409": {
-            "description": "Another execution is in progress for this schedule"
+            "description": "Schedule cannot be triggered (paused, system-disabled, or another execution is in progress)"
           }
         }
       }
@@ -18026,15 +41504,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -38,11 +38,29 @@ Set OMNI_API_TOKEN env var, or run: omni config init
 ### Download a dashboard
   omni dashboards download <dashboard-id>
 
+### Read or edit a document (v2)
+  # Read live state. The response is a valid draft PATCH body (round-trip design).
+  omni documents v2-get <identifier> --compact
+
+  # Edit metadata with flags (no JSON needed), then publish the draft:
+  omni documents v2-patch-draft <identifier> --name "Q3 Revenue" --summary "rename"
+  omni documents v2-publish-draft <identifier>
+
+  # Edit content by round-tripping the full state through a file:
+  omni documents v2-get <identifier> > doc.json
+  # ...edit doc.json (containers, controls, queryPresentations, settings)...
+  omni documents v2-patch-draft <identifier> --body - < doc.json
+  omni documents v2-publish-draft <identifier>
+
+  # Create a brand-new document (published immediately):
+  omni documents v2-create <model-id> "My Dashboard"
+
 ### Search Omni documentation
   omni ai search-omni-docs --body '{"query":"how do I..."}'
 
 ## Command Groups
   ai            AI-powered query generation, jobs, doc search
+  ai-eval       AI eval prompt set management
   connections   Manage database connections
   content       List content across the org
   dashboards    Download dashboards, manage filters

--- a/cmd/omni/openapi.json
+++ b/cmd/omni/openapi.json
@@ -16015,9 +16015,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16119,9 +16116,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16265,9 +16259,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16343,9 +16334,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16424,9 +16412,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16543,9 +16528,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16617,9 +16599,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -16710,9 +16689,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -16741,9 +16717,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -16815,9 +16788,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -16938,9 +16908,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -16999,9 +16966,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -17055,9 +17019,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -17158,9 +17119,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -17202,7 +17160,7 @@
                 ]
               }
             ],
-            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.). Visibility is determined by placement in the filter-bar container."
           },
           "map": {
             "type": "object",
@@ -17277,7 +17235,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/QueryPresentationPatchExternal"
             },
-            "description": "Query presentations keyed by tab ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete. Capped at 48 entries per patch."
+            "description": "Query presentations keyed by tab ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete. Capped at 48 entries per patch. When the request carries no `containers` and the document has a dashboard layout, dashboard-eligible tiles added at new keys are auto-placed on the dashboard's first page (non-renderable types such as CSV / dataset / query-view / dbt tabs are stored but not placed), and containers created by auto-placement are removed when their tile is deleted — containers placed via an explicit `containers` write are left in the layout. When `containers` is present it fully defines the layout; on a workbook-only document (no layout yet) tiles are stored without placement."
           },
           "order": {
             "type": "array",
@@ -20156,9 +20114,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20260,9 +20215,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20406,9 +20358,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20484,9 +20433,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20565,9 +20511,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20684,9 +20627,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20758,9 +20698,6 @@
                         ]
                       }
                     ]
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "label": {
                     "type": "string"
@@ -20851,9 +20788,6 @@
                       }
                     ]
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "label": {
                     "type": "string"
                   },
@@ -20882,9 +20816,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -20956,9 +20887,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -21079,9 +21007,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -21140,9 +21065,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -21196,9 +21118,6 @@
                 "properties": {
                   "description": {
                     "type": "string"
-                  },
-                  "hidden": {
-                    "type": "boolean"
                   },
                   "id": {
                     "type": "string"
@@ -21299,9 +21218,6 @@
                   "description": {
                     "type": "string"
                   },
-                  "hidden": {
-                    "type": "boolean"
-                  },
                   "id": {
                     "type": "string"
                   },
@@ -21343,7 +21259,7 @@
                 ]
               }
             ],
-            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.). Visibility is determined by placement in the filter-bar container."
           },
           "map": {
             "type": "object",
@@ -24194,7 +24110,7 @@
                 "$ref": "#/components/schemas/Containers"
               },
               {
-                "description": "Container layout. When present, fully replaces the existing layout."
+                "description": "Container layout. When present, fully replaces the existing layout and disables automatic tile placement for the request."
               }
             ]
           },
@@ -24816,6 +24732,524 @@
         },
         "required": [
           "prompt_set"
+        ]
+      },
+      "EvalRunsListResponse": {
+        "type": "object",
+        "properties": {
+          "runs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalRunListItem"
+            },
+            "description": "Runs for the prompt set, newest first, filtered to those whose model the caller can access."
+          }
+        },
+        "required": [
+          "runs"
+        ]
+      },
+      "EvalRunListItem": {
+        "type": "object",
+        "properties": {
+          "branch_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional branch ID the run was executed against. Null when run against the main shared model.",
+            "example": null
+          },
+          "branch_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name for the branch, if `branch_id` is set.",
+            "example": null
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run reached a terminal state.",
+            "example": null
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description for the run.",
+            "example": null
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the run.",
+            "example": "660e8400-e29b-41d4-a716-446655440001"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the run has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this run was executed against.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "prompt_set_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The prompt set this run was created from.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "run_number": {
+            "type": "integer",
+            "description": "Sequential, per-prompt-set run number.",
+            "example": 3
+          },
+          "stats": {
+            "$ref": "#/components/schemas/EvalRunStats"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "COMPLETE",
+              "CANCELLED"
+            ],
+            "description": "Run-level lifecycle. Flips to a terminal state (COMPLETE or CANCELLED) exactly once.",
+            "example": "RUNNING"
+          }
+        },
+        "required": [
+          "branch_id",
+          "branch_name",
+          "completed_at",
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "prompt_set_id",
+          "run_number",
+          "stats",
+          "status"
+        ]
+      },
+      "EvalRunStats": {
+        "type": "object",
+        "properties": {
+          "terminal": {
+            "type": "integer",
+            "description": "Number of per-prompt jobs that have reached a terminal state (COMPLETE, FAILED, or CANCELLED).",
+            "example": 8
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of per-prompt jobs in the run.",
+            "example": 12
+          }
+        },
+        "required": [
+          "terminal",
+          "total"
+        ]
+      },
+      "EvalRunsCreateResponse": {
+        "type": "object",
+        "properties": {
+          "job_count": {
+            "type": "integer",
+            "description": "Number of per-prompt agentic jobs created for this run (one per prompt that fanned out successfully). Enqueue onto the work queue happens after creation and is best-effort, so this count reflects jobs created, not necessarily those successfully enqueued.",
+            "example": 12
+          },
+          "run": {
+            "$ref": "#/components/schemas/EvalRunDetail"
+          }
+        },
+        "required": [
+          "job_count",
+          "run"
+        ]
+      },
+      "EvalRunDetail": {
+        "type": "object",
+        "properties": {
+          "branch_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional branch ID the run was executed against. Null when run against the main shared model.",
+            "example": null
+          },
+          "branch_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name for the branch, if `branch_id` is set.",
+            "example": null
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run reached a terminal state.",
+            "example": null
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the run was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description for the run.",
+            "example": null
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the run.",
+            "example": "660e8400-e29b-41d4-a716-446655440001"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the run has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this run was executed against.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "prompt_set_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The prompt set this run was created from.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalRunResult"
+            },
+            "description": "Per-prompt results for this run, ordered by their creation order in the prompt set."
+          },
+          "run_number": {
+            "type": "integer",
+            "description": "Sequential, per-prompt-set run number.",
+            "example": 3
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "COMPLETE",
+              "CANCELLED"
+            ],
+            "description": "Run-level lifecycle. Flips to a terminal state (COMPLETE or CANCELLED) exactly once.",
+            "example": "RUNNING"
+          }
+        },
+        "required": [
+          "branch_id",
+          "branch_name",
+          "completed_at",
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "prompt_set_id",
+          "results",
+          "run_number",
+          "status"
+        ],
+        "description": "The newly created run with its initial results."
+      },
+      "EvalRunResult": {
+        "type": "object",
+        "properties": {
+          "agentic_job": {
+            "$ref": "#/components/schemas/EvalRunResultAgenticJob"
+          },
+          "cost": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Total LLM cost (USD) for this prompt, if available.",
+            "example": 0.0021
+          },
+          "error_reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Failure reason string for prompts whose underlying job failed.",
+            "example": null
+          },
+          "expectation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The prompt's expectation as of run creation (snapshotted, so later prompt edits don't change past runs), or null when none was set. The analysis judge scores the analysis against it.",
+            "example": "The top product by revenue should be Aniseed Syrup."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the run result row.",
+            "example": "aa0e8400-e29b-41d4-a716-446655440005"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "The prompt text that was evaluated.",
+            "example": "What are the top 5 products by revenue?"
+          },
+          "score": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Numeric judge score for this prompt result, if scoring ran.",
+            "example": 0.9
+          },
+          "scoring_cost": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Total LLM cost (USD) for scoring this prompt result.",
+            "example": 0.0004
+          },
+          "timing_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Wall-clock duration of the underlying job in milliseconds.",
+            "example": 4321
+          }
+        },
+        "required": [
+          "agentic_job",
+          "cost",
+          "error_reason",
+          "expectation",
+          "id",
+          "prompt",
+          "score",
+          "scoring_cost",
+          "timing_ms"
+        ]
+      },
+      "EvalRunResultAgenticJob": {
+        "type": "object",
+        "properties": {
+          "conversation_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Conversation the agentic job belongs to.",
+            "example": "770e8400-e29b-41d4-a716-446655440002"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Agentic job identifier.",
+            "example": "990e8400-e29b-41d4-a716-446655440004"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "CANCELLED",
+              "COMPLETE",
+              "DELIVERING",
+              "EXECUTING",
+              "FAILED",
+              "QUEUED"
+            ],
+            "description": "Current state of the agentic job that ran this prompt.",
+            "example": "COMPLETE"
+          }
+        },
+        "required": [
+          "conversation_id",
+          "id",
+          "state"
+        ]
+      },
+      "EvalApiError429": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Too many active runs; wait for an in-flight run to finish"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 429
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError503": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "AI eval is paused for this organization"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 503
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalRunsCreateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024,
+            "description": "Optional human-readable description for the run. Pass `null` to clear (or omit). Max 1024 characters.",
+            "example": "Re-running after switching to gpt-4o for query generation"
+          },
+          "prompt_set_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The prompt set to execute.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "run_config": {
+            "type": "object",
+            "properties": {
+              "branch_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Optional branch ID to run against. Must be a branch of the prompt set's model.",
+                "example": "440e8400-e29b-41d4-a716-446655440006"
+              }
+            },
+            "description": "Per-run configuration. Optional — omit if no overrides."
+          }
+        },
+        "required": [
+          "prompt_set_id"
+        ]
+      },
+      "EvalRunsGetResponse": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/EvalRunDetail"
+          }
+        },
+        "required": [
+          "run"
+        ]
+      },
+      "EvalRunsDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "is_archived": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always `true` on success — the run has been archived."
+          }
+        },
+        "required": [
+          "is_archived"
+        ]
+      },
+      "EvalRunsCancelResponse": {
+        "type": "object",
+        "properties": {
+          "cancelled": {
+            "type": "integer",
+            "description": "Number of per-prompt agentic jobs that were cancelled by this request.",
+            "example": 4
+          },
+          "run": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvalRunDetail"
+              },
+              {
+                "description": "The cancelled run. `status: CANCELLED` and `is_archived: true` after this call."
+              }
+            ]
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of per-prompt jobs in the run.",
+            "example": 12
+          }
+        },
+        "required": [
+          "cancelled",
+          "run",
+          "total"
+        ]
+      },
+      "EvalRunsUnarchiveResponse": {
+        "type": "object",
+        "properties": {
+          "is_archived": {
+            "type": "boolean",
+            "enum": [
+              false
+            ],
+            "description": "Always `false` on success — the run has been unarchived."
+          }
+        },
+        "required": [
+          "is_archived"
         ]
       },
       "FoldersListResponse": {
@@ -34096,7 +34530,8 @@
         }
       },
       "put": {
-        "description": "Updates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
+        "deprecated": true,
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
         "operationId": "documentsPut",
         "summary": "Replace document (full replacement)",
         "tags": [
@@ -34153,7 +34588,8 @@
         }
       },
       "patch": {
-        "description": "Updates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
+        "deprecated": true,
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
         "operationId": "documentsUpdate",
         "summary": "Rename document",
         "tags": [
@@ -35383,7 +35819,7 @@
     },
     "/api/v2/documents": {
       "post": {
-        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
+        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nWhen `containers` is omitted, every dashboard-eligible tile is auto-placed in a default layout. When `containers` is present, it fully defines the layout — tiles it does not reference are stored but not rendered.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
         "operationId": "documentsV2Create",
         "summary": "Create document",
         "tags": [
@@ -36236,6 +36672,489 @@
           },
           "404": {
             "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs": {
+      "get": {
+        "description": "List runs for a prompt set, newest first, filtered to runs whose model the caller can access. The `prompt_set_id` query parameter is required.",
+        "operationId": "aiEvalRunsList",
+        "summary": "List eval runs",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When `true`, returns archived runs instead of active ones. Defaults to `false`.",
+              "example": "false"
+            },
+            "required": false,
+            "description": "When `true`, returns archived runs instead of active ones. Defaults to `false`.",
+            "name": "archived",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Required — the prompt set whose runs should be listed.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Required — the prompt set whose runs should be listed.",
+            "name": "prompt_set_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of runs for the prompt set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid `prompt_set_id`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create and start a new run against an existing prompt set. The run enqueues one agentic job per prompt and begins executing immediately. Returns the newly created run with its initial per-prompt result rows.",
+        "operationId": "aiEvalRunsCreate",
+        "summary": "Start an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalRunsCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Run created and jobs enqueued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions. The caller must have at least the Querier role on the prompt set's model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The prompt set was not found, or `run_config.branch_id` does not match an existing branch in the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "`run_config.branch_id` does not belong to the prompt set's model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError422"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-user active-run cap reached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError429"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Run created and jobs enqueued, but it could not be re-read for the response. The run exists — list runs for the prompt set to find it rather than retrying, since a retry starts a duplicate run.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "AI eval is paused for this organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError503"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs/{runId}": {
+      "get": {
+        "description": "Get an eval run with every per-prompt result row, including the underlying agentic job state and any scoring data.",
+        "operationId": "aiEvalRunsGet",
+        "summary": "Get an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run detail.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsGetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Archive (soft-delete) an eval run. Any non-terminal per-prompt agentic jobs are cancelled as part of the archive (best-effort), and a still-RUNNING run is flipped to CANCELLED before archival. The call is idempotent; archiving an already-terminal or already-archived run is a no-op.",
+        "operationId": "aiEvalRunsArchive",
+        "summary": "Archive an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run archived successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsDeleteResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "A still-running run may already be flipped to CANCELLED and archived even though the rest of the cascade failed — safe to retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs/{runId}/cancel": {
+      "post": {
+        "description": "Cancel an in-flight eval run. Any non-terminal per-prompt jobs are cancelled and the run is archived — the response returns the updated run inline (`status: CANCELLED`, `is_archived: true`); use `/unarchive` to surface it in the default `archived=false` list again.",
+        "operationId": "aiEvalRunsCancel",
+        "summary": "Cancel an eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancellation processed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsCancelResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The run was cancelled and archived, but could not be re-read for the response — safe to retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/runs/{runId}/unarchive": {
+      "post": {
+        "description": "Restore an archived eval run.",
+        "operationId": "aiEvalRunsUnarchive",
+        "summary": "Restore an archived eval run",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval run.",
+              "example": "660e8400-e29b-41d4-a716-446655440001"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval run.",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run restored successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalRunsUnarchiveResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found.",
             "content": {
               "application/json": {
                 "schema": {

--- a/cmd/omni/openapi.json
+++ b/cmd/omni/openapi.json
@@ -16,6 +16,10 @@
       "name": "AI"
     },
     {
+      "description": "AI evaluation: manage prompt sets and runs used to score AI quality against curated prompt suites.",
+      "name": "AI Eval"
+    },
+    {
       "description": "API token management",
       "name": "API Tokens"
     },
@@ -118,9 +122,412 @@
         "description": "Update an existing variable by ID. Variable names cannot be changed after creation.",
         "title": "DbtEnvironmentVariableUpdate"
       },
+      "CompositeFilter": {
+        "type": "object",
+        "properties": {
+          "cancel_query_filter": {
+            "type": "boolean"
+          },
+          "ignore_if_unjoinable": {
+            "type": "boolean"
+          },
+          "conjunction": {
+            "type": "string",
+            "enum": [
+              "OR",
+              "AND"
+            ]
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "appliedLabels": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "case_insensitive": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "CONTAINS",
+                        "ENDS_WITH",
+                        "STARTS_WITH",
+                        "EQUALS",
+                        "IS_EMPTY",
+                        "SQL_LIKE"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string"
+                      ]
+                    },
+                    "values": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "type",
+                    "values"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "is_inclusive": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "LESS_THAN",
+                        "GREATER_THAN",
+                        "EQUALS",
+                        "BETWEEN"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "number"
+                      ]
+                    },
+                    "values": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "type",
+                    "values"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "isFiscal": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "IS_ON_DAY_OF_WEEK",
+                        "IS_ON_DAY_OF_QUARTER",
+                        "IS_IN_MONTH_OF_YEAR",
+                        "IS_ON_DAY_OF_YEAR",
+                        "IS_AT_HOUR_OF_DAY",
+                        "IS_IN_QUARTER_OF_YEAR",
+                        "IS_IN_WEEK_OF_YEAR",
+                        "IS_ON_DAY_OF_MONTH",
+                        "BETWEEN",
+                        "ON_OR_AFTER",
+                        "BEFORE",
+                        "TIME_FOR_INTERVAL_DURATION",
+                        "TIME_FOR_UNIT_DURATION",
+                        "QUERY_OFFSET"
+                      ]
+                    },
+                    "left_side": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "offset_interval_string": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "right_side": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "date"
+                      ]
+                    },
+                    "ui_type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "ANY_TIME",
+                        "BEFORE",
+                        "BETWEEN",
+                        "MONTH_OF_YEAR",
+                        "PAST",
+                        "YEAR",
+                        "DAY",
+                        "IS_ON_DAY_OF_WEEK",
+                        "ON_OR_AFTER",
+                        "IS_IN_THE_MONTH",
+                        "IS_IN_THE_QUARTER",
+                        "IS_IN_THE_FISCAL_QUARTER",
+                        "IS_IN_THE_FISCAL_YEAR",
+                        "TIME_FOR_INTERVAL_DURATION",
+                        "TIME_FOR_UNIT_DURATION",
+                        "CUSTOM",
+                        null
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "treat_nulls_as_false": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "boolean"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "disregard_limit": {
+                      "type": "boolean"
+                    },
+                    "field_name": {
+                      "type": "string"
+                    },
+                    "is_negative": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "query_id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "query"
+                      ]
+                    },
+                    "view_query": {
+                      "type": "object",
+                      "properties": {
+                        "fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "filters": {
+                          "type": "object",
+                          "additionalProperties": {},
+                          "default": {}
+                        },
+                        "limit": {
+                          "type": "number"
+                        },
+                        "sorts": {
+                          "type": "array",
+                          "items": {},
+                          "default": []
+                        },
+                        "table": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fields"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "cancel_query_filter": {
+                      "type": "boolean"
+                    },
+                    "ignore_if_unjoinable": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "user_attribute"
+                      ]
+                    },
+                    "user_attribute_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "user_attribute_name"
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/CompositeFilter"
+                }
+              ]
+            },
+            "description": "Child filters — each a simple filter or another composite filter. Recursive; see the dashboard-filters reference for the full grammar."
+          },
+          "is_negative": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "composite"
+            ]
+          }
+        },
+        "required": [
+          "conjunction",
+          "filters",
+          "type"
+        ]
+      },
       "AiGenerateQueryResponse": {
         "type": "object",
         "properties": {
+          "baseView": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The base view name used for query generation when queryAllViews surfaced a non-topic view. Mutually exclusive with `topic` — exactly one is non-null when a query was generated.",
+            "example": null
+          },
+          "downgradedModelTier": {
+            "type": "string",
+            "description": "Present only when the organization is over its AI downgrade threshold, signaling the query was generated on a downgraded (cheaper) model tier (e.g. 'haiku') to conserve credits. Advisory and best-effort — the call still succeeds, and clients may surface that a downgraded model was used. Absent when no downgrade applied.",
+            "example": "haiku"
+          },
           "error": {
             "type": [
               "object",
@@ -153,8 +560,11 @@
             "description": "Query execution results as a JSON object. Only present when runQuery is true (the default) and the query executed successfully. The structure contains the query result data."
           },
           "topic": {
-            "type": "string",
-            "description": "The topic name that was used for query generation.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic name used for query generation. Mutually exclusive with `baseView` — exactly one is non-null when a query was generated.",
             "example": "order_items"
           },
           "workbookUrl": {
@@ -268,6 +678,34 @@
           }
         },
         "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "AiCreditShutoffError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "shutoff"
+            ],
+            "description": "Stable reason code identifying an AI-credit shutoff.",
+            "example": "shutoff"
+          },
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "The AI agent is currently unavailable. Contact your administrator to re-enable."
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 402
+          }
+        },
+        "required": [
+          "code",
           "detail",
           "status"
         ]
@@ -936,7 +1374,48 @@
           "error"
         ]
       },
-      "ApiKeyListResponse": {
+      "AiBrandingResponse": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Body / description copy shown beneath the headline on AI helper landing surfaces.",
+            "example": "Ask a data question to get started. I can help refine answers, adjust charts, or surface new areas to explore."
+          },
+          "headline": {
+            "type": "string",
+            "description": "Short headline shown on AI helper landing surfaces.",
+            "example": "What would you like to know?"
+          },
+          "logoUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "Absolute URL to a custom AI helper logo. `null` when the org has not configured a custom logo — clients should render their default avatar (e.g. Blobby).",
+            "example": "https://example.com/blobby.png"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name for the AI helper. Defaults to `Omni Agent` when no custom branding is set.",
+            "example": "Blobby"
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "Placeholder text for the AI helper's prompt input.",
+            "example": "Ask a question about your data..."
+          }
+        },
+        "required": [
+          "body",
+          "headline",
+          "logoUrl",
+          "name",
+          "placeholder"
+        ]
+      },
+      "AiConversationsListResponse": {
         "type": "object",
         "properties": {
           "pageInfo": {
@@ -945,8 +1424,9 @@
           "records": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ApiKey"
-            }
+              "$ref": "#/components/schemas/AiConversation"
+            },
+            "description": "Conversations ordered by updatedAt descending."
           }
         },
         "required": [
@@ -984,6 +1464,157 @@
           "totalRecords"
         ]
       },
+      "AiConversation": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the conversation was started.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Conversation ID. Pass as conversationId on subsequent /api/v1/ai/jobs submissions to continue this conversation.",
+            "example": "660e8400-e29b-41d4-a716-446655440001"
+          },
+          "lastPrompt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The most recent user prompt in this conversation, useful for displaying a one-line summary in a list.",
+            "example": "What were our top products last week?"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Conversation title. Set by the AI after the first turn; null on brand-new sessions.",
+            "example": "Top products last week"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the conversation was last touched (most recent prompt or AI activity).",
+            "example": "2025-01-15T10:01:30.000Z"
+          }
+        },
+        "required": [
+          "createdAt",
+          "id",
+          "lastPrompt",
+          "name",
+          "updatedAt"
+        ]
+      },
+      "AiConversationDetailResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiConversationMessage"
+            },
+            "description": "Messages in chronological order. Alternating user / assistant turns."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "createdAt",
+          "id",
+          "messages",
+          "name",
+          "updatedAt"
+        ]
+      },
+      "AiConversationMessage": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this turn was recorded.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "jobId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The agentic job that produced this assistant turn. Only set for assistant messages — clients use it to fetch the rendered chart via GET /api/v1/ai/jobs/{jobId}/vis. Null when the turn predates jobs or when we could not associate one.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "omniChatUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "Deep link to the assistant turn in the Omni chat UI. Null for user turns, and for assistant turns produced outside the Agentic API (where no AgenticJob row exists).",
+            "example": "https://my-org.omni.co/chat/660e8400-e29b-41d4-a716-446655440001"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant"
+            ],
+            "description": "Speaker — `user` for prompts the user submitted, `assistant` for Blobby's responses.",
+            "example": "user"
+          },
+          "text": {
+            "type": "string",
+            "description": "Markdown content of the message. For assistant turns this is the same string returned by /api/v1/ai/jobs/{jobId}/result#message.",
+            "example": "What were our top products last week?"
+          }
+        },
+        "required": [
+          "createdAt",
+          "jobId",
+          "omniChatUrl",
+          "role",
+          "text"
+        ]
+      },
+      "ApiKeyListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKey"
+            }
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
       "ApiKey": {
         "type": "object",
         "properties": {
@@ -995,7 +1626,7 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether the token can currently authenticate. Organization tokens may be disabled by admins; personal and MCP tokens are always `true` (revocation deletes them).",
+            "description": "Whether the token can currently authenticate. A disabled token cannot authenticate but remains visible until deleted.",
             "example": true
           },
           "id": {
@@ -1043,7 +1674,7 @@
         "properties": {
           "enabled": {
             "type": "boolean",
-            "description": "Set to `false` to disable the token, `true` to re-enable it. Only organization-level tokens may be disabled; personal and MCP tokens do not support this.",
+            "description": "Set to `false` to disable the token, `true` to re-enable it.",
             "example": false
           }
         },
@@ -1103,6 +1734,10 @@
             "type": "boolean",
             "description": "Whether this is the default environment"
           },
+          "isDeferralEnabled": {
+            "type": "boolean",
+            "description": "Whether dbt deferral is enabled for this environment. Always false for the default (production) environment — the backend rejects enabling it there."
+          },
           "name": {
             "type": "string",
             "description": "Environment name"
@@ -1150,6 +1785,7 @@
         "required": [
           "id",
           "isDefaultEnvironment",
+          "isDeferralEnabled",
           "name",
           "ownerId",
           "targetDatabase",
@@ -1193,6 +1829,12 @@
       "DbtEnvironmentCreateBody": {
         "type": "object",
         "properties": {
+          "isDeferralEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to enable dbt deferral for this environment. Ignored (forced to false) for the default (production) environment.",
+            "example": false
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -1281,6 +1923,12 @@
       "DbtEnvironmentUpdateBody": {
         "type": "object",
         "properties": {
+          "isDeferralEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to enable dbt deferral for this environment. Ignored (forced to false) for the default (production) environment.",
+            "example": false
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -1619,6 +2267,10 @@
           "folder": {
             "$ref": "#/components/schemas/InternalFolder"
           },
+          "hasApp": {
+            "type": "boolean",
+            "description": "Whether document has an app"
+          },
           "hasDashboard": {
             "type": "boolean",
             "description": "Whether document has a dashboard"
@@ -1652,7 +2304,7 @@
           },
           "url": {
             "type": "string",
-            "description": "URL to view the document. Returns dashboard URL if document has a dashboard, otherwise workbook URL.",
+            "description": "URL to view the document. Returns the dashboard URL if it has a dashboard, the app URL if it has an app, otherwise the workbook URL.",
             "example": "https://org.omni.co/dashboards/abc123"
           },
           "visits": {
@@ -1670,6 +2322,7 @@
           "connectionId",
           "deleted",
           "folder",
+          "hasApp",
           "hasDashboard",
           "identifier",
           "updatedAt",
@@ -1949,6 +2602,10 @@
           "folder": {
             "$ref": "#/components/schemas/DocumentFolder"
           },
+          "hasApp": {
+            "type": "boolean",
+            "description": "Whether the document has an associated app"
+          },
           "hasDashboard": {
             "type": "boolean",
             "description": "Whether the document has an associated dashboard"
@@ -1997,7 +2654,7 @@
           },
           "url": {
             "type": "string",
-            "description": "URL to view the document. Returns dashboard URL if document has a dashboard, otherwise workbook URL.",
+            "description": "URL to view the document. Returns the dashboard URL if it has a dashboard, the app URL if it has an app, otherwise the workbook URL.",
             "example": "https://org.omni.co/dashboards/abc123"
           }
         },
@@ -2180,10 +2837,13 @@
                 },
                 "description": {
                   "type": "string",
+                  "maxLength": 500,
                   "description": "Query presentation description"
                 },
                 "name": {
                   "type": "string",
+                  "minLength": 1,
+                  "maxLength": 144,
                   "description": "Query presentation name"
                 },
                 "prefersChart": {
@@ -2217,11 +2877,16 @@
                 },
                 "subTitle": {
                   "type": "string",
+                  "maxLength": 250,
                   "description": "Subtitle"
                 },
                 "topicName": {
-                  "type": "string",
-                  "description": "Topic name"
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "maxLength": 256,
+                  "description": "Topic name. Omit or pass null for raw-SQL tiles or any tile with no semantic topic."
                 },
                 "visConfig": {
                   "$ref": "#/components/schemas/ApiVisConfig"
@@ -2247,7 +2912,10 @@
         "description": "Optional document identifier. If omitted, an identifier is auto-generated. Must be unique within the organization."
       },
       "ApiVisConfig": {
-        "type": "object",
+        "type": [
+          "object",
+          "null"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -2517,10 +3185,13 @@
           },
           "description": {
             "type": "string",
+            "maxLength": 500,
             "description": "Description"
           },
           "name": {
             "type": "string",
+            "minLength": 1,
+            "maxLength": 144,
             "description": "Query presentation name"
           },
           "prefersChart": {
@@ -2530,16 +3201,26 @@
           "query": {
             "description": "Query definition"
           },
+          "queryIdentifierMapKey": {
+            "type": "string",
+            "pattern": "^[1-9][0-9]*$",
+            "description": "Round-trip preservation hint. When the value matches an existing key on the document, the tile keeps its map key (and dashboard containers stay attached). Omit for new tiles. Must be a positive integer string (e.g. \"1\", \"2\", \"10\")."
+          },
           "resultConfig": {
             "description": "Result config"
           },
           "subTitle": {
             "type": "string",
+            "maxLength": 250,
             "description": "Subtitle"
           },
           "topicName": {
-            "type": "string",
-            "description": "Topic name"
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256,
+            "description": "Topic name. Omit or pass null for raw-SQL tiles or any tile with no semantic topic."
           },
           "visConfig": {
             "$ref": "#/components/schemas/ApiVisConfig"
@@ -2720,6 +3401,10 @@
             "type": "boolean",
             "description": "Allow using dashboard AI"
           },
+          "canUseTimezoneOverride": {
+            "type": "boolean",
+            "description": "Allow timezone override"
+          },
           "canViewWorkbook": {
             "type": "boolean",
             "description": "Allow viewing workbook"
@@ -2888,6 +3573,118 @@
           }
         }
       },
+      "DocumentsListDraftsResponse": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ApiDraft"
+        }
+      },
+      "ApiDraft": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "$ref": "#/components/schemas/ApiDraftBranch"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the draft was created"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/ApiDraftActor"
+          },
+          "draftOutOfDate": {
+            "type": "boolean",
+            "description": "True when the published document was published more recently than the draft was created (the draft is based on a stale baseline)"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Draft workbook identifier — use this to address the draft"
+          },
+          "lastEditedBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiDraftActor"
+              },
+              {
+                "description": "User who most recently edited the draft"
+              }
+            ]
+          },
+          "publishedIdentifier": {
+            "type": "string",
+            "description": "Identifier of the published document the draft is for"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ApiDraftStatus"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Most recent edit time on the draft workbook"
+          },
+          "workbookModelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "omni_model ID for the draft workbook"
+          }
+        },
+        "required": [
+          "branch",
+          "createdAt",
+          "createdBy",
+          "draftOutOfDate",
+          "identifier",
+          "lastEditedBy",
+          "publishedIdentifier",
+          "status",
+          "updatedAt",
+          "workbookModelId"
+        ]
+      },
+      "ApiDraftBranch": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Branch (omni model) ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Branch name"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "description": "Branch the draft is attached to, or null for a draft on main"
+      },
+      "ApiDraftActor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "description": "User who created the draft"
+      },
+      "ApiDraftStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "archived"
+        ],
+        "description": "Lifecycle status: \"active\" for current drafts, \"archived\" for soft-deleted drafts (retained ~7 days)"
+      },
       "DocumentsDuplicateResponse": {
         "type": "object",
         "properties": {
@@ -3017,6 +3814,20445 @@
           "principals"
         ]
       },
+      "DocumentsListFavoritesResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageInfo"
+              },
+              {
+                "description": "Pagination information"
+              }
+            ]
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentFavoriteUser"
+            },
+            "description": "Users who favorited this document"
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "DocumentFavoriteUser": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Favoriting user's email. Null when the user has no resolvable email — e.g. an embed-SSO favoriter whose embed session did not provide one."
+          },
+          "favoritedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp when the user favorited the document"
+          },
+          "name": {
+            "type": "string",
+            "description": "Favoriting user's display name"
+          },
+          "userId": {
+            "type": "string",
+            "description": "Membership ID of the user who favorited the document (use with other v1 endpoints' userId parameter)"
+          }
+        },
+        "required": [
+          "email",
+          "favoritedAt",
+          "name",
+          "userId"
+        ]
+      },
+      "DocumentsV2CreateResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Identifier of the newly created document."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "description",
+          "identifier",
+          "name"
+        ]
+      },
+      "DocumentsV2CreateBody": {
+        "type": "object",
+        "properties": {
+          "containers": {
+            "$ref": "#/components/schemas/Containers"
+          },
+          "controls": {
+            "$ref": "#/components/schemas/ControlsPatchExternal"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "folderId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Folder to create the document in. When omitted, defaults to the caller’s personal \"My documents\" (requires permission to save personal content — otherwise the request is rejected)."
+          },
+          "identifier": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DocumentIdentifier"
+              },
+              {
+                "description": "Identifier for the new document. Must be unique within the organization. Auto-generated when omitted."
+              }
+            ]
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Base workbook model the document is built on — a SHARED model, or a SHARED_EXTENSION with `allowAsWorkbookBase = true`."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 254,
+            "description": "Document name."
+          },
+          "queryPresentations": {
+            "$ref": "#/components/schemas/QueryPresentationsPatchExternal"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsPatchExternal"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Caller-supplied note describing the create, written to the history audit trail. Defaults to \"Created document\" when omitted."
+          }
+        },
+        "required": [
+          "modelId",
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "Containers": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/components/schemas/GridContainer"
+            },
+            {
+              "$ref": "#/components/schemas/PageContainer"
+            },
+            {
+              "$ref": "#/components/schemas/StackContainer"
+            }
+          ]
+        },
+        "description": "Container layout array (grid / stack / page / reference containers, recursively nested). The server validates the full structure on apply."
+      },
+      "GridContainer": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Optional description for the container, providing additional context or information"
+          },
+          "instanceKey": {
+            "type": "string",
+            "description": "Unique identifier for this container. Used to reference the container when adding, moving, or removing children."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the container, used for easier reference in logic and design"
+          },
+          "aspectRatio": {
+            "type": "string"
+          },
+          "fillSpace": {
+            "type": "boolean"
+          },
+          "height": {
+            "type": "string"
+          },
+          "maxHeight": {
+            "type": "string"
+          },
+          "maxWidth": {
+            "type": "string"
+          },
+          "minHeight": {
+            "type": "string"
+          },
+          "minWidth": {
+            "type": "string"
+          },
+          "width": {
+            "type": "string"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "before": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ReferenceContainer"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/StackContainer"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GridContainer"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "chart",
+                                "result",
+                                "ai",
+                                "metadata"
+                              ],
+                              "description": "Render mode: \"chart\" for visualization, \"result\" for data table, \"ai\" for AI summary, \"metadata\" for query metadata"
+                            },
+                            "format": {
+                              "type": "string",
+                              "enum": [
+                                "subtitle",
+                                "description",
+                                "name"
+                              ],
+                              "description": "Display format when as is \"ai\" or \"metadata\": \"name\" (metadata only), \"subtitle\", or \"description\""
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^[1-9][0-9]*$",
+                              "description": "The query presentation ID this content item references"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Display name for this query item"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "query"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "appearance": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "inline"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tooltip"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                }
+                              ],
+                              "description": "Display mode: \"inline\" renders directly, \"tooltip\" shows on hover"
+                            },
+                            "content": {
+                              "type": "string",
+                              "description": "The text content to display (supports markdown)"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Display name for this text item (e.g., title, subtitle)"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "textAlign": {
+                              "type": "string",
+                              "enum": [
+                                "start",
+                                "center",
+                                "end"
+                              ],
+                              "description": "Text alignment: \"start\", \"center\", or \"end\""
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-text"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "content",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "appearance": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tabs"
+                                      ]
+                                    },
+                                    "variant": {
+                                      "type": "string",
+                                      "enum": [
+                                        "underline",
+                                        "bordered"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "buttons"
+                                      ]
+                                    },
+                                    "variant": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segment",
+                                        "toggle",
+                                        "pills"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "list"
+                                      ]
+                                    },
+                                    "description": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "as": {
+                                      "type": "string",
+                                      "enum": [
+                                        "dropdown"
+                                      ]
+                                    },
+                                    "description": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "as"
+                                  ]
+                                }
+                              ]
+                            },
+                            "options": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "disabled": {
+                                    "type": "boolean"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "includeControls": {
+                                    "type": "boolean"
+                                  },
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "target": {
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-page-switcher"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "UUID of the rich text content block"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "text"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "control"
+                              ]
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "filter"
+                              ]
+                            },
+                            "appearance": {
+                              "type": "object",
+                              "properties": {
+                                "control": {
+                                  "type": "string",
+                                  "enum": [
+                                    "buttonToggle",
+                                    "dropdown"
+                                  ]
+                                },
+                                "display": {
+                                  "type": "string",
+                                  "enum": [
+                                    "inline",
+                                    "popover"
+                                  ]
+                                },
+                                "options": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "value"
+                                    ]
+                                  }
+                                },
+                                "value": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "id",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ],
+                          "additionalProperties": {}
+                        }
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gridPosition": {
+                          "type": "object",
+                          "properties": {
+                            "h": {
+                              "type": "number"
+                            },
+                            "w": {
+                              "type": "number"
+                            },
+                            "x": {
+                              "type": "number"
+                            },
+                            "y": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "h",
+                            "w",
+                            "x",
+                            "y"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "gridPosition"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "grid"
+            ]
+          },
+          "gridPosition": {
+            "type": "object",
+            "properties": {
+              "h": {
+                "type": "number",
+                "description": "Height in grid units (default: 36 for charts)"
+              },
+              "w": {
+                "type": "number",
+                "description": "Width in grid columns on a 24-column grid. Common widths: 24 (full), 12 (half), 8 (third), 6 (quarter). x + w must not exceed 24."
+              },
+              "x": {
+                "type": "number",
+                "description": "X position on a 24-column grid (0=left edge, 12=middle). Items side-by-side share the same y with complementary x values."
+              },
+              "y": {
+                "type": "number",
+                "description": "Y position in grid units (0=top, higher values=lower on page)"
+              }
+            },
+            "required": [
+              "h",
+              "w",
+              "x",
+              "y"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "attachedQueryKey": {
+                "type": "string",
+                "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              }
+            },
+            "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
+          },
+          "padding": {
+            "anyOf": [
+              {
+                "type": "number",
+                "enum": [
+                  0
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  0.5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  2
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  3
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  4
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  6
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  7
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  8
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "style": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          }
+        },
+        "required": [
+          "instanceKey",
+          "children",
+          "containerType"
+        ],
+        "description": "Grid container — children are positioned on a grid (each carries a gridPosition)."
+      },
+      "StackContainer": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Optional description for the container, providing additional context or information"
+          },
+          "instanceKey": {
+            "type": "string",
+            "description": "Unique identifier for this container. Used to reference the container when adding, moving, or removing children."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the container, used for easier reference in logic and design"
+          },
+          "aspectRatio": {
+            "type": "string"
+          },
+          "fillSpace": {
+            "type": "boolean"
+          },
+          "height": {
+            "type": "string"
+          },
+          "maxHeight": {
+            "type": "string"
+          },
+          "maxWidth": {
+            "type": "string"
+          },
+          "minHeight": {
+            "type": "string"
+          },
+          "minWidth": {
+            "type": "string"
+          },
+          "width": {
+            "type": "string"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "align": {
+            "type": "string",
+            "enum": [
+              "flex-start",
+              "flex-end",
+              "center",
+              "stretch"
+            ],
+            "description": "Cross-axis alignment of children (e.g., center, stretch)"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "as": {
+                      "type": "string",
+                      "enum": [
+                        "chart",
+                        "result",
+                        "ai",
+                        "metadata"
+                      ],
+                      "description": "Render mode: \"chart\" for visualization, \"result\" for data table, \"ai\" for AI summary, \"metadata\" for query metadata"
+                    },
+                    "format": {
+                      "type": "string",
+                      "enum": [
+                        "subtitle",
+                        "description",
+                        "name"
+                      ],
+                      "description": "Display format when as is \"ai\" or \"metadata\": \"name\" (metadata only), \"subtitle\", or \"description\""
+                    },
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[1-9][0-9]*$",
+                      "description": "The query presentation ID this content item references"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Display name for this query item"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "query"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "appearance": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "inline"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "tooltip"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        }
+                      ],
+                      "description": "Display mode: \"inline\" renders directly, \"tooltip\" shows on hover"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "The text content to display (supports markdown)"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Display name for this text item (e.g., title, subtitle)"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "textAlign": {
+                      "type": "string",
+                      "enum": [
+                        "start",
+                        "center",
+                        "end"
+                      ],
+                      "description": "Text alignment: \"start\", \"center\", or \"end\""
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-text"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "content",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "appearance": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "tabs"
+                              ]
+                            },
+                            "variant": {
+                              "type": "string",
+                              "enum": [
+                                "underline",
+                                "bordered"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "buttons"
+                              ]
+                            },
+                            "variant": {
+                              "type": "string",
+                              "enum": [
+                                "segment",
+                                "toggle",
+                                "pills"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "list"
+                              ]
+                            },
+                            "description": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "as": {
+                              "type": "string",
+                              "enum": [
+                                "dropdown"
+                              ]
+                            },
+                            "description": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "as"
+                          ]
+                        }
+                      ]
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "includeControls": {
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "type": "string"
+                          },
+                          "uri": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-page-switcher"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "UUID of the rich text content block"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "text"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "control"
+                      ]
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "filter"
+                      ]
+                    },
+                    "appearance": {
+                      "type": "object",
+                      "properties": {
+                        "control": {
+                          "type": "string",
+                          "enum": [
+                            "buttonToggle",
+                            "dropdown"
+                          ]
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "inline",
+                            "popover"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          }
+                        },
+                        "value": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "id",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ],
+                  "additionalProperties": {}
+                },
+                {
+                  "$ref": "#/components/schemas/ReferenceContainer"
+                },
+                {
+                  "$ref": "#/components/schemas/GridContainer"
+                },
+                {
+                  "$ref": "#/components/schemas/StackContainer"
+                }
+              ]
+            }
+          },
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "stack"
+            ],
+            "description": "Stack containers lay out children sequentially in a direction (column or row)"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "column",
+              "row"
+            ],
+            "description": "Layout direction: \"row\" lays out horizontally, \"column\" stacks vertically (default if not specified)"
+          },
+          "gap": {
+            "anyOf": [
+              {
+                "type": "number",
+                "enum": [
+                  0
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  0.5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  2
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  3
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  4
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  6
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  7
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  8
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  9
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  10
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  11
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  12
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  13
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  14
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  15
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  16
+                ]
+              }
+            ],
+            "description": "Space between children (CSS size value)"
+          },
+          "justify": {
+            "type": "string",
+            "enum": [
+              "flex-start",
+              "flex-end",
+              "center",
+              "space-between"
+            ],
+            "description": "Main-axis alignment of children (e.g., start, center, end)"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "attachedQueryKey": {
+                "type": "string",
+                "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              }
+            },
+            "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
+          },
+          "padding": {
+            "anyOf": [
+              {
+                "type": "number",
+                "enum": [
+                  0
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  0.5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  2
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  3
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  4
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  5
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  6
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  7
+                ]
+              },
+              {
+                "type": "number",
+                "enum": [
+                  8
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "enum": [
+                          0
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          0.5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          1
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          3
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          4
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          5
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          6
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          7
+                        ]
+                      },
+                      {
+                        "type": "number",
+                        "enum": [
+                          8
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "style": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "wrap": {
+            "type": "string",
+            "enum": [
+              "nowrap",
+              "wrap"
+            ],
+            "description": "Whether flex items should wrap to new lines (defaults to nowrap if not specified)"
+          }
+        },
+        "required": [
+          "instanceKey",
+          "children",
+          "containerType"
+        ],
+        "description": "Stack container — an ordered list of nested children (content, grid, stack, or reference)."
+      },
+      "ReferenceContainer": {
+        "type": "object",
+        "properties": {
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "reference"
+            ]
+          },
+          "instanceKey": {
+            "type": "string"
+          },
+          "referenceKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "containerType",
+          "instanceKey",
+          "referenceKey"
+        ],
+        "description": "Reference container — points at another container in the collection by its instanceKey."
+      },
+      "PageContainer": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Optional description for the container, providing additional context or information"
+          },
+          "instanceKey": {
+            "type": "string",
+            "description": "Unique identifier for this container. Used to reference the container when adding, moving, or removing children."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the container, used for easier reference in logic and design"
+          },
+          "breakpoint": {
+            "type": "string",
+            "enum": [
+              "desktop",
+              "mobile"
+            ]
+          },
+          "container": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridContainer"
+              },
+              {
+                "$ref": "#/components/schemas/StackContainer"
+              },
+              {
+                "$ref": "#/components/schemas/ReferenceContainer"
+              }
+            ]
+          },
+          "containerType": {
+            "type": "string",
+            "enum": [
+              "page"
+            ]
+          },
+          "media": {
+            "type": "string",
+            "enum": [
+              "screen",
+              "print"
+            ]
+          }
+        },
+        "required": [
+          "instanceKey",
+          "container",
+          "containerType"
+        ],
+        "description": "Page container — a top-level page wrapping a single grid, stack, or reference container, optionally per breakpoint/media."
+      },
+      "ControlsPatchExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ControlPatchExternal"
+            },
+            "description": "Controls keyed by control ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Display order for controls. When present, replaces the existing order."
+          }
+        }
+      },
+      "ControlPatchExternal": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "config": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "case_insensitive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "CONTAINS",
+                      "ENDS_WITH",
+                      "STARTS_WITH",
+                      "EQUALS",
+                      "IS_EMPTY",
+                      "SQL_LIKE"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_inclusive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "LESS_THAN",
+                      "GREATER_THAN",
+                      "EQUALS",
+                      "BETWEEN"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "number"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "isFiscal": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "IS_ON_DAY_OF_WEEK",
+                      "IS_ON_DAY_OF_QUARTER",
+                      "IS_IN_MONTH_OF_YEAR",
+                      "IS_ON_DAY_OF_YEAR",
+                      "IS_AT_HOUR_OF_DAY",
+                      "IS_IN_QUARTER_OF_YEAR",
+                      "IS_IN_WEEK_OF_YEAR",
+                      "IS_ON_DAY_OF_MONTH",
+                      "BETWEEN",
+                      "ON_OR_AFTER",
+                      "BEFORE",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "QUERY_OFFSET"
+                    ]
+                  },
+                  "left_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "offset_interval_string": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "right_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "date"
+                    ]
+                  },
+                  "ui_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANY_TIME",
+                      "BEFORE",
+                      "BETWEEN",
+                      "MONTH_OF_YEAR",
+                      "PAST",
+                      "YEAR",
+                      "DAY",
+                      "IS_ON_DAY_OF_WEEK",
+                      "ON_OR_AFTER",
+                      "IS_IN_THE_MONTH",
+                      "IS_IN_THE_QUARTER",
+                      "IS_IN_THE_FISCAL_QUARTER",
+                      "IS_IN_THE_FISCAL_YEAR",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "CUSTOM",
+                      null
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "null"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "treat_nulls_as_false": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "boolean"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "disregard_limit": {
+                    "type": "boolean"
+                  },
+                  "field_name": {
+                    "type": "string"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "query_id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "query"
+                    ]
+                  },
+                  "view_query": {
+                    "type": "object",
+                    "properties": {
+                      "fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "filters": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "default": {}
+                      },
+                      "limit": {
+                        "type": "number"
+                      },
+                      "sorts": {
+                        "type": "array",
+                        "items": {},
+                        "default": []
+                      },
+                      "table": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "additionalProperties": {}
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "user_attribute"
+                    ]
+                  },
+                  "user_attribute_name": {
+                    "type": "string"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type",
+                  "user_attribute_name"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR",
+                      "AND"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CompositeFilter"
+                    }
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "composite"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "conjunction",
+                  "filters",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD",
+                      "TIMEFRAME"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_SELECTION"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "field",
+                  "kind",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "selectionMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_SELECTION"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "selectionMap",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "computations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "isDynamicPreviousPeriod": {
+                          "type": "boolean"
+                        },
+                        "periodsAgo": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "timeUnitName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "periodsAgo",
+                        "timeUnitName"
+                      ]
+                    }
+                  },
+                  "filterFieldName": {
+                    "type": "string"
+                  },
+                  "filterId": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "PERIOD_OVER_PERIOD"
+                    ]
+                  }
+                },
+                "required": [
+                  "computations",
+                  "filterFieldName",
+                  "id",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_PICKER"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filter": {
+                          "$ref": "#/components/schemas/JsonValue"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fieldName",
+                        "filter",
+                        "id"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "conjunction",
+                  "filters",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "fieldSelection": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "full-model"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "mode"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "auto"
+                            ]
+                          },
+                          "topics": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "mode",
+                          "topics"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "fields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "fieldName": {
+                                  "type": "string"
+                                },
+                                "topicName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldName"
+                              ]
+                            }
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "specific"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fields",
+                          "mode"
+                        ]
+                      }
+                    ]
+                  },
+                  "includeViewNameInLabels": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "DYNAMIC_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "fieldSelection",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "defaultValue": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "max": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "min": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "TOP_N"
+                    ]
+                  },
+                  "value": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "id",
+                  "defaultValue",
+                  "field",
+                  "type",
+                  "value"
+                ]
+              }
+            ],
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+          },
+          "map": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ]
+                }
+              ]
+            },
+            "description": "Per-tile field overrides keyed by tab ID. Values are a field name (override) or false (exclude tile from control)."
+          }
+        },
+        "required": [
+          "config"
+        ]
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "description": "Arbitrary JSON value (string, number, boolean, null, object, or array)."
+      },
+      "QueryPresentationsPatchExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/QueryPresentationPatchExternal"
+            },
+            "description": "Query presentations keyed by tab ID. Shallow-merged by key — omitted keys are untouched; set to `null` to delete. Capped at 48 entries per patch."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "description": "Tab display order. When present, replaces the existing order."
+          }
+        }
+      },
+      "QueryPresentationPatchExternal": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "aiConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "description": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "subTitle": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "description": "AI-generated metadata config (subtitle/description auto-generation settings)."
+          },
+          "automaticVis": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "When true, the system automatically selects the best visualization type."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 500,
+            "description": "User-provided tab description."
+          },
+          "editingModelObjectName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Model object (view/topic) currently being edited via the dataset/query-view editor. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "editingModelObjectNameChange": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "filterOrder": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ordered list of filter field names controlling display order on this tab."
+          },
+          "isSql": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this tab is in raw SQL mode."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 144,
+            "description": "User-provided tab name."
+          },
+          "prefersChart": {
+            "type": "boolean",
+            "description": "When true, the chart view is shown by default instead of the data table."
+          },
+          "query": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "aiGenerated": {
+                "type": "boolean",
+                "description": "True when AI generated this query’s SQL; the AI SQL is shown in the advanced SQL box."
+              },
+              "branch_id": {
+                "type": "string",
+                "description": "Branch model ID when querying against a model branch."
+              },
+              "calculations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "allow_refs_to_unselected_fields": {
+                      "type": "boolean",
+                      "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
+                    },
+                    "calc_name": {
+                      "type": "string",
+                      "description": "Internal identifier for the calculation, used as the column alias."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of the calculation."
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "Number/date format string (e.g. \"#,##0.00\")."
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label shown in the UI."
+                    },
+                    "original_formula": {
+                      "type": "string",
+                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                    },
+                    "outside_pivot": {
+                      "type": "boolean",
+                      "description": "When true, the calculation is evaluated outside the pivot grouping."
+                    },
+                    "pushdown": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Per-calc override for whether to evaluate before the row limit. `null` defers to the model-level default."
+                    },
+                    "sql": {
+                      "type": "string",
+                      "description": "Compiled SQL string produced from the formula."
+                    },
+                    "sql_expression": {
+                      "description": "Parsed SQL expression tree (serialized)."
+                    },
+                    "swallow_errors": {
+                      "type": "boolean",
+                      "description": "When true, calculation errors are silently swallowed instead of surfaced."
+                    }
+                  },
+                  "required": [
+                    "calc_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Table calculations attached to this query."
+              },
+              "column_limit": {
+                "type": "number",
+                "description": "Max number of pivot columns to return."
+              },
+              "column_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Column-level aggregation totals, keyed by field name."
+              },
+              "controls": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD",
+                            "TIMEFRAME"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_SELECTION"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "field",
+                        "kind",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "selectionMap": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_SELECTION"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "selectionMap",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "computations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "filterId": {
+                                "type": "string"
+                              },
+                              "isDynamicPreviousPeriod": {
+                                "type": "boolean"
+                              },
+                              "periodsAgo": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "timeUnitName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "periodsAgo",
+                              "timeUnitName"
+                            ]
+                          }
+                        },
+                        "filterFieldName": {
+                          "type": "string"
+                        },
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "PERIOD_OVER_PERIOD"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "computations",
+                        "filterFieldName",
+                        "id",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_PICKER"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fieldName": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "$ref": "#/components/schemas/JsonValue"
+                              },
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldName",
+                              "filter",
+                              "id"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "fieldSelection": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "full-model"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "mode"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "auto"
+                                  ]
+                                },
+                                "topics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "mode",
+                                "topics"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fields": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "fieldName": {
+                                        "type": "string"
+                                      },
+                                      "topicName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldName"
+                                    ]
+                                  }
+                                },
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "specific"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fields",
+                                "mode"
+                              ]
+                            }
+                          ]
+                        },
+                        "includeViewNameInLabels": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "DYNAMIC_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "fieldSelection",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "defaultValue": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "max": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "min": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "TOP_N"
+                          ]
+                        },
+                        "value": {
+                          "type": "integer",
+                          "minimum": 1
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "defaultValue",
+                        "field",
+                        "type",
+                        "value"
+                      ]
+                    }
+                  ]
+                },
+                "description": "Interactive controls (field selectors, PoP controls) attached to this query."
+              },
+              "cube_metadata": {
+                "type": "object",
+                "properties": {
+                  "cube_name": {
+                    "type": "string"
+                  },
+                  "hash_key": {
+                    "type": "string"
+                  },
+                  "topic_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cube_name",
+                  "hash_key",
+                  "topic_name"
+                ],
+                "additionalProperties": {},
+                "description": "Cube-specific metadata (topic name, cube name, hash key) for cube-backed queries."
+              },
+              "custom_summary_types": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Per-field custom summary functions (e.g. SUM, AVG, COUNT)."
+              },
+              "dbtFileName": {
+                "type": "string",
+                "description": "dbt file name when this query is backed by a dbt model."
+              },
+              "dbtMode": {
+                "type": "boolean",
+                "description": "Whether this query is in dbt mode."
+              },
+              "default_group_by": {
+                "type": "boolean",
+                "description": "When true, all dimensions are implicitly included in GROUP BY."
+              },
+              "dimensionIndex": {
+                "type": "number",
+                "description": "Index of the primary dimension used for result ordering."
+              },
+              "executableSQL": {
+                "type": "string",
+                "description": "Server-compiled SQL string (read-only, set by the backend)."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model field names selected for the query (dimensions + measures)."
+              },
+              "fill_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields whose missing date/time values should be filled with nulls to create continuous series."
+              },
+              "filters": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Query filters keyed by filter ID."
+              },
+              "filtersUsedInSql": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Filters that were embedded directly in raw SQL (read-only)."
+              },
+              "join_paths_from_topic_name": {
+                "type": "string",
+                "description": "Topic name that determines join path precedence for parsed SQL queries."
+              },
+              "join_via_map": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "description": "Virtual topic join path overrides, keyed by view name to ordered join path."
+              },
+              "limit": {
+                "type": "number",
+                "description": "Row limit for the query."
+              },
+              "manualSort": {
+                "type": "boolean",
+                "description": "When true, the user has explicitly set a custom sort order."
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "order": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "description": "Per-field display metadata (format, label, order)."
+              },
+              "offset": {
+                "type": "number",
+                "description": "Row offset for pagination."
+              },
+              "parsed": {
+                "type": "boolean",
+                "description": "Whether this raw SQL query has been parsed into a semantic query."
+              },
+              "periodOverPeriodTransposed": {
+                "type": "boolean",
+                "description": "Whether the period-over-period comparison columns are transposed."
+              },
+              "period_over_period_computations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "date_filter_field_name": {
+                      "type": "string",
+                      "description": "The date dimension field this comparison is anchored to."
+                    },
+                    "date_filter_id": {
+                      "type": "string",
+                      "description": "ID of the date filter being offset (if backed by a dashboard filter)."
+                    },
+                    "is_dynamic_previous_period": {
+                      "type": "boolean",
+                      "description": "When true, the previous period is calculated dynamically relative to the current filter range."
+                    },
+                    "periods_ago": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "How many periods back to compare (e.g. 1 = previous period). Null if not set."
+                    },
+                    "time_unit_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Time grain for the offset (e.g. \"month\", \"year\"). Null if not set."
+                    }
+                  },
+                  "required": [
+                    "date_filter_field_name",
+                    "periods_ago",
+                    "time_unit_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Period-over-period comparison configurations."
+              },
+              "pivots": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names to pivot on (columns become values)."
+              },
+              "rewriteSql": {
+                "type": "boolean",
+                "description": "When true, the backend should rewrite/optimize the SQL."
+              },
+              "row_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Row-level aggregation totals, keyed by field name."
+              },
+              "sorts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "column_name": {
+                      "type": "string",
+                      "description": "The model field name to sort by."
+                    },
+                    "is_column_sort": {
+                      "type": "boolean",
+                      "description": "When true, this sort targets a pivoted column rather than a row dimension."
+                    },
+                    "pivot_value_map": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": "Maps pivot field names to specific pivot values, scoping the sort to a single pivot column."
+                    },
+                    "sort_descending": {
+                      "type": "boolean",
+                      "description": "When true, sort order is descending."
+                    },
+                    "subtotal_sort": {
+                      "type": "string",
+                      "description": "Field name whose subtotal row should be used as the sort key."
+                    }
+                  },
+                  "required": [
+                    "column_name",
+                    "sort_descending"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Sort clauses applied to the query result set."
+              },
+              "sqlSortsEnabled": {
+                "type": "boolean",
+                "description": "Whether user-created sorts are enabled on a raw SQL query."
+              },
+              "staticQueryReferences": {
+                "type": "object",
+                "additionalProperties": {},
+                "description": "Pre-computed query references for AI chat context. Inner shape is `OmniQuery & { model_id: string }`; left as `unknown` to avoid a recursive zod schema. Validated structurally by consumers when they execute the referenced sub-queries."
+              },
+              "table": {
+                "type": "string",
+                "description": "Base view (table) name in the model."
+              },
+              "transposed_measures": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Measure field names that have been transposed into rows."
+              },
+              "userEditedSQL": {
+                "type": "string",
+                "description": "User-authored raw SQL (empty string when not in SQL mode)."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for migration support."
+              }
+            },
+            "required": [
+              "calculations",
+              "column_totals",
+              "fields",
+              "fill_fields",
+              "filters",
+              "pivots",
+              "row_totals",
+              "sorts",
+              "table",
+              "userEditedSQL"
+            ],
+            "additionalProperties": {},
+            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). Omitted on a no-op replay; the server anchors new/changed tiles to the draft."
+          },
+          "resultConfig": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Result display configuration (column widths, frozen columns, conditional formatting, number formatting, etc.)."
+          },
+          "subTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 250,
+            "description": "User-provided tab subtitle."
+          },
+          "topicName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic (explore) this query is built on."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "blank",
+              "csv",
+              "query",
+              "dataset",
+              "spreadsheet",
+              "sql",
+              "dbt",
+              "query-view",
+              "linked",
+              "app"
+            ],
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+          },
+          "visConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "chartType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "auto",
+                  "area",
+                  "areaStacked",
+                  "areaStackedPercentage",
+                  "bar",
+                  "barLine",
+                  "barGrouped",
+                  "barStacked",
+                  "barStackedPercentage",
+                  "boxplot",
+                  "code",
+                  "column",
+                  "columnGrouped",
+                  "columnStacked",
+                  "columnStackedPercentage",
+                  "heatmap",
+                  "kpi",
+                  "line",
+                  "lineColor",
+                  "map",
+                  "regionMap",
+                  "markdown",
+                  "omni-ai-summary-markdown",
+                  "pie",
+                  "funnel",
+                  "sankey",
+                  "point",
+                  "pointColor",
+                  "pointSize",
+                  "pointSizeColor",
+                  "singleRecord",
+                  "omni-spreadsheet",
+                  "summaryValue",
+                  "svgMap",
+                  "table",
+                  null
+                ],
+                "description": "High-level chart type (e.g. \"bar\", \"line\", \"area\")."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names used in the visualization axes/series."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for vis config migration."
+              },
+              "visConfig": {
+                "type": "object",
+                "properties": {
+                  "visType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "vegalite",
+                      "omni-ai-summary-markdown",
+                      "basic",
+                      "omni-kpi",
+                      "map",
+                      "omni-markdown",
+                      "funnel",
+                      "sankey",
+                      "single-record",
+                      "svg-map",
+                      "omni-spreadsheet",
+                      "spreadsheet-tab",
+                      "summary-value",
+                      "omni-table",
+                      "app",
+                      null
+                    ],
+                    "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
+                  }
+                },
+                "additionalProperties": {},
+                "description": "Inner visualization config — structure varies by visType."
+              }
+            },
+            "additionalProperties": {},
+            "description": "Visualization configuration for the tile."
+          },
+          "sourceQueryPresentationKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[1-9][0-9]*$",
+            "description": "For LINKED-type tabs, the record key — the same identifier used as a `queryPresentations.data` key — of the source tile whose query this tab reuses. Null for all other tab types. This is a tile record key, NOT a positional index into `order`."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      },
+      "SettingsPatchExternal": {
+        "type": "object",
+        "properties": {
+          "crossfilterEnabled": {
+            "type": "boolean",
+            "description": "When true, clicking a value in one tile filters all other tiles on the dashboard."
+          },
+          "customText": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "queryError": {
+                "type": "string",
+                "description": "Custom text shown when a query errors, replacing the default error text."
+              },
+              "queryNoResults": {
+                "type": "string",
+                "description": "Custom text shown when a query returns no results, replacing the default empty state."
+              }
+            },
+            "description": "Custom text replacing default UI strings on the dashboard, e.g. when queries error or return no results."
+          },
+          "facetFilters": {
+            "type": "boolean",
+            "description": "When true, dashboard filters are applied per-facet when faceting is active."
+          },
+          "refreshInterval": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Auto-refresh interval in seconds. Null disables auto-refresh."
+          },
+          "runQueriesOn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "current-page",
+              "all-pages",
+              null
+            ],
+            "description": "Controls whether dashboard queries execute on the visible page or across all pages."
+          }
+        },
+        "description": "Document settings. Shallow-merged with the existing settings."
+      },
+      "DocumentsV2ReadResponse": {
+        "type": "object",
+        "properties": {
+          "containers": {
+            "$ref": "#/components/schemas/Containers"
+          },
+          "controls": {
+            "$ref": "#/components/schemas/ControlsReadExternal"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 254,
+            "description": "Document name."
+          },
+          "queryPresentations": {
+            "$ref": "#/components/schemas/QueryPresentationsReadExternal"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsReadExternal"
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "queryPresentations"
+        ]
+      },
+      "ControlsReadExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ControlReadExternal"
+            },
+            "description": "Controls keyed by control ID."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Display order for controls."
+          }
+        },
+        "required": [
+          "data",
+          "order"
+        ]
+      },
+      "ControlReadExternal": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "case_insensitive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "CONTAINS",
+                      "ENDS_WITH",
+                      "STARTS_WITH",
+                      "EQUALS",
+                      "IS_EMPTY",
+                      "SQL_LIKE"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_inclusive": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "LESS_THAN",
+                      "GREATER_THAN",
+                      "EQUALS",
+                      "BETWEEN"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "number"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "isFiscal": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "IS_ON_DAY_OF_WEEK",
+                      "IS_ON_DAY_OF_QUARTER",
+                      "IS_IN_MONTH_OF_YEAR",
+                      "IS_ON_DAY_OF_YEAR",
+                      "IS_AT_HOUR_OF_DAY",
+                      "IS_IN_QUARTER_OF_YEAR",
+                      "IS_IN_WEEK_OF_YEAR",
+                      "IS_ON_DAY_OF_MONTH",
+                      "BETWEEN",
+                      "ON_OR_AFTER",
+                      "BEFORE",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "QUERY_OFFSET"
+                    ]
+                  },
+                  "left_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "offset_interval_string": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "right_side": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "date"
+                    ]
+                  },
+                  "ui_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANY_TIME",
+                      "BEFORE",
+                      "BETWEEN",
+                      "MONTH_OF_YEAR",
+                      "PAST",
+                      "YEAR",
+                      "DAY",
+                      "IS_ON_DAY_OF_WEEK",
+                      "ON_OR_AFTER",
+                      "IS_IN_THE_MONTH",
+                      "IS_IN_THE_QUARTER",
+                      "IS_IN_THE_FISCAL_QUARTER",
+                      "IS_IN_THE_FISCAL_YEAR",
+                      "TIME_FOR_INTERVAL_DURATION",
+                      "TIME_FOR_UNIT_DURATION",
+                      "CUSTOM",
+                      null
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "kind",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "null"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "treat_nulls_as_false": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "boolean"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "disregard_limit": {
+                    "type": "boolean"
+                  },
+                  "field_name": {
+                    "type": "string"
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "query_id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "query"
+                    ]
+                  },
+                  "view_query": {
+                    "type": "object",
+                    "properties": {
+                      "fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "filters": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "default": {}
+                      },
+                      "limit": {
+                        "type": "number"
+                      },
+                      "sorts": {
+                        "type": "array",
+                        "items": {},
+                        "default": []
+                      },
+                      "table": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "additionalProperties": {}
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "user_attribute"
+                    ]
+                  },
+                  "user_attribute_name": {
+                    "type": "string"
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type",
+                  "user_attribute_name"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cancel_query_filter": {
+                    "type": "boolean"
+                  },
+                  "ignore_if_unjoinable": {
+                    "type": "boolean"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR",
+                      "AND"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/CompositeFilter"
+                    }
+                  },
+                  "is_negative": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "composite"
+                    ]
+                  },
+                  "appliedLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "base_view": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fieldName": {
+                    "type": "string"
+                  },
+                  "filterControlType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "multiValueEquals",
+                          "singleValueEquals"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "singleDay",
+                          "timeframe"
+                        ]
+                      }
+                    ]
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "watchedContainerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "conjunction",
+                  "filters",
+                  "type"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD",
+                      "TIMEFRAME"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_SELECTION"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "field",
+                  "kind",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "string",
+                    "enum": [
+                      "SELECT",
+                      "BUTTON_TOGGLE"
+                    ]
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "selectionMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_SELECTION"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "selectionMap",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "computations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "isDynamicPreviousPeriod": {
+                          "type": "boolean"
+                        },
+                        "periodsAgo": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "timeUnitName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "periodsAgo",
+                        "timeUnitName"
+                      ]
+                    }
+                  },
+                  "filterFieldName": {
+                    "type": "string"
+                  },
+                  "filterId": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "PERIOD_OVER_PERIOD"
+                    ]
+                  }
+                },
+                "required": [
+                  "computations",
+                  "filterFieldName",
+                  "id",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "isDimension": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "topicLabel": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "viewLabel": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "FIELD_PICKER"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "options",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "conjunction": {
+                    "type": "string",
+                    "enum": [
+                      "OR"
+                    ]
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filter": {
+                          "$ref": "#/components/schemas/JsonValue"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fieldName",
+                        "filter",
+                        "id"
+                      ]
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "MULTI_FIELD_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "conjunction",
+                  "filters",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "fieldSelection": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "full-model"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "mode"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "auto"
+                            ]
+                          },
+                          "topics": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "mode",
+                          "topics"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "fields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "fieldName": {
+                                  "type": "string"
+                                },
+                                "topicName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldName"
+                              ]
+                            }
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "specific"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fields",
+                          "mode"
+                        ]
+                      }
+                    ]
+                  },
+                  "includeViewNameInLabels": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "DYNAMIC_FILTER"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "fieldSelection",
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "defaultValue": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "max": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "min": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "TOP_N"
+                    ]
+                  },
+                  "value": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "id",
+                  "defaultValue",
+                  "field",
+                  "type",
+                  "value"
+                ]
+              }
+            ],
+            "description": "Filter or interactive control config. Discriminated by `type`: filter types (string, date, number, etc.) or control types (FIELD_SELECTION, PERIOD_OVER_PERIOD, etc.)."
+          },
+          "map": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ]
+                }
+              ]
+            },
+            "description": "Per-tile field overrides keyed by tab ID. Values are a field name (override) or false (exclude tile from control)."
+          }
+        },
+        "required": [
+          "config"
+        ]
+      },
+      "QueryPresentationsReadExternal": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/QueryPresentationReadExternal"
+            },
+            "description": "Query presentations keyed by tab ID."
+          },
+          "order": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "description": "Tab display order."
+          }
+        },
+        "required": [
+          "data",
+          "order"
+        ]
+      },
+      "QueryPresentationReadExternal": {
+        "type": "object",
+        "properties": {
+          "aiConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "description": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "subTitle": {
+                "type": "object",
+                "properties": {
+                  "aiContext": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "description": "AI-generated metadata config (subtitle/description auto-generation settings)."
+          },
+          "automaticVis": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "When true, the system automatically selects the best visualization type."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 500,
+            "description": "User-provided tab description."
+          },
+          "editingModelObjectName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Model object (view/topic) currently being edited via the dataset/query-view editor. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "editingModelObjectNameChange": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
+          },
+          "filterOrder": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ordered list of filter field names controlling display order on this tab."
+          },
+          "isSql": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this tab is in raw SQL mode."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 144,
+            "description": "User-provided tab name."
+          },
+          "prefersChart": {
+            "type": "boolean",
+            "description": "When true, the chart view is shown by default instead of the data table."
+          },
+          "query": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "aiGenerated": {
+                "type": "boolean",
+                "description": "True when AI generated this query’s SQL; the AI SQL is shown in the advanced SQL box."
+              },
+              "branch_id": {
+                "type": "string",
+                "description": "Branch model ID when querying against a model branch."
+              },
+              "calculations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "allow_refs_to_unselected_fields": {
+                      "type": "boolean",
+                      "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
+                    },
+                    "calc_name": {
+                      "type": "string",
+                      "description": "Internal identifier for the calculation, used as the column alias."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of the calculation."
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "Number/date format string (e.g. \"#,##0.00\")."
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label shown in the UI."
+                    },
+                    "original_formula": {
+                      "type": "string",
+                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                    },
+                    "outside_pivot": {
+                      "type": "boolean",
+                      "description": "When true, the calculation is evaluated outside the pivot grouping."
+                    },
+                    "pushdown": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Per-calc override for whether to evaluate before the row limit. `null` defers to the model-level default."
+                    },
+                    "sql": {
+                      "type": "string",
+                      "description": "Compiled SQL string produced from the formula."
+                    },
+                    "sql_expression": {
+                      "description": "Parsed SQL expression tree (serialized)."
+                    },
+                    "swallow_errors": {
+                      "type": "boolean",
+                      "description": "When true, calculation errors are silently swallowed instead of surfaced."
+                    }
+                  },
+                  "required": [
+                    "calc_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Table calculations attached to this query."
+              },
+              "column_limit": {
+                "type": "number",
+                "description": "Max number of pivot columns to return."
+              },
+              "column_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Column-level aggregation totals, keyed by field name."
+              },
+              "controls": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD",
+                            "TIMEFRAME"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_SELECTION"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "field",
+                        "kind",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "SELECT",
+                            "BUTTON_TOGGLE"
+                          ]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "selectionMap": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_SELECTION"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "selectionMap",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "computations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "filterId": {
+                                "type": "string"
+                              },
+                              "isDynamicPreviousPeriod": {
+                                "type": "boolean"
+                              },
+                              "periodsAgo": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "timeUnitName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "periodsAgo",
+                              "timeUnitName"
+                            ]
+                          }
+                        },
+                        "filterFieldName": {
+                          "type": "string"
+                        },
+                        "filterId": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "PERIOD_OVER_PERIOD"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "computations",
+                        "filterFieldName",
+                        "id",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "isDimension": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "topicLabel": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "viewLabel": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "FIELD_PICKER"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "options",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fieldName": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "$ref": "#/components/schemas/JsonValue"
+                              },
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldName",
+                              "filter",
+                              "id"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MULTI_FIELD_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "fieldSelection": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "full-model"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "mode"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "auto"
+                                  ]
+                                },
+                                "topics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "mode",
+                                "topics"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fields": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "fieldName": {
+                                        "type": "string"
+                                      },
+                                      "topicName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldName"
+                                    ]
+                                  }
+                                },
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "specific"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fields",
+                                "mode"
+                              ]
+                            }
+                          ]
+                        },
+                        "includeViewNameInLabels": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "DYNAMIC_FILTER"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "fieldSelection",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "defaultValue": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "field": {
+                          "type": "string"
+                        },
+                        "max": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "min": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "TOP_N"
+                          ]
+                        },
+                        "value": {
+                          "type": "integer",
+                          "minimum": 1
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "defaultValue",
+                        "field",
+                        "type",
+                        "value"
+                      ]
+                    }
+                  ]
+                },
+                "description": "Interactive controls (field selectors, PoP controls) attached to this query."
+              },
+              "cube_metadata": {
+                "type": "object",
+                "properties": {
+                  "cube_name": {
+                    "type": "string"
+                  },
+                  "hash_key": {
+                    "type": "string"
+                  },
+                  "topic_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cube_name",
+                  "hash_key",
+                  "topic_name"
+                ],
+                "additionalProperties": {},
+                "description": "Cube-specific metadata (topic name, cube name, hash key) for cube-backed queries."
+              },
+              "custom_summary_types": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Per-field custom summary functions (e.g. SUM, AVG, COUNT)."
+              },
+              "dbtFileName": {
+                "type": "string",
+                "description": "dbt file name when this query is backed by a dbt model."
+              },
+              "dbtMode": {
+                "type": "boolean",
+                "description": "Whether this query is in dbt mode."
+              },
+              "default_group_by": {
+                "type": "boolean",
+                "description": "When true, all dimensions are implicitly included in GROUP BY."
+              },
+              "dimensionIndex": {
+                "type": "number",
+                "description": "Index of the primary dimension used for result ordering."
+              },
+              "executableSQL": {
+                "type": "string",
+                "description": "Server-compiled SQL string (read-only, set by the backend)."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model field names selected for the query (dimensions + measures)."
+              },
+              "fill_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields whose missing date/time values should be filled with nulls to create continuous series."
+              },
+              "filters": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Query filters keyed by filter ID."
+              },
+              "filtersUsedInSql": {
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "case_insensitive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "CONTAINS",
+                            "ENDS_WITH",
+                            "STARTS_WITH",
+                            "EQUALS",
+                            "IS_EMPTY",
+                            "SQL_LIKE"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_inclusive": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "LESS_THAN",
+                            "GREATER_THAN",
+                            "EQUALS",
+                            "BETWEEN"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "number"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
+                          }
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type",
+                        "values"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "isFiscal": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "IS_ON_DAY_OF_WEEK",
+                            "IS_ON_DAY_OF_QUARTER",
+                            "IS_IN_MONTH_OF_YEAR",
+                            "IS_ON_DAY_OF_YEAR",
+                            "IS_AT_HOUR_OF_DAY",
+                            "IS_IN_QUARTER_OF_YEAR",
+                            "IS_IN_WEEK_OF_YEAR",
+                            "IS_ON_DAY_OF_MONTH",
+                            "BETWEEN",
+                            "ON_OR_AFTER",
+                            "BEFORE",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "QUERY_OFFSET"
+                          ]
+                        },
+                        "left_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "offset_interval_string": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "right_side": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "date"
+                          ]
+                        },
+                        "ui_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "ANY_TIME",
+                            "BEFORE",
+                            "BETWEEN",
+                            "MONTH_OF_YEAR",
+                            "PAST",
+                            "YEAR",
+                            "DAY",
+                            "IS_ON_DAY_OF_WEEK",
+                            "ON_OR_AFTER",
+                            "IS_IN_THE_MONTH",
+                            "IS_IN_THE_QUARTER",
+                            "IS_IN_THE_FISCAL_QUARTER",
+                            "IS_IN_THE_FISCAL_YEAR",
+                            "TIME_FOR_INTERVAL_DURATION",
+                            "TIME_FOR_UNIT_DURATION",
+                            "CUSTOM",
+                            null
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "null"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "treat_nulls_as_false": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "boolean"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "disregard_limit": {
+                          "type": "boolean"
+                        },
+                        "field_name": {
+                          "type": "string"
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "query_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "query"
+                          ]
+                        },
+                        "view_query": {
+                          "type": "object",
+                          "properties": {
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "filters": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "default": {}
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "sorts": {
+                              "type": "array",
+                              "items": {},
+                              "default": []
+                            },
+                            "table": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fields"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_attribute"
+                          ]
+                        },
+                        "user_attribute_name": {
+                          "type": "string"
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "user_attribute_name"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "cancel_query_filter": {
+                          "type": "boolean"
+                        },
+                        "ignore_if_unjoinable": {
+                          "type": "boolean"
+                        },
+                        "conjunction": {
+                          "type": "string",
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ]
+                        },
+                        "filters": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CompositeFilter"
+                          }
+                        },
+                        "is_negative": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "composite"
+                          ]
+                        },
+                        "appliedLabels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "base_view": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "filterControlType": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "multiValueEquals",
+                                "singleValueEquals"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "singleDay",
+                                "timeframe"
+                              ]
+                            }
+                          ]
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "topic": {
+                          "type": "string"
+                        },
+                        "watchedContainerIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "conjunction",
+                        "filters",
+                        "type"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
+                },
+                "description": "Filters that were embedded directly in raw SQL (read-only)."
+              },
+              "join_paths_from_topic_name": {
+                "type": "string",
+                "description": "Topic name that determines join path precedence for parsed SQL queries."
+              },
+              "join_via_map": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "description": "Virtual topic join path overrides, keyed by view name to ordered join path."
+              },
+              "limit": {
+                "type": "number",
+                "description": "Row limit for the query."
+              },
+              "manualSort": {
+                "type": "boolean",
+                "description": "When true, the user has explicitly set a custom sort order."
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "order": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "description": "Per-field display metadata (format, label, order)."
+              },
+              "offset": {
+                "type": "number",
+                "description": "Row offset for pagination."
+              },
+              "parsed": {
+                "type": "boolean",
+                "description": "Whether this raw SQL query has been parsed into a semantic query."
+              },
+              "periodOverPeriodTransposed": {
+                "type": "boolean",
+                "description": "Whether the period-over-period comparison columns are transposed."
+              },
+              "period_over_period_computations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "date_filter_field_name": {
+                      "type": "string",
+                      "description": "The date dimension field this comparison is anchored to."
+                    },
+                    "date_filter_id": {
+                      "type": "string",
+                      "description": "ID of the date filter being offset (if backed by a dashboard filter)."
+                    },
+                    "is_dynamic_previous_period": {
+                      "type": "boolean",
+                      "description": "When true, the previous period is calculated dynamically relative to the current filter range."
+                    },
+                    "periods_ago": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "How many periods back to compare (e.g. 1 = previous period). Null if not set."
+                    },
+                    "time_unit_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Time grain for the offset (e.g. \"month\", \"year\"). Null if not set."
+                    }
+                  },
+                  "required": [
+                    "date_filter_field_name",
+                    "periods_ago",
+                    "time_unit_name"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Period-over-period comparison configurations."
+              },
+              "pivots": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names to pivot on (columns become values)."
+              },
+              "rewriteSql": {
+                "type": "boolean",
+                "description": "When true, the backend should rewrite/optimize the SQL."
+              },
+              "row_totals": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "aggregation"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "description": "Row-level aggregation totals, keyed by field name."
+              },
+              "sorts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "column_name": {
+                      "type": "string",
+                      "description": "The model field name to sort by."
+                    },
+                    "is_column_sort": {
+                      "type": "boolean",
+                      "description": "When true, this sort targets a pivoted column rather than a row dimension."
+                    },
+                    "pivot_value_map": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": "Maps pivot field names to specific pivot values, scoping the sort to a single pivot column."
+                    },
+                    "sort_descending": {
+                      "type": "boolean",
+                      "description": "When true, sort order is descending."
+                    },
+                    "subtotal_sort": {
+                      "type": "string",
+                      "description": "Field name whose subtotal row should be used as the sort key."
+                    }
+                  },
+                  "required": [
+                    "column_name",
+                    "sort_descending"
+                  ],
+                  "additionalProperties": {}
+                },
+                "description": "Sort clauses applied to the query result set."
+              },
+              "sqlSortsEnabled": {
+                "type": "boolean",
+                "description": "Whether user-created sorts are enabled on a raw SQL query."
+              },
+              "staticQueryReferences": {
+                "type": "object",
+                "additionalProperties": {},
+                "description": "Pre-computed query references for AI chat context. Inner shape is `OmniQuery & { model_id: string }`; left as `unknown` to avoid a recursive zod schema. Validated structurally by consumers when they execute the referenced sub-queries."
+              },
+              "table": {
+                "type": "string",
+                "description": "Base view (table) name in the model."
+              },
+              "transposed_measures": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Measure field names that have been transposed into rows."
+              },
+              "userEditedSQL": {
+                "type": "string",
+                "description": "User-authored raw SQL (empty string when not in SQL mode)."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for migration support."
+              }
+            },
+            "required": [
+              "calculations",
+              "column_totals",
+              "fields",
+              "fill_fields",
+              "filters",
+              "pivots",
+              "row_totals",
+              "sorts",
+              "table",
+              "userEditedSQL"
+            ],
+            "additionalProperties": {},
+            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). For LINKED-type tabs this field is read-only."
+          },
+          "resultConfig": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Result display configuration (column widths, frozen columns, conditional formatting, number formatting, etc.)."
+          },
+          "subTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 250,
+            "description": "User-provided tab subtitle."
+          },
+          "topicName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic (explore) this query is built on."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "blank",
+              "csv",
+              "query",
+              "dataset",
+              "spreadsheet",
+              "sql",
+              "dbt",
+              "query-view",
+              "linked",
+              "app"
+            ],
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+          },
+          "visConfig": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "chartType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "auto",
+                  "area",
+                  "areaStacked",
+                  "areaStackedPercentage",
+                  "bar",
+                  "barLine",
+                  "barGrouped",
+                  "barStacked",
+                  "barStackedPercentage",
+                  "boxplot",
+                  "code",
+                  "column",
+                  "columnGrouped",
+                  "columnStacked",
+                  "columnStackedPercentage",
+                  "heatmap",
+                  "kpi",
+                  "line",
+                  "lineColor",
+                  "map",
+                  "regionMap",
+                  "markdown",
+                  "omni-ai-summary-markdown",
+                  "pie",
+                  "funnel",
+                  "sankey",
+                  "point",
+                  "pointColor",
+                  "pointSize",
+                  "pointSizeColor",
+                  "singleRecord",
+                  "omni-spreadsheet",
+                  "summaryValue",
+                  "svgMap",
+                  "table",
+                  null
+                ],
+                "description": "High-level chart type (e.g. \"bar\", \"line\", \"area\")."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names used in the visualization axes/series."
+              },
+              "version": {
+                "type": "number",
+                "description": "Schema version for vis config migration."
+              },
+              "visConfig": {
+                "type": "object",
+                "properties": {
+                  "visType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "vegalite",
+                      "omni-ai-summary-markdown",
+                      "basic",
+                      "omni-kpi",
+                      "map",
+                      "omni-markdown",
+                      "funnel",
+                      "sankey",
+                      "single-record",
+                      "svg-map",
+                      "omni-spreadsheet",
+                      "spreadsheet-tab",
+                      "summary-value",
+                      "omni-table",
+                      "app",
+                      null
+                    ],
+                    "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
+                  }
+                },
+                "additionalProperties": {},
+                "description": "Inner visualization config — structure varies by visType."
+              }
+            },
+            "additionalProperties": {},
+            "description": "Visualization configuration for the tile."
+          },
+          "sourceQueryPresentationKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[1-9][0-9]*$",
+            "description": "For LINKED-type tabs, the record key — the same identifier used as a `queryPresentations.data` key — of the source tile whose query this tab reuses. Null for all other tab types. This is a tile record key, NOT a positional index into `order`."
+          }
+        },
+        "required": [
+          "aiConfig",
+          "automaticVis",
+          "description",
+          "filterOrder",
+          "isSql",
+          "name",
+          "prefersChart",
+          "query",
+          "resultConfig",
+          "subTitle",
+          "topicName",
+          "type",
+          "visConfig",
+          "sourceQueryPresentationKey"
+        ]
+      },
+      "SettingsReadExternal": {
+        "type": "object",
+        "properties": {
+          "crossfilterEnabled": {
+            "type": "boolean",
+            "description": "When true, clicking a value in one tile filters all other tiles on the dashboard."
+          },
+          "customText": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "queryError": {
+                "type": "string",
+                "description": "Custom text shown when a query errors, replacing the default error text."
+              },
+              "queryNoResults": {
+                "type": "string",
+                "description": "Custom text shown when a query returns no results, replacing the default empty state."
+              }
+            },
+            "description": "Custom text replacing default UI strings on the dashboard, e.g. when queries error or return no results."
+          },
+          "facetFilters": {
+            "type": "boolean",
+            "description": "When true, dashboard filters are applied per-facet when faceting is active."
+          },
+          "refreshInterval": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Auto-refresh interval in seconds. Null disables auto-refresh."
+          },
+          "runQueriesOn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "current-page",
+              "all-pages",
+              null
+            ],
+            "description": "Controls whether dashboard queries execute on the visible page or across all pages."
+          }
+        },
+        "required": [
+          "crossfilterEnabled",
+          "customText",
+          "facetFilters",
+          "refreshInterval",
+          "runQueriesOn"
+        ]
+      },
+      "DocumentsV2PatchDraftResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "draftIdentifier": {
+            "type": "string",
+            "description": "Identifier of the draft the patch was applied to."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Published document identifier the draft targets."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "description",
+          "draftIdentifier",
+          "identifier",
+          "name"
+        ]
+      },
+      "DocumentsV2CreateDraftBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DocumentsV2PatchDraftBody"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "branchId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Branch the draft is created on. Omit for a draft on the main (unpublished) workspace."
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "DocumentsV2PatchDraftBody": {
+        "type": "object",
+        "properties": {
+          "containers": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Containers"
+              },
+              {
+                "description": "Container layout. When present, fully replaces the existing layout."
+              }
+            ]
+          },
+          "controls": {
+            "$ref": "#/components/schemas/ControlsPatchExternal"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 254,
+            "description": "Document name."
+          },
+          "queryPresentations": {
+            "$ref": "#/components/schemas/QueryPresentationsPatchExternal"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsPatchExternal"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Caller-supplied description of what this patch changes, written to the history audit trail. When absent, the server generates one from the touched sections."
+          }
+        },
+        "additionalProperties": false
+      },
+      "DocumentsV2PublishDraftResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Document description."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Published document identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "description",
+          "identifier",
+          "name"
+        ]
+      },
       "EmbedSsoGenerateSessionResponse": {
         "type": "object",
         "properties": {
@@ -3062,6 +24298,524 @@
         "required": [
           "externalId",
           "name"
+        ]
+      },
+      "EvalPromptSetsListResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_sets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalPromptSetListItem"
+            },
+            "description": "Prompt sets matching the query, sorted alphabetically by name."
+          }
+        },
+        "required": [
+          "prompt_sets"
+        ]
+      },
+      "EvalPromptSetListItem": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description of the prompt set.",
+            "example": "Regression suite for the orders topic"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the prompt set.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the prompt set has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this prompt set is bound to.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the prompt set.",
+            "example": "Orders regression"
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe identifier for the prompt set. Unique per `model_id`.",
+            "example": "orders-regression"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was last updated.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "latest_run_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp of the most recent run on this prompt set, if any.",
+            "example": "2025-01-15T10:05:00.000Z"
+          },
+          "prompt_count": {
+            "type": "integer",
+            "description": "Number of prompts in the set.",
+            "example": 12
+          }
+        },
+        "required": [
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "name",
+          "slug",
+          "updated_at",
+          "latest_run_at",
+          "prompt_count"
+        ]
+      },
+      "EvalApiError400": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Bad Request: name: Required"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 400
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError401": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Unauthorized: Missing or invalid API key"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 401
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError403": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "AI eval requires at least Querier access on the model"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 403
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalApiError404": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Prompt set not found"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 404
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalPromptSetsCreateResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
+        ]
+      },
+      "EvalPromptSet": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable description of the prompt set.",
+            "example": "Regression suite for the orders topic"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the prompt set.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "is_archived": {
+            "type": "boolean",
+            "description": "Whether the prompt set has been archived.",
+            "example": false
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this prompt set is bound to.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the prompt set.",
+            "example": "Orders regression"
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalPrompt"
+            },
+            "description": "Prompts that make up the set."
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe identifier for the prompt set. Unique per `model_id`.",
+            "example": "orders-regression"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt set was last updated.",
+            "example": "2025-01-15T10:00:00.000Z"
+          }
+        },
+        "required": [
+          "created_at",
+          "description",
+          "id",
+          "is_archived",
+          "model_id",
+          "name",
+          "prompts",
+          "slug",
+          "updated_at"
+        ]
+      },
+      "EvalPrompt": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt was created.",
+            "example": "2025-01-15T10:00:00.000Z"
+          },
+          "expectation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The expectation the analysis judge scores the analysis against, or null when none was set.",
+            "example": "The top product by revenue should be Aniseed Syrup."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the prompt.",
+            "example": "770e8400-e29b-41d4-a716-446655440002"
+          },
+          "prompt_text": {
+            "type": "string",
+            "description": "The natural language prompt text the AI is evaluated on.",
+            "example": "What are the top 5 products by revenue?"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp when the prompt was last updated.",
+            "example": "2025-01-15T10:00:00.000Z"
+          }
+        },
+        "required": [
+          "created_at",
+          "expectation",
+          "id",
+          "prompt_text",
+          "updated_at"
+        ]
+      },
+      "EvalPromptSetsCreateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024,
+            "description": "Optional human-readable description of the prompt set. Max 1024 characters.",
+            "example": "Regression suite for the orders topic"
+          },
+          "model_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model this prompt set is bound to.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Human-readable name for the prompt set. 255 characters or fewer.",
+            "example": "Orders regression"
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "expectation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "maxLength": 16000,
+                  "description": "Optional expectation the analysis judge scores the analysis against. Max 16000 characters.",
+                  "example": "The top product by revenue should be Aniseed Syrup."
+                },
+                "prompt_text": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 8000,
+                  "description": "The natural language prompt text. Max 8000 characters.",
+                  "example": "What are the top 5 products by revenue?"
+                }
+              },
+              "required": [
+                "prompt_text"
+              ]
+            },
+            "maxItems": 25,
+            "default": [],
+            "description": "Initial prompts for the set. Defaults to an empty list. At most 25 prompts."
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 255,
+            "pattern": "^[a-z][a-z0-9-]*$",
+            "description": "URL-safe identifier for the prompt set. Must be unique per `model_id` and match `^[a-z][a-z0-9-]*$`. Max 255 characters.",
+            "example": "orders-regression"
+          }
+        },
+        "required": [
+          "model_id",
+          "name",
+          "slug"
+        ]
+      },
+      "EvalPromptSetsGetResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
+        ]
+      },
+      "EvalPromptSetsUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
+        ]
+      },
+      "EvalApiError422": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "A prompt being updated does not belong to this prompt set"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 422
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalPromptSetsUpdateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024,
+            "description": "New description for the prompt set. Pass `null` to clear. Max 1024 characters."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "New human-readable name for the prompt set. 255 characters or fewer."
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "expectation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "maxLength": 16000,
+                  "description": "Optional expectation the analysis judge scores the analysis against. Pass `null` to clear. Max 16000 characters.",
+                  "example": "The top product by revenue should be Aniseed Syrup."
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Existing prompt id. When provided, updates that prompt; when omitted, a new prompt is created. Prompts not included in this list are removed."
+                },
+                "prompt_text": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 8000,
+                  "description": "Updated or new prompt text. Max 8000 characters.",
+                  "example": "What are the top 10 products by revenue this quarter?"
+                }
+              },
+              "required": [
+                "prompt_text"
+              ]
+            },
+            "maxItems": 25,
+            "description": "Full desired set of prompts after the update. Prompts omitted from this list are deleted; new prompts (no `id`) are appended in body order. Existing prompts retain their original position — reordering is not supported on this endpoint. At most 25 prompts total."
+          }
+        }
+      },
+      "EvalPromptSetsDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "cancelled_job_count": {
+            "type": "integer",
+            "description": "Number of in-flight agentic jobs associated with this prompt set that were cancelled as part of the archive.",
+            "example": 0
+          },
+          "is_archived": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always `true` on success — archives the prompt set."
+          }
+        },
+        "required": [
+          "cancelled_job_count",
+          "is_archived"
+        ]
+      },
+      "EvalApiError500": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "Archive committed but a run-cancellation failed; retry to complete"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 500
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "EvalPromptSetsUnarchiveResponse": {
+        "type": "object",
+        "properties": {
+          "prompt_set": {
+            "$ref": "#/components/schemas/EvalPromptSet"
+          }
+        },
+        "required": [
+          "prompt_set"
         ]
       },
       "FoldersListResponse": {
@@ -4405,7 +26159,24 @@
         "properties": {
           "aggregateType": {
             "type": "string",
-            "description": "Aggregate type for measures"
+            "enum": [
+              "AVERAGE",
+              "COUNT",
+              "COUNT_DISTINCT",
+              "LIST",
+              "MAX",
+              "MIN",
+              "SUM",
+              "MEDIAN",
+              "PERCENTILE",
+              "AVERAGE_DISTINCT_ON",
+              "SUM_DISTINCT_ON",
+              "MEDIAN_DISTINCT_ON",
+              "PERCENTILE_DISTINCT_ON",
+              "SEMANTIC_VIEW_AGG"
+            ],
+            "description": "Aggregate type for measures. Setting this property promotes the field to a measure (written under `measures:`); omit it to create a dimension (written under `dimensions:`). Values must be uppercase canonical names.",
+            "example": "SUM"
           },
           "aiContext": {
             "type": "string",
@@ -4456,7 +26227,8 @@
         "required": [
           "fieldName",
           "viewName"
-        ]
+        ],
+        "additionalProperties": false
       },
       "ModelsRefreshResponse": {
         "type": "object",
@@ -4541,6 +26313,11 @@
           "commitMessage": {
             "type": "string",
             "description": "Commit message for git sync"
+          },
+          "deleteViewsAndTopicsMissingFromSource": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), views and topics in the target model that are missing from the migrated source are deleted (the source is treated as the complete model). When false, they are kept (inherited) instead — useful when the source git ref may be missing objects that exist in omni but not in git, e.g. a newly synced schema."
           },
           "gitRef": {
             "type": "string",
@@ -5482,6 +27259,11 @@
             "type": "string",
             "description": "Optional branch ID"
           },
+          "creator_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Restrict replacement to documents created by this user (user ID). Unknown IDs return 400."
+          },
           "find": {
             "type": "string",
             "minLength": 1,
@@ -5580,7 +27362,7 @@
               "extension",
               "staged",
               "merged",
-              "history"
+              "fully-resolved"
             ],
             "default": "combined",
             "description": "IDE mode for YAML operations"
@@ -5612,6 +27394,50 @@
           "yaml"
         ],
         "additionalProperties": false
+      },
+      "AiAgentActionsResponse": {
+        "type": "object",
+        "properties": {
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiAgentAction"
+            },
+            "description": "AI agent actions in display order: sample queries first, then skills. Topic-level entries follow model-level ones, and skills are deduped by id with topic skills winning over model skills."
+          }
+        },
+        "required": [
+          "records"
+        ]
+      },
+      "AiAgentAction": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "sample",
+              "skill"
+            ],
+            "description": "Source of the entry: `sample` for `sample_queries` (model- or topic-level) and `skill` for `skills` (model- or topic-level).",
+            "example": "skill"
+          },
+          "label": {
+            "type": "string",
+            "description": "Short, human-readable name for the action — chip text in client UIs and the visible \"prompt\" on the answer card.",
+            "example": "Revenue trends"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Submit this string verbatim as the `prompt` on `POST /api/v1/ai/jobs`. For sample queries this is the raw prompt; for skills it is a pre-formatted wrapper around the skill's input.",
+            "example": "Skill:\nShow me the recent revenue trends grouped by month…"
+          }
+        },
+        "required": [
+          "kind",
+          "label",
+          "prompt"
+        ]
       },
       "QueryRunResponse": {
         "type": "object",
@@ -5710,7 +27536,7 @@
           "userId": {
             "type": "string",
             "format": "uuid",
-            "description": "User ID to execute the query as (for row-level security). Only valid for org-scoped API keys.",
+            "description": "Alternate location for the `?userId=` query parameter. Prefer the query parameter — this body field exists for backwards compatibility. Supplying both forms results in a 400. Only valid for org-scoped API keys; when set, the user's attributes are applied for row-level security and connection-environment switching.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           }
         }
@@ -5926,7 +27752,7 @@
             "example": false
           },
           "filterConfig": {
-            "description": "Applied dashboard filter configuration"
+            "description": "The effective dashboard filter configuration that the schedule will run with: the dashboard's current default filters merged under the schedule's persisted overrides, with any keys no longer present on the dashboard dropped. This matches what is shown when the schedule is opened in the Edit Delivery panel, and may differ from the schedule's persisted filter configuration."
           },
           "id": {
             "type": "string",
@@ -6632,6 +28458,76 @@
                     {
                       "type": "object",
                       "properties": {
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                }
+                              },
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {}
+                              }
+                            ]
+                          }
+                        },
+                        "urn:omni:params:1.0:UserAttribute": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                }
+                              },
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {}
+                              }
+                            ]
+                          }
+                        },
                         "active": {
                           "type": "boolean"
                         },
@@ -7412,6 +29308,7 @@
           }
         },
         "required": [
+          "file",
           "modelId"
         ]
       },
@@ -7981,7 +29878,7 @@
         },
         "responses": {
           "200": {
-            "description": "Query generated successfully. If runQuery is true (default), includes execution results. Check the error field — a 200 response may still contain a partial error if the query was generated but execution failed.",
+            "description": "Query generated successfully. If runQuery is true (default), includes execution results. Check the error field — a 200 response may still contain a partial error if the query was generated but execution failed. When the organization is over its AI downgrade threshold the response also carries `downgradedModelTier` naming the cheaper tier the query was generated with.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8006,6 +29903,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "AI is unavailable because the organization is over its AI credit limit. The body carries the stable reason code `shutoff`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditShutoffError"
                 }
               }
             }
@@ -8188,6 +30095,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -8565,6 +30473,191 @@
         }
       }
     },
+    "/api/v1/ai/branding": {
+      "get": {
+        "description": "Returns the organization's AI helper branding — display name, optional custom logo URL, and copy used on AI helper landing surfaces (headline, body, prompt placeholder). Falls back to Omni's defaults when the organization hasn't configured custom branding, so the response is always populated. Used by client apps (iOS, embeds) to render the AI helper with the org's chosen identity.",
+        "operationId": "aiBranding",
+        "summary": "Get AI helper branding",
+        "tags": [
+          "AI"
+        ],
+        "responses": {
+          "200": {
+            "description": "AI branding retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiBrandingResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI access is required to view AI helper branding (no model in the org grants USE_AI to the caller).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/conversations": {
+      "get": {
+        "description": "List the user's recent AI conversations, ordered by most-recent activity. Each record includes the conversation id (pass it back as `conversationId` on subsequent /api/v1/ai/jobs submissions to continue the thread), an optional name, and a one-line summary of the most recent prompt for display. Paginated via opaque `pageInfo.nextCursor` — pass it back as `cursor` to fetch the next page.",
+        "operationId": "aiConversationsList",
+        "summary": "List AI conversations",
+        "tags": [
+          "AI"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of conversations.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiConversationsListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/conversations/{conversationId}": {
+      "get": {
+        "description": "Return a conversation with its full message history (alternating user / assistant turns). Used by clients (iOS app, embed widgets) to restore a prior conversation in their UI.",
+        "operationId": "aiConversationDetail",
+        "summary": "Get AI conversation with messages",
+        "tags": [
+          "AI"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "conversationId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation with messages in chronological order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiConversationDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI access is required to view chat conversations (no model in the org grants USE_AI to the caller).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found. User-scoped keys also get 404 (not 403) when the conversation exists but belongs to a different user — existence of another user's conversations is not disclosed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/api-keys": {
       "get": {
         "description": "Returns all API tokens in the organization, including organization-level keys, personal access tokens, and MCP OAuth grants. Secrets are never returned. Requires organization admin permissions.",
@@ -8587,15 +30680,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -8716,9 +30809,9 @@
         }
       },
       "put": {
-        "description": "Enables or disables an organization-level API token. Personal access tokens and MCP OAuth grants do not support this operation. Requires organization admin permissions.",
+        "description": "Enables or disables an API token. Requires organization admin permissions.",
         "operationId": "apiKeysUpdate",
-        "summary": "Enable or disable an organization API token",
+        "summary": "Enable or disable an API token",
         "tags": [
           "API Tokens"
         ],
@@ -8758,7 +30851,7 @@
             }
           },
           "400": {
-            "description": "Invalid body, malformed `id`, target is not an organization token, or missing/malformed `Authorization` header"
+            "description": "Invalid body, malformed `id`, or missing/malformed `Authorization` header"
           },
           "403": {
             "description": "Invalid bearer token, or caller lacks organization admin permissions"
@@ -8931,6 +31024,11 @@
                             "description": "Whether branch environments override user attributes",
                             "example": false
                           },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "Timestamp when connection was created (ISO 8601)",
+                            "example": "2024-01-15T10:30:00Z"
+                          },
                           "database": {
                             "type": [
                               "string",
@@ -8996,7 +31094,12 @@
                             "description": "Connection display name",
                             "example": "Production Snowflake"
                           },
-                          "userAttributeNameForConnectionsEnvironments": {
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "Timestamp when connection was last updated (ISO 8601)",
+                            "example": "2024-01-15T10:30:00Z"
+                          },
+                          "userAttributeNameForConnectionEnvironments": {
                             "type": [
                               "string",
                               "null"
@@ -9022,6 +31125,7 @@
                         "required": [
                           "baseRole",
                           "branchConnectionEnvironmentOverridesUserAttr",
+                          "createdAt",
                           "database",
                           "defaultSchema",
                           "deletedAt",
@@ -9029,7 +31133,8 @@
                           "environmentConnectionSwitchesSchemaModel",
                           "id",
                           "name",
-                          "userAttributeNameForConnectionsEnvironments",
+                          "updatedAt",
+                          "userAttributeNameForConnectionEnvironments",
                           "userAttributeValuesForDefaultEnvironment"
                         ],
                         "description": "Connection object",
@@ -9351,6 +31456,191 @@
       }
     },
     "/api/v1/connections/{id}": {
+      "get": {
+        "description": "Fetch a single connection by ID.",
+        "operationId": "connectionsGet",
+        "summary": "Get connection",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Connection ID",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Connection ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "connection": {
+                      "type": "object",
+                      "properties": {
+                        "baseRole": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Default role for users on this connection",
+                          "example": "QUERIER"
+                        },
+                        "branchConnectionEnvironmentOverridesUserAttr": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether branch environments override user attributes",
+                          "example": false
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "description": "Timestamp when connection was created (ISO 8601)",
+                          "example": "2024-01-15T10:30:00Z"
+                        },
+                        "database": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Database name",
+                          "example": "analytics_db"
+                        },
+                        "defaultSchema": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Default schema for the connection",
+                          "example": "public"
+                        },
+                        "deletedAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Timestamp when connection was deleted (ISO 8601)",
+                          "example": null
+                        },
+                        "dialect": {
+                          "type": "string",
+                          "enum": [
+                            "snowflake",
+                            "bigquery",
+                            "redshift",
+                            "postgres",
+                            "mysql",
+                            "mariadb",
+                            "databricks",
+                            "databricks_lakebase",
+                            "trino",
+                            "athena",
+                            "duckdb",
+                            "motherduck",
+                            "sqlserver",
+                            "clickhouse",
+                            "singlestore"
+                          ],
+                          "description": "Database dialect type",
+                          "example": "snowflake"
+                        },
+                        "environmentConnectionSwitchesSchemaModel": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether environment connections switch schema model",
+                          "example": false
+                        },
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Unique connection identifier",
+                          "example": "550e8400-e29b-41d4-a716-446655440000"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Connection display name",
+                          "example": "Production Snowflake"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "description": "Timestamp when connection was last updated (ISO 8601)",
+                          "example": "2024-01-15T10:30:00Z"
+                        },
+                        "userAttributeNameForConnectionEnvironments": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "User attribute name used for connection environments",
+                          "example": "region"
+                        },
+                        "userAttributeValuesForDefaultEnvironment": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Default user attribute values for the base environment",
+                          "example": [
+                            "us-east",
+                            "us-west"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "baseRole",
+                        "branchConnectionEnvironmentOverridesUserAttr",
+                        "createdAt",
+                        "database",
+                        "defaultSchema",
+                        "deletedAt",
+                        "dialect",
+                        "environmentConnectionSwitchesSchemaModel",
+                        "id",
+                        "name",
+                        "updatedAt",
+                        "userAttributeNameForConnectionEnvironments",
+                        "userAttributeValuesForDefaultEnvironment"
+                      ],
+                      "description": "Connection object",
+                      "title": "Connection"
+                    }
+                  },
+                  "required": [
+                    "connection"
+                  ],
+                  "description": "Get connection response",
+                  "title": "ConnectionsGetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied — caller lacks READ on the connection"
+          },
+          "404": {
+            "description": "Connection does not exist"
+          }
+        }
+      },
       "patch": {
         "description": "Update connection settings including base role, environment user attributes, and credentials.\n\nCredential fields:\n- `passwordUnencrypted`: Update password (all dialects) or service account JSON (BigQuery)\n- `privateKey`: Add/rotate RSA keypair for Snowflake keypair authentication\n\nNote: Credentials are encrypted at rest and never returned in API responses.",
         "operationId": "connectionsUpdate",
@@ -9470,6 +31760,70 @@
           },
           "404": {
             "description": "Connection not found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Archive a connection (move to trash). Archived connections can be restored from the trash in the connection settings UI.\n\nA connection that is already archived returns 410.",
+        "operationId": "connectionsDelete",
+        "summary": "Delete connection",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Connection ID",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Connection ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection moved to trash",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Status message describing the result",
+                      "example": "Connection moved to trash."
+                    },
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when the connection was archived",
+                      "example": true
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "success"
+                  ],
+                  "description": "Archive connection response",
+                  "title": "ConnectionsDeleteResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied - connection admin role required"
+          },
+          "404": {
+            "description": "Connection not found"
+          },
+          "410": {
+            "description": "Connection has already been archived"
           }
         }
       }
@@ -9852,15 +32206,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -10174,6 +32528,11 @@
                             "description": "Timestamp when schedule was disabled (ISO 8601)",
                             "example": null
                           },
+                          "hardRefresh": {
+                            "type": "boolean",
+                            "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                            "example": false
+                          },
                           "schedule": {
                             "type": "string",
                             "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10201,6 +32560,7 @@
                           "createdAt",
                           "description",
                           "disabledAt",
+                          "hardRefresh",
                           "schedule",
                           "scheduleId",
                           "timezone",
@@ -10258,6 +32618,12 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "hardRefresh": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false (the default), it performs a soft refresh that merges newly generated views with the existing model.",
+                    "example": false
+                  },
                   "schedule": {
                     "type": "string",
                     "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10311,6 +32677,11 @@
                       "description": "Timestamp when schedule was disabled (ISO 8601)",
                       "example": null
                     },
+                    "hardRefresh": {
+                      "type": "boolean",
+                      "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                      "example": false
+                    },
                     "schedule": {
                       "type": "string",
                       "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10338,6 +32709,7 @@
                     "createdAt",
                     "description",
                     "disabledAt",
+                    "hardRefresh",
                     "schedule",
                     "scheduleId",
                     "timezone",
@@ -10429,6 +32801,11 @@
                       "description": "Timestamp when schedule was disabled (ISO 8601)",
                       "example": null
                     },
+                    "hardRefresh": {
+                      "type": "boolean",
+                      "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                      "example": false
+                    },
                     "schedule": {
                       "type": "string",
                       "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10456,6 +32833,7 @@
                     "createdAt",
                     "description",
                     "disabledAt",
+                    "hardRefresh",
                     "schedule",
                     "scheduleId",
                     "timezone",
@@ -10516,6 +32894,12 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "hardRefresh": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false (the default), it performs a soft refresh that merges newly generated views with the existing model.",
+                    "example": false
+                  },
                   "schedule": {
                     "type": "string",
                     "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10569,6 +32953,11 @@
                       "description": "Timestamp when schedule was disabled (ISO 8601)",
                       "example": null
                     },
+                    "hardRefresh": {
+                      "type": "boolean",
+                      "description": "When true, the scheduled refresh performs a hard refresh that fully discards and rebuilds the schema model. When false, it performs a soft refresh that merges newly generated views with the existing model.",
+                      "example": false
+                    },
                     "schedule": {
                       "type": "string",
                       "description": "AWS EventBridge cron expression (6 fields: minute hour day-of-month month day-of-week year). See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html",
@@ -10596,6 +32985,7 @@
                     "createdAt",
                     "description",
                     "disabledAt",
+                    "hardRefresh",
                     "schedule",
                     "scheduleId",
                     "timezone",
@@ -11048,15 +33438,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -11194,6 +33584,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11276,6 +33667,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11339,6 +33731,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11382,6 +33775,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11433,6 +33827,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -11900,7 +34295,7 @@
       }
     },
     "/api/v1/documents/{identifier}/move": {
-      "post": {
+      "put": {
         "operationId": "documentsMove",
         "summary": "Move document",
         "tags": [
@@ -12321,6 +34716,64 @@
           },
           "404": {
             "description": "Document or draft not found"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{identifier}/drafts": {
+      "get": {
+        "description": "Lists drafts for a document with branch context. By default only active drafts are returned; pass `include=archived` to also include soft-deleted drafts (retained ~7 days). Results are sorted by `createdAt` descending.",
+        "operationId": "documentsListDrafts",
+        "summary": "List document drafts",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier (either document ID or identifier slug)",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier (either document ID or identifier slug)",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated list of additional drafts to include. Only \"archived\" is recognized — when present, soft-deleted drafts (retained ~7 days) are returned alongside active drafts.",
+              "example": "archived"
+            },
+            "required": false,
+            "description": "Comma-separated list of additional drafts to include. Only \"archived\" is recognized — when present, soft-deleted drafts (retained ~7 days) are returned alongside active drafts.",
+            "name": "include",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of drafts for the document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsListDraftsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Insufficient permissions to view the document"
+          },
+          "404": {
+            "description": "Document not found"
           }
         }
       }
@@ -12750,15 +35203,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -12840,6 +35293,438 @@
         }
       }
     },
+    "/api/v1/documents/{identifier}/favorites": {
+      "get": {
+        "description": "Lists users who have favorited the document, paginated and sorted by favoritedAt. Document-centric counterpart to GET /api/v1/documents?include=onlyFavorites: useful for migration scripts that need to preserve favorites when replacing documents, without iterating every user in the organization.",
+        "operationId": "documentsListFavorites",
+        "summary": "List users who favorited the document",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier (either document ID or identifier slug)",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier (either document ID or identifier slug)",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc",
+              "description": "Sort direction by favoritedAt (default: asc — oldest first)",
+              "example": "desc"
+            },
+            "required": false,
+            "description": "Sort direction by favoritedAt (default: asc — oldest first)",
+            "name": "sortDirection",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of users who favorited the document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsListFavoritesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied — caller lacks MANAGER on the document, or used a user-scoped (personal access token) API key (org-scoped only)"
+          },
+          "404": {
+            "description": "Document not found"
+          }
+        }
+      }
+    },
+    "/api/v2/documents": {
+      "post": {
+        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
+        "operationId": "documentsV2Create",
+        "summary": "Create document",
+        "tags": [
+          "Documents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2CreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Document created and published successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2CreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or schema validation error (e.g. unknown top-level field, name too long, query presentation cap exceeded), or the `identifier` is already in use."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to create a document on this model."
+          },
+          "404": {
+            "description": "Base model or branch not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}": {
+      "get": {
+        "description": "Read the document's current draft state (or the published state if no draft exists). Returns the full `DocumentsV2ReadResponse` shape.\n\nThe response is structured so a caller can take it verbatim and submit it as the body of the draft PATCH routes. Tiles in `queryPresentations.data` are keyed by a stable record key (e.g. `\"1\"`, `\"2\"`) — the server uses that key to identify existing tiles for updates, so callers do not need to track or send any other identifier. Control IDs and container `instanceKey` / `referenceKey` values also round-trip unchanged.",
+        "operationId": "documentsV2Get",
+        "summary": "Read document state",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document state. A workbook-only document (no dashboard layout yet) returns only the workbook-scoped fields (`name`, `description`, `queryPresentations`); the dashboard-scoped `containers`, `controls`, and `settings` are omitted until a layout exists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2ReadResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to read the document."
+          },
+          "404": {
+            "description": "Document not found."
+          },
+          "422": {
+            "description": "The document cannot be read as a dashboard: a classic-layout dashboard (upgrade to the advanced layout first) or an app document."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft": {
+      "patch": {
+        "description": "Create a new draft on the published document and apply the patch. No auto-publish — the response includes the new `draftIdentifier` for follow-up calls.\n\nPass an optional `branchId` to attach the draft to a branch; omit it for a draft on the main (unpublished) workspace.",
+        "operationId": "documentsV2PatchDraft",
+        "summary": "Create draft and patch document",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2CreateDraftBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Draft created and patch applied successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or schema validation error (e.g. unknown top-level field, name too long, query presentation cap exceeded)."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the document."
+          },
+          "404": {
+            "description": "Document or branch not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document (drafts only attach to published documents), or a concurrent request just created the layout for this document — retry."
+          },
+          "422": {
+            "description": "The document cannot satisfy the patch: a classic-layout dashboard (upgrade to the advanced layout first), an app document, or a workbook-only document patched without a `containers` payload (or with an empty one)."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft/{draftIdentifier}": {
+      "get": {
+        "description": "Read the named draft's state. Returns the full `DocumentsV2ReadResponse` shape — same as the live-state read endpoint.\n\nThe response is structured so a caller can take it verbatim and submit it as the body of the draft PATCH routes. Tiles in `queryPresentations.data` are keyed by a stable record key (e.g. `\"1\"`, `\"2\"`) — the server uses that key to identify existing tiles for updates, so callers do not need to track or send any other identifier. Control IDs and container `instanceKey` / `referenceKey` values also round-trip unchanged.",
+        "operationId": "documentsV2GetDraft",
+        "summary": "Read draft state",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2ReadResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to read the draft."
+          },
+          "404": {
+            "description": "Document or draft not found."
+          },
+          "422": {
+            "description": "The draft cannot be read as a dashboard: a classic-layout dashboard (upgrade to the advanced layout first) or an app document."
+          }
+        }
+      },
+      "patch": {
+        "description": "Apply the patch to an existing draft addressed by `draftIdentifier`. Pure apply — no draft creation, no publish.",
+        "operationId": "documentsV2PatchDraftByIdentifier",
+        "summary": "Patch draft",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2PatchDraftBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Patch applied to draft successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or schema validation error (e.g. unknown top-level field, name too long, query presentation cap exceeded)."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the draft."
+          },
+          "404": {
+            "description": "Document or draft not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document (drafts only attach to published documents), or a concurrent request just created the layout for this document — retry."
+          },
+          "422": {
+            "description": "The draft cannot satisfy the patch: a classic-layout dashboard (upgrade to the advanced layout first), an app document, or a workbook-only draft patched without a `containers` payload (or with an empty one)."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft/publish": {
+      "post": {
+        "description": "Publish the document's current main (non-branch) draft, promoting it to the published version. No request body — the draft is consumed, so the response echoes the now-published document metadata.\n\nOnly the main draft is publishable here; a branch-attached draft is published by merging its branch (`POST /api/v1/models/{modelId}/branch/{branchName}/merge`), so a document with no main draft returns 404. Documents that require a pull request to publish return 400.",
+        "operationId": "documentsV2PublishDraft",
+        "summary": "Publish draft",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
+            "name": "identifier",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft published successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PublishDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The document requires a pull request to publish (response detail: \"Can't publish because this document can only be edited through a branch\")."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to publish the draft."
+          },
+          "404": {
+            "description": "Document not found, or it has no main draft to publish (a branch-attached draft is published by merging its branch)."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document."
+          }
+        }
+      }
+    },
     "/api/v1/embed/sso/generate-session": {
       "post": {
         "operationId": "embedSsoGenerateSession",
@@ -12875,6 +35760,489 @@
           },
           "403": {
             "description": "Permission denied - embed not enabled"
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/prompt-sets": {
+      "get": {
+        "description": "List eval prompt sets, sorted alphabetically by name. When `model_ids` is omitted, returns prompt sets for every shared model the caller can access. Requires at least the Querier role on each requested model.",
+        "operationId": "aiEvalPromptSetsList",
+        "summary": "List eval prompt sets",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When `true`, returns archived prompt sets instead of active ones. Defaults to `false`.",
+              "example": "false"
+            },
+            "required": false,
+            "description": "When `true`, returns archived prompt sets instead of active ones. Defaults to `false`.",
+            "name": "archived",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "description": "Optional list of model IDs to filter prompt sets by. When omitted, returns prompt sets for every model the caller can access. Supply multiple times to filter by more than one model (e.g., `?model_ids=A&model_ids=B`)."
+            },
+            "required": false,
+            "description": "Optional list of model IDs to filter prompt sets by. When omitted, returns prompt sets for every model the caller can access. Supply multiple times to filter by more than one model (e.g., `?model_ids=A&model_ids=B`).",
+            "name": "model_ids",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of prompt sets, sorted alphabetically by name.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query params (e.g. `model_ids` contains a non-UUID, or `archived` is not `true`/`false`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions. The caller must have at least the Querier role on each requested model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No eval-accessible models for this caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new eval prompt set bound to a shared model. Initial prompts can be supplied; additional prompts can be added later via PATCH.",
+        "operationId": "aiEvalPromptSetsCreate",
+        "summary": "Create an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalPromptSetsCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Prompt set created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions. The caller must have at least the Querier role on the model.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/prompt-sets/{promptSetId}": {
+      "get": {
+        "description": "Get a single prompt set with all of its prompts.",
+        "operationId": "aiEvalPromptSetsGet",
+        "summary": "Get an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt set details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsGetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `promptSetId` — must be a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a prompt set's name, description, and/or prompts. When `prompts` is supplied, it fully replaces the existing list — existing prompts omitted from the list are deleted, entries without an `id` are created, and entries with a matching `id` are updated in place.",
+        "operationId": "aiEvalPromptSetsUpdate",
+        "summary": "Update an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalPromptSetsUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prompt set updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsUpdateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "A `prompts[].id` in the request does not belong to this prompt set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError422"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Archive (soft-delete) a prompt set. As part of the archive, Omni attempts to cancel every in-flight agentic job associated with the set; the returned `cancelled_job_count` reports how many were cancelled. The archive is committed before run cancellations start. Cancellation is best-effort — the database cancel is authoritative, but the Redis stop-signal that halts a running worker can lag. If the archive itself or a whole run-cancellation fails, the endpoint returns 500, but the prompt set is already archived. The call is idempotent — retrying drains any remaining runs.",
+        "operationId": "aiEvalPromptSetsArchive",
+        "summary": "Archive an eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt set archived successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `promptSetId` — must be a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Archive committed but a run-cancellation failed; the set is already archived — safe to retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/eval/prompt-sets/{promptSetId}/unarchive": {
+      "post": {
+        "description": "Restore an archived prompt set.",
+        "operationId": "aiEvalPromptSetsUnarchive",
+        "summary": "Restore an archived eval prompt set",
+        "tags": [
+          "AI Eval"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique identifier of the eval prompt set.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "The unique identifier of the eval prompt set.",
+            "name": "promptSetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt set restored successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalPromptSetsUnarchiveResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `promptSetId` — must be a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt set not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError404"
+                }
+              }
+            }
           }
         }
       }
@@ -13437,6 +36805,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -13540,6 +36909,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -13606,6 +36976,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -14811,6 +38182,43 @@
             "description": "Branch ID for branch-based schema refresh. Required when branch-based schema refresh is enabled for the connection. Must not be provided when branch-based schema refresh is not enabled.",
             "name": "branch_id",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When true (the default), performs a hard refresh that fully discards and rebuilds the schema model. When false, performs a soft refresh that merges newly generated views with the existing model. Must be set to false when `schemas` or `tables` filters are provided.",
+              "example": "false"
+            },
+            "required": false,
+            "description": "When true (the default), performs a hard refresh that fully discards and rebuilds the schema model. When false, performs a soft refresh that merges newly generated views with the existing model. Must be set to false when `schemas` or `tables` filters are provided.",
+            "name": "hard_refresh",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional comma-separated list of schemas to refresh selectively. Only the listed schemas are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+              "example": "public,analytics"
+            },
+            "required": false,
+            "description": "Optional comma-separated list of schemas to refresh selectively. Only the listed schemas are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+            "name": "schemas",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional comma-separated list of tables to refresh selectively. Only the listed tables are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+              "example": "public.orders,public.customers"
+            },
+            "required": false,
+            "description": "Optional comma-separated list of tables to refresh selectively. Only the listed tables are reloaded; the rest of the schema model is preserved. Requires `hard_refresh=false`.",
+            "name": "tables",
+            "in": "query"
           }
         ],
         "responses": {
@@ -14825,7 +38233,7 @@
             }
           },
           "400": {
-            "description": "Bad request - branch_id required when branch-based schema refresh is enabled, or branch_id not allowed when it is not enabled"
+            "description": "Bad request - branch_id required when branch-based schema refresh is enabled, branch_id not allowed when it is not enabled, or hard refresh requested with selective schemas/tables filters"
           },
           "401": {
             "description": "Authentication required"
@@ -15050,15 +38458,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -15691,6 +39099,17 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
+              "description": "Filter to documents created by this user (user ID). Unknown IDs return 400."
+            },
+            "required": false,
+            "description": "Filter to documents created by this user (user ID). Unknown IDs return 400.",
+            "name": "creator_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "minLength": 1,
               "description": "Optional value to find. Used with find_type to scope validation to a single view, field, or topic. Requires find_type to be provided."
             },
@@ -15805,6 +39224,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Target user membership ID (for org-scoped API keys)"
             },
             "required": false,
@@ -15897,7 +39317,7 @@
                 "extension",
                 "staged",
                 "merged",
-                "history"
+                "fully-resolved"
               ],
               "default": "combined",
               "description": "IDE mode for YAML operations"
@@ -16084,7 +39504,7 @@
                 "extension",
                 "staged",
                 "merged",
-                "history"
+                "fully-resolved"
               ],
               "default": "combined",
               "description": "IDE mode for YAML operations"
@@ -16124,12 +39544,70 @@
         }
       }
     },
+    "/api/v1/models/{modelId}/ai-agent-actions": {
+      "get": {
+        "description": "Returns the AI agent actions configured for this model — a unified list of sample queries and skills suitable for surfacing as suggested prompts above an AI prompt input. Sample queries come from both `model.sample_queries` and each topic's `sample_queries`; skills come from `model.skills` and each topic's `skills`, deduped by id with topic skills overriding model skills. Each entry's `prompt` is ready to submit verbatim to `POST /api/v1/ai/jobs`.",
+        "operationId": "modelAiAgentActions",
+        "summary": "Get model AI agent actions",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI agent actions in display order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiAgentActionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          },
+          "403": {
+            "description": "Caller cannot read the model."
+          },
+          "404": {
+            "description": "Model not found."
+          }
+        }
+      }
+    },
     "/api/v1/query/run": {
       "post": {
         "operationId": "queryRun",
         "summary": "Execute a semantic query",
         "tags": [
           "Query"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
         ],
         "requestBody": {
           "content": {
@@ -16248,15 +39726,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },
@@ -17118,7 +40596,7 @@
             "description": "Schedule not found"
           },
           "409": {
-            "description": "Another execution is in progress for this schedule"
+            "description": "Schedule cannot be triggered (paused, system-disabled, or another execution is in progress)"
           }
         }
       }
@@ -18026,15 +41504,15 @@
           },
           {
             "schema": {
-              "type": "number",
+              "type": "integer",
               "minimum": 1,
               "maximum": 100,
               "default": 20,
-              "description": "Number of results per page (1-100)",
+              "description": "Number of results per page (1-100, integer)",
               "example": 20
             },
             "required": false,
-            "description": "Number of results per page (1-100)",
+            "description": "Number of results per page (1-100, integer)",
             "name": "pageSize",
             "in": "query"
           },

--- a/internal/openapi/body_shorthand.go
+++ b/internal/openapi/body_shorthand.go
@@ -277,8 +277,19 @@ func applyBodyShorthand(cmd *cobra.Command, op *operationInfo, sh *BodyShorthand
 			rawBody = jsonBodyFlag
 		}
 
-		// If --body/--json-body is provided, use existing behavior
+		// If --body/--json-body is provided, use existing behavior — but
+		// reject explicitly-set shorthand flags rather than silently
+		// dropping them from the request.
 		if rawBody != "" {
+			var conflicting []string
+			for _, f := range sh.Flags {
+				if cmd.Flags().Changed(f.FlagName) {
+					conflicting = append(conflicting, "--"+f.FlagName)
+				}
+			}
+			if len(conflicting) > 0 {
+				return fmt.Errorf("%s cannot be combined with --body; include the field(s) in the JSON body instead", strings.Join(conflicting, ", "))
+			}
 			return originalRunE(cmd, args)
 		}
 

--- a/internal/openapi/body_shorthand.go
+++ b/internal/openapi/body_shorthand.go
@@ -202,6 +202,44 @@ var bodyShorthands = map[string]*BodyShorthand{
 		ExampleShort: `omni models git-sync <model-id> --commit-message "Update schema"`,
 		ExampleJSON:  `omni models git-sync <model-id> --body '{"commitMessage":"Update schema"}'`,
 	},
+
+	// v2 documents. Metadata fields are promoted to flags; the heavy nested
+	// content (containers / controls / queryPresentations / settings) stays
+	// on --body/stdin. Because a v2-get response is a valid draft PATCH body,
+	// content round-trips cleanly: v2-get <id> > doc.json, edit, then
+	// v2-patch-draft <id> --body - < doc.json and v2-publish-draft <id>.
+	"documentsV2Create": {
+		Args: []ArgMapping{
+			{Name: "model-id", FieldPath: "modelId", Description: "UUID of the model the document is built on", Transform: "string"},
+			{Name: "name", FieldPath: "name", Description: "name for the new document", Transform: "string"},
+		},
+		Flags: []FlagMapping{
+			{FlagName: "identifier", FieldPath: "identifier", Description: "identifier for the new document (server-minted if omitted)"},
+			{FlagName: "description", FieldPath: "description", Description: "document description"},
+			{FlagName: "folder-id", FieldPath: "folderId", Description: "destination folder ID (omit for the root folder)"},
+		},
+		ExampleShort: `omni documents v2-create 770e8400-e29b-41d4-a716-446655440002 "Q3 Revenue"`,
+		ExampleJSON:  `omni documents v2-create --body '{"modelId":"770e8400-...","name":"Q3 Revenue"}'`,
+	},
+	"documentsV2PatchDraft": {
+		Flags: []FlagMapping{
+			{FlagName: "name", FieldPath: "name", Description: "document name"},
+			{FlagName: "description", FieldPath: "description", Description: "document description"},
+			{FlagName: "summary", FieldPath: "summary", Description: "what this patch changes; written to the history audit trail"},
+			{FlagName: "branch-id", FieldPath: "branchId", Description: "branch the new draft is created on (omit for the main workspace)"},
+		},
+		ExampleShort: `omni documents v2-patch-draft <identifier> --name "WIP title"`,
+		ExampleJSON:  `omni documents v2-patch-draft <identifier> --body '{"name":"WIP title"}'`,
+	},
+	"documentsV2PatchDraftByIdentifier": {
+		Flags: []FlagMapping{
+			{FlagName: "name", FieldPath: "name", Description: "document name"},
+			{FlagName: "description", FieldPath: "description", Description: "document description"},
+			{FlagName: "summary", FieldPath: "summary", Description: "what this patch changes; written to the history audit trail"},
+		},
+		ExampleShort: `omni documents v2-patch-draft-by-identifier <identifier> <draft-identifier> --name "Edited"`,
+		ExampleJSON:  `omni documents v2-patch-draft-by-identifier <identifier> <draft-identifier> --body '{"name":"Edited"}'`,
+	},
 }
 
 // GetBodyShorthand returns the shorthand for an operation, or nil if none exists.
@@ -323,16 +361,14 @@ func assembleBody(sh *BodyShorthand, args []string, pathParamCount int, cmd *cob
 	}
 
 	for _, fm := range sh.Flags {
+		val, _ := cmd.Flags().GetString(fm.FlagName)
+		if val == "" {
+			continue
+		}
 		if fm.IsBool {
-			val, _ := cmd.Flags().GetString(fm.FlagName)
-			if val != "" {
-				body[fm.FieldPath] = (val == "true")
-			}
+			body[fm.FieldPath] = (val == "true")
 		} else {
-			val, _ := cmd.Flags().GetString(fm.FlagName)
-			if val != "" {
-				body[fm.FieldPath] = val
-			}
+			body[fm.FieldPath] = val
 		}
 	}
 

--- a/internal/openapi/body_shorthand_test.go
+++ b/internal/openapi/body_shorthand_test.go
@@ -534,6 +534,104 @@ func TestShorthand_ModelsGitSync_FlagsOnly(t *testing.T) {
 	}
 }
 
+func TestShorthand_DocumentsV2Create(t *testing.T) {
+	var captured APIRequest
+	exec := func(req APIRequest) error { captured = req; return nil }
+
+	op := &operationInfo{
+		Tag:         "Documents",
+		OperationID: "documentsV2Create",
+		Method:      "POST",
+		Path:        "/api/v2/documents",
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, exec)
+	cmd.SetArgs([]string{"770e8400-e29b-41d4-a716-446655440002", "Q3 Revenue", "--folder-id", "f-1", "--identifier", "q3-rev"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(captured.Body, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if body["modelId"] != "770e8400-e29b-41d4-a716-446655440002" {
+		t.Errorf("modelId = %v, want the positional model ID", body["modelId"])
+	}
+	if body["name"] != "Q3 Revenue" {
+		t.Errorf("name = %v, want 'Q3 Revenue'", body["name"])
+	}
+	if body["folderId"] != "f-1" {
+		t.Errorf("folderId = %v, want f-1", body["folderId"])
+	}
+	if body["identifier"] != "q3-rev" {
+		t.Errorf("identifier = %v, want q3-rev", body["identifier"])
+	}
+}
+
+func TestShorthand_DocumentsV2PatchDraft(t *testing.T) {
+	var captured APIRequest
+	exec := func(req APIRequest) error { captured = req; return nil }
+
+	op := &operationInfo{
+		Tag:         "Documents",
+		OperationID: "documentsV2PatchDraft",
+		Method:      "PATCH",
+		Path:        "/api/v2/documents/{identifier}/draft",
+		PathParams:  []paramInfo{{Name: "identifier", In: "path"}},
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, exec)
+	cmd.SetArgs([]string{"abc123", "--name", "WIP", "--branch-id", "b-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var body map[string]interface{}
+	json.Unmarshal(captured.Body, &body)
+	if body["name"] != "WIP" {
+		t.Errorf("name = %v, want WIP", body["name"])
+	}
+	if body["branchId"] != "b-1" {
+		t.Errorf("branchId = %v, want b-1", body["branchId"])
+	}
+}
+
+func TestShorthand_DocumentsV2PatchDraftByIdentifier(t *testing.T) {
+	var captured APIRequest
+	exec := func(req APIRequest) error { captured = req; return nil }
+
+	op := &operationInfo{
+		Tag:         "Documents",
+		OperationID: "documentsV2PatchDraftByIdentifier",
+		Method:      "PATCH",
+		Path:        "/api/v2/documents/{identifier}/draft/{draftIdentifier}",
+		PathParams:  []paramInfo{{Name: "identifier", In: "path"}, {Name: "draftIdentifier", In: "path"}},
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, exec)
+	cmd.SetArgs([]string{"abc123", "draft456", "--name", "Edited"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(captured.Path, "abc123") || !strings.Contains(captured.Path, "draft456") {
+		t.Errorf("path = %q, expected to contain both identifiers", captured.Path)
+	}
+
+	var body map[string]interface{}
+	json.Unmarshal(captured.Body, &body)
+	if body["name"] != "Edited" {
+		t.Errorf("name = %v, want Edited", body["name"])
+	}
+	if _, exists := body["draftIdentifier"]; exists {
+		t.Error("path param draftIdentifier should not appear in body")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Fallback / alias tests
 //
@@ -722,8 +820,8 @@ func TestShorthand_RegistryNotEmpty(t *testing.T) {
 	if len(bodyShorthands) == 0 {
 		t.Fatal("bodyShorthands registry is empty")
 	}
-	if len(bodyShorthands) != 16 {
-		t.Errorf("expected 16 shorthand entries, got %d", len(bodyShorthands))
+	if len(bodyShorthands) != 19 {
+		t.Errorf("expected 19 shorthand entries, got %d", len(bodyShorthands))
 	}
 }
 

--- a/internal/openapi/body_shorthand_test.go
+++ b/internal/openapi/body_shorthand_test.go
@@ -712,6 +712,60 @@ func TestShorthand_BothBodyFlagsError(t *testing.T) {
 	}
 }
 
+// Combining a promoted shorthand flag with --body is an error: the raw body
+// is sent verbatim, so a silently-dropped flag (e.g. --branch-id) would
+// produce a request the user didn't intend.
+func TestShorthand_BodyWithShorthandFlagErrors(t *testing.T) {
+	exec := func(req APIRequest) error { return nil }
+
+	op := &operationInfo{
+		Tag:         "Documents",
+		OperationID: "documentsV2PatchDraft",
+		Method:      "PATCH",
+		Path:        "/api/v2/documents/{identifier}/draft",
+		PathParams:  []paramInfo{{Name: "identifier", In: "path"}},
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, exec)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"doc-123", "--branch-id", "b-1", "--body", `{"name":"x"}`})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --branch-id is combined with --body")
+	}
+	if !strings.Contains(err.Error(), "--branch-id") {
+		t.Errorf("error = %q, want it to name --branch-id", err.Error())
+	}
+}
+
+// The conflict check also covers the hidden --json-body alias.
+func TestShorthand_JsonBodyWithShorthandFlagErrors(t *testing.T) {
+	exec := func(req APIRequest) error { return nil }
+
+	op := &operationInfo{
+		Tag:         "Documents",
+		OperationID: "documentsV2PatchDraft",
+		Method:      "PATCH",
+		Path:        "/api/v2/documents/{identifier}/draft",
+		PathParams:  []paramInfo{{Name: "identifier", In: "path"}},
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, exec)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"doc-123", "--summary", "s", "--json-body", `{"name":"x"}`})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --summary is combined with --json-body")
+	}
+	if !strings.Contains(err.Error(), "--summary") {
+		t.Errorf("error = %q, want it to name --summary", err.Error())
+	}
+}
+
 // Verify that --body still works for operations with a shorthand when
 // the user provides path params + --body but no shorthand positional arg.
 func TestShorthand_BodyWithPathParams(t *testing.T) {

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -147,6 +147,13 @@ func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*o
 			}
 		}
 
+		// Positional args follow the URL shape, not the spec's parameters
+		// array — some endpoints declare path params out of path order.
+		sort.SliceStable(info.PathParams, func(i, j int) bool {
+			return strings.Index(pathStr, "{"+info.PathParams[i].Name+"}") <
+				strings.Index(pathStr, "{"+info.PathParams[j].Name+"}")
+		})
+
 		// Check for request body
 		if op.RequestBody != nil {
 			info.HasBody = true

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -228,6 +228,54 @@ func TestGenerateCommandsFromSpec(t *testing.T) {
 	}
 }
 
+// Some endpoints declare path params in the spec's parameters array in a
+// different order than they appear in the URL (e.g. the v2 document draft
+// routes list draftIdentifier before identifier). Positional args must follow
+// the URL shape, so a generated command's arg order matches the path template
+// regardless of declaration order.
+func TestGenerateCommands_PathParamsFollowPathOrder(t *testing.T) {
+	spec := `{
+		"openapi": "3.1.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/api/v1/things/{outerId}/items/{innerId}": {
+				"get": {
+					"operationId": "testGetItem",
+					"tags": ["test"],
+					"parameters": [
+						{"name": "innerId", "in": "path", "required": true, "schema": {"type": "string"}},
+						{"name": "outerId", "in": "path", "required": true, "schema": {"type": "string"}}
+					],
+					"responses": {"200": {"description": "ok"}}
+				}
+			}
+		}
+	}`
+
+	var captured APIRequest
+	exec := func(req APIRequest) error { captured = req; return nil }
+	cmds, err := GenerateCommands([]byte(spec), exec)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	if len(cmds) != 1 || len(cmds[0].Commands()) != 1 {
+		t.Fatalf("expected 1 tag group with 1 subcommand, got %v", cmds)
+	}
+
+	sub := cmds[0].Commands()[0]
+	if sub.Use != "get-item <outerid> <innerid>" {
+		t.Errorf("Use = %q, want %q", sub.Use, "get-item <outerid> <innerid>")
+	}
+
+	// Positional args in path order must substitute into the matching slots.
+	if err := sub.RunE(sub, []string{"outer-val", "inner-val"}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if captured.Path != "/api/v1/things/outer-val/items/inner-val" {
+		t.Errorf("path = %q, want %q", captured.Path, "/api/v1/things/outer-val/items/inner-val")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Command behavior tests
 //


### PR DESCRIPTION
## Summary

Adds CLI commands for the v2 documents API, which is now **GA** — refreshed against the latest monorepo spec (no more experimental flags).

The six operations auto-generate from the embedded spec:

| Command | Operation |
|---|---|
| `omni documents v2-create <model-id> <name>` | `POST /api/v2/documents` (create + publish) |
| `omni documents v2-get <identifier>` | `GET /api/v2/documents/{identifier}` |
| `omni documents v2-get-draft <identifier> <draft-identifier>` | `GET .../draft/{draftIdentifier}` |
| `omni documents v2-patch-draft <identifier>` | `PATCH .../draft` (create draft + apply) |
| `omni documents v2-patch-draft-by-identifier <identifier> <draft-identifier>` | `PATCH .../draft/{draftIdentifier}` |
| `omni documents v2-publish-draft <identifier>` | `POST .../draft/publish` |

Since the first cut of this branch, upstream removed the one-shot `PATCH /api/v2/documents/{identifier}` in favor of the draft flow (patch a draft, then publish) and added the create and publish routes — this refresh tracks that.

Body shorthands promote metadata to flags (`--name`/`--description`/`--summary`, `--branch-id` on `v2-patch-draft`; positional `<model-id> <name>` plus `--identifier`/`--description`/`--folder-id` on `v2-create`). Heavy nested content (`containers`, `controls`, `queryPresentations`, `settings`) stays on `--body`/stdin and round-trips from a `v2-get` response. The agent-help guide documents the create/read/edit/publish workflow.

**Note:** the spec is synced from the monorepo branch `dan/api-v2-documents-ga` (drops the experimental flags upstream) ahead of its merge to main. New body fields on POST/PATCH endpoints don't appear as flags — those endpoints take `--body`.

Side-effect operations pulled in by the full sync: a new `omni ai-eval` group (`aiEvalPromptSets*`), plus `aiBranding`, `aiConversationDetail`, `aiConversationsList`, `connectionsDelete`, `connectionsGet`, `documentsListDrafts`, `documentsListFavorites`, `modelAiAgentActions`.

## Test plan

- [x] `make build` and `make test` pass
- [x] `omni documents --help` shows all six v2 commands (no `v2-patch`), with GA summaries (no "experimental")
- [x] `omni documents v2-create --help` / `v2-publish-draft --help` show expected args, flags, and examples
- [x] Embedded spec contains zero `experimental` markers
- [ ] Optional live verification: `omni documents v2-get <identifier>` against a real org

🤖 Generated with [Claude Code](https://claude.com/claude-code)