### PR TITLE
sync spec: add AI routines, model suggestions, credit controls, and whoami

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -16,8 +16,16 @@
       "name": "AI"
     },
     {
+      "description": "Saved AI prompts that fire on a schedule and deliver the response to email recipients.",
+      "name": "AI Routines"
+    },
+    {
       "description": "AI evaluation: manage prompt sets and runs used to score AI quality against curated prompt suites.",
       "name": "AI Eval"
+    },
+    {
+      "description": "AI-generated model suggestions: list, generate, schedule, and manage suggested improvements to a shared model.",
+      "name": "AI Model Suggestions"
     },
     {
       "description": "API token management",
@@ -82,6 +90,10 @@
     {
       "description": "User and group management",
       "name": "Users"
+    },
+    {
+      "description": "Self-introspection: the authenticated caller can discover their own identity, key scope, org role, and resolved per-model permissions.",
+      "name": "Whoami"
     }
   ],
   "components": {
@@ -696,7 +708,7 @@
           "detail": {
             "type": "string",
             "description": "Human-readable error message describing what went wrong.",
-            "example": "The AI agent is currently unavailable. Contact your administrator to re-enable."
+            "example": "The AI credit limit has been reached. Contact your administrator for assistance."
           },
           "status": {
             "type": "integer",
@@ -982,7 +994,7 @@
           "modelId": {
             "type": "string",
             "format": "uuid",
-            "description": "The UUID of the shared model to query against. Only shared models are supported.",
+            "description": "The UUID of the model to query against. Must be a shared model, or a shared-extension model usable as a workbook base.",
             "example": "770e8400-e29b-41d4-a716-446655440002"
           },
           "progressWebhookEnabled": {
@@ -1019,7 +1031,7 @@
           "webhookUrl": {
             "type": "string",
             "format": "uri",
-            "description": "URL to receive webhook POSTs. Always receives a terminal event (job.complete or job.failed) when the job finishes. When progressWebhookEnabled is true, also receives real-time progress events during execution.",
+            "description": "URL to receive webhook POSTs. Always receives a terminal event (job.complete, job.failed, or job.denied) when the job finishes; a job.denied event (e.g. the organization is over its AI credit limit) additionally carries a reason field. When progressWebhookEnabled is true, also receives real-time progress events during execution.",
             "example": "https://example.com/webhooks/omni"
           }
         },
@@ -1595,6 +1607,476 @@
           "omniChatUrl",
           "role",
           "text"
+        ]
+      },
+      "AiCreditControlsResponse": {
+        "type": "object",
+        "properties": {
+          "accountCreditLimit": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Monthly AI credit limit for the whole Omni account (shared across every org under the same Salesforce account), not just this org. 0 when no limit is configured.",
+            "example": 2000
+          },
+          "creditsUsed": {
+            "type": "number",
+            "minimum": 0,
+            "description": "This org's credit usage in the current billing period.",
+            "example": 450
+          },
+          "downgradeCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Downgrade threshold, or `null` if the downgrade control is off.",
+            "example": 800
+          },
+          "periodEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "periodStart": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "shutoffCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Shutoff threshold, or `null` if the shutoff control is off.",
+            "example": 1200
+          }
+        },
+        "required": [
+          "accountCreditLimit",
+          "creditsUsed",
+          "downgradeCredits",
+          "periodEnd",
+          "periodStart",
+          "shutoffCredits"
+        ]
+      },
+      "AiCreditControlsUpdateBody": {
+        "type": "object",
+        "properties": {
+          "downgradeCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Credit usage at which AI downgrades to a cheaper model. Omit to leave unchanged, `null` to turn off, or a non-negative number to set. Must be at or below shutoffCredits.",
+            "example": 800
+          },
+          "shutoffCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Credit usage at which AI shuts off entirely. Omit to leave unchanged, `null` to turn off, or a non-negative number to set.",
+            "example": 1200
+          }
+        },
+        "additionalProperties": false
+      },
+      "RoutinesListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineResponse"
+            },
+            "description": "Routines returned for this request, newest first."
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "RoutineResponse": {
+        "type": "object",
+        "properties": {
+          "branchId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Branch of the shared model the prompt runs against, or null."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp when the routine was created."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display-only notes about the routine, or null."
+          },
+          "destination": {
+            "$ref": "#/components/schemas/RoutineEmailDestination"
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the owner has paused the routine."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the routine."
+          },
+          "lastRun": {
+            "$ref": "#/components/schemas/RoutineLastRun"
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model the prompt runs against."
+          },
+          "name": {
+            "type": "string",
+            "description": "Customer-visible name of the routine, used as the email subject."
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Natural language prompt Omni runs on each scheduled run."
+          },
+          "recipientCount": {
+            "type": "integer",
+            "description": "Number of distinct deliverable recipients after expanding user groups and removing duplicates."
+          },
+          "schedule": {
+            "type": "string",
+            "description": "Six-field cron expression (minute, hour, day-of-month, month, day-of-week, year; use `?` for an unspecified day field)."
+          },
+          "systemDisabled": {
+            "type": "boolean",
+            "description": "Whether Omni disabled the routine because it could no longer run successfully or safely."
+          },
+          "systemDisabledReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reason Omni disabled the routine, or null."
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone identifier used to evaluate the schedule."
+          },
+          "topicName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Topic scoping query generation, or null."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp when the routine was last updated."
+          }
+        },
+        "required": [
+          "branchId",
+          "createdAt",
+          "description",
+          "destination",
+          "disabled",
+          "id",
+          "lastRun",
+          "modelId",
+          "name",
+          "prompt",
+          "recipientCount",
+          "schedule",
+          "systemDisabled",
+          "systemDisabledReason",
+          "timezone",
+          "topicName",
+          "updatedAt"
+        ]
+      },
+      "RoutineEmailDestination": {
+        "type": "object",
+        "properties": {
+          "recipientEmails": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 100,
+            "default": [],
+            "description": "Email addresses that receive each scheduled run of the routine.",
+            "example": [
+              "alice@example.com",
+              "bob@example.com"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "email"
+            ],
+            "description": "Destination type. Only `email` is supported.",
+            "example": "email"
+          },
+          "userGroupIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "maxItems": 100,
+            "default": [],
+            "description": "User group IDs whose active members receive each scheduled run. Omni expands each group to the members' current email addresses when the routine runs.",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440000"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false,
+        "description": "Email delivery configuration for the routine."
+      },
+      "RoutineLastRun": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "completedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp the last completed run finished."
+          },
+          "label": {
+            "type": "string",
+            "description": "Customer-visible status of the last completed run.",
+            "example": "Delivered"
+          },
+          "state": {
+            "type": "string",
+            "description": "Machine-readable status of the last completed run.",
+            "example": "COMPLETE"
+          }
+        },
+        "required": [
+          "completedAt",
+          "label",
+          "state"
+        ],
+        "description": "Most recent completed run, or null if the routine has never completed a run."
+      },
+      "RoutineCreateResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier for the newly created routine.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "ApiError429": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "User has reached the maximum of 100 routines"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 429
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "RoutineCreateBody": {
+        "type": "object",
+        "properties": {
+          "branchId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional branch ID for the model. Must be a branch of the shared model specified by modelId.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2000,
+            "description": "Optional human-readable notes about the routine. Display-only — never used as model input.",
+            "example": "Weekly signups summary for the growth team."
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The UUID of the shared model the prompt runs against. Only shared models are supported.",
+            "example": "770e8400-e29b-41d4-a716-446655440002"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "description": "Customer-visible name of the routine. Used as the email subject for each scheduled run.",
+            "example": "Weekly user signups"
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Natural language prompt Omni runs on each scheduled run.",
+            "example": "How many users signed up last week?"
+          },
+          "schedule": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Six-field cron expression (minute, hour, day-of-month, month, day-of-week, year; use `?` for an unspecified day field). Minimum frequency is once per hour; contact Omni support if you need more frequent scheduling.",
+            "example": "0 9 ? * MON *"
+          },
+          "timezone": {
+            "type": "string",
+            "minLength": 1,
+            "description": "IANA timezone identifier used to evaluate the schedule.",
+            "example": "America/New_York"
+          },
+          "topicName": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Topic name to scope query generation. If omitted, the AI picks the best topic.",
+            "example": "users"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/RoutineDestination"
+          }
+        },
+        "required": [
+          "modelId",
+          "name",
+          "prompt",
+          "schedule",
+          "timezone",
+          "destination"
+        ],
+        "additionalProperties": false
+      },
+      "RoutineDestination": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/RoutineEmailDestination"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "email": "#/components/schemas/RoutineEmailDestination"
+          }
+        },
+        "description": "Single delivery destination for the routine. To send results to multiple destinations, create one routine per destination. Omni runs the prompt once per scheduled run using the routine owner's permissions, and every recipient receives the same result regardless of their own permissions."
+      },
+      "RoutineUpdateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2000,
+            "description": "Display-only notes about the routine. Pass null to clear it."
+          },
+          "destination": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineDestination"
+              },
+              {
+                "description": "Replaces the routine's full recipient configuration with the supplied destination."
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "description": "New customer-visible name of the routine, used as the email subject."
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New natural language prompt Omni runs on each scheduled run."
+          },
+          "schedule": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New six-field cron expression (minute, hour, day-of-month, month, day-of-week, year; use `?` for an unspecified day field). Minimum frequency is once per hour."
+          },
+          "timezone": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New IANA timezone identifier used to evaluate the schedule."
+          }
+        },
+        "additionalProperties": false
+      },
+      "RoutineDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always true on a successful delete."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The deleted routine’s ID."
+          }
+        },
+        "required": [
+          "deleted",
+          "id"
+        ]
+      },
+      "RoutineTriggerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The ID of the run (scheduled job) that was started.",
+            "example": "990e8400-e29b-41d4-a716-446655440004"
+          }
+        },
+        "required": [
+          "id"
         ]
       },
       "ApiKeyListResponse": {
@@ -2949,8 +3431,7 @@
               "omni-spreadsheet",
               "spreadsheet-tab",
               "summary-value",
-              "omni-table",
-              "app"
+              "omni-table"
             ],
             "description": "Visualization type (e.g. basic, omni-markdown, omni-table)"
           }
@@ -3899,7 +4380,7 @@
         "type": "object",
         "properties": {
           "containers": {
-            "$ref": "#/components/schemas/Containers"
+            "$ref": "#/components/schemas/ContainersOnCreate"
           },
           "controls": {
             "$ref": "#/components/schemas/ControlsPatchExternal"
@@ -3950,7 +4431,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 255,
-            "description": "Caller-supplied note describing the create, written to the history audit trail. Defaults to \"Created document\" when omitted."
+            "description": "Optional. Caller-supplied note describing the create, written to the history audit trail. When omitted, the server auto-fills it with \"Created document\"."
           }
         },
         "required": [
@@ -3959,8 +4440,11 @@
         ],
         "additionalProperties": false
       },
-      "Containers": {
-        "type": "array",
+      "ContainersOnCreate": {
+        "type": [
+          "array",
+          "null"
+        ],
         "items": {
           "anyOf": [
             {
@@ -3974,7 +4458,7 @@
             }
           ]
         },
-        "description": "Container layout array (grid / stack / page / reference containers, recursively nested). The server validates the full structure on apply."
+        "description": "Container layout array, or `null` to create a workbook-only document with no dashboard. When `null`, `controls` and `settings` must be omitted."
       },
       "GridContainer": {
         "type": "object",
@@ -9087,6 +9571,1622 @@
                           "type": "object",
                           "properties": {
                             "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "size": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 2000,
+                              "description": "Fixed size in px along the parent stack axis (default 16). In grids the size comes from gridPosition; ignored when style.fillSpace is true."
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-spacer"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "align": {
+                              "type": "string",
+                              "enum": [
+                                "start",
+                                "center",
+                                "end"
+                              ],
+                              "description": "Placement of the line within its slot along the cross axis (default center): horizontal → top/center/bottom, vertical → left/center/right"
+                            },
+                            "color": {
+                              "type": "string",
+                              "enum": [
+                                "border1",
+                                "border4",
+                                "text1",
+                                "text4"
+                              ],
+                              "description": "Theme color for the line, subtle → bold (default border4)"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "horizontal",
+                                "vertical"
+                              ],
+                              "description": "Line orientation (default horizontal)"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "thickness": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                }
+                              ],
+                              "description": "Line thickness in px (default 1)"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-divider"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
                               "type": "string"
                             },
                             "type": {
@@ -9176,6 +11276,14 @@
               "attachedQueryKey": {
                 "type": "string",
                 "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              },
+              "generatedHeading": {
+                "type": "boolean",
+                "description": "Marks the auto-injected heading wrapper (title + description row) created for a tile, so it can be labeled generically and treated as managed."
+              },
+              "locked": {
+                "type": "boolean",
+                "description": "Locks the container's internal arrangement so its children cannot be dragged, reordered, resized, or have new items dropped in. Cascades to all descendants. Does not lock the container's own position/size."
               }
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
@@ -14919,6 +17027,1622 @@
                   "type": "object",
                   "properties": {
                     "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "size": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 2000,
+                      "description": "Fixed size in px along the parent stack axis (default 16). In grids the size comes from gridPosition; ignored when style.fillSpace is true."
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-spacer"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "align": {
+                      "type": "string",
+                      "enum": [
+                        "start",
+                        "center",
+                        "end"
+                      ],
+                      "description": "Placement of the line within its slot along the cross axis (default center): horizontal → top/center/bottom, vertical → left/center/right"
+                    },
+                    "color": {
+                      "type": "string",
+                      "enum": [
+                        "border1",
+                        "border4",
+                        "text1",
+                        "text4"
+                      ],
+                      "description": "Theme color for the line, subtle → bold (default border4)"
+                    },
+                    "direction": {
+                      "type": "string",
+                      "enum": [
+                        "horizontal",
+                        "vertical"
+                      ],
+                      "description": "Line orientation (default horizontal)"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "thickness": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        }
+                      ],
+                      "description": "Line thickness in px (default 1)"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-divider"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
                       "type": "string"
                     },
                     "type": {
@@ -15087,6 +18811,14 @@
               "attachedQueryKey": {
                 "type": "string",
                 "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              },
+              "generatedHeading": {
+                "type": "boolean",
+                "description": "Marks the auto-injected heading wrapper (title + description row) created for a tile, so it can be labeled generically and treated as managed."
+              },
+              "locked": {
+                "type": "boolean",
+                "description": "Locks the container's internal arrangement so its children cannot be dragged, reordered, resized, or have new items dropped in. Cascades to all descendants. Does not lock the container's own position/size."
               }
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
@@ -19811,8 +23543,7 @@
               "sql",
               "dbt",
               "query-view",
-              "linked",
-              "app"
+              "linked"
             ],
             "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
           },
@@ -19901,7 +23632,6 @@
                       "spreadsheet-tab",
                       "summary-value",
                       "omni-table",
-                      "app",
                       null
                     ],
                     "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
@@ -20011,6 +23741,23 @@
           "name",
           "queryPresentations"
         ]
+      },
+      "Containers": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/components/schemas/GridContainer"
+            },
+            {
+              "$ref": "#/components/schemas/PageContainer"
+            },
+            {
+              "$ref": "#/components/schemas/StackContainer"
+            }
+          ]
+        },
+        "description": "Container layout array (grid / stack / page / reference containers, recursively nested). The server validates the full structure on apply."
       },
       "ControlsReadExternal": {
         "type": "object",
@@ -23868,8 +27615,7 @@
               "sql",
               "dbt",
               "query-view",
-              "linked",
-              "app"
+              "linked"
             ],
             "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
           },
@@ -23958,7 +27704,6 @@
                       "spreadsheet-tab",
                       "summary-value",
                       "omni-table",
-                      "app",
                       null
                     ],
                     "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
@@ -24139,7 +27884,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 255,
-            "description": "Caller-supplied description of what this patch changes, written to the history audit trail. When absent, the server generates one from the touched sections."
+            "description": "Optional. Caller-supplied description of what this patch changes, written to the history audit trail. When omitted, the server auto-generates one from the touched sections."
           }
         },
         "additionalProperties": false
@@ -24520,6 +28265,25 @@
           "updated_at"
         ]
       },
+      "EvalApiError422": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "A prompt being updated does not belong to this prompt set"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 422
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
       "EvalPromptSetsCreateBody": {
         "type": "object",
         "properties": {
@@ -24571,7 +28335,7 @@
                 "prompt_text"
               ]
             },
-            "maxItems": 25,
+            "maxItems": 100,
             "default": [],
             "description": "Initial prompts for the set. Defaults to an empty list. At most 25 prompts."
           },
@@ -24609,25 +28373,6 @@
         },
         "required": [
           "prompt_set"
-        ]
-      },
-      "EvalApiError422": {
-        "type": "object",
-        "properties": {
-          "detail": {
-            "type": "string",
-            "description": "Human-readable error message describing what went wrong.",
-            "example": "A prompt being updated does not belong to this prompt set"
-          },
-          "status": {
-            "type": "integer",
-            "description": "HTTP status code of the error.",
-            "example": 422
-          }
-        },
-        "required": [
-          "detail",
-          "status"
         ]
       },
       "EvalPromptSetsUpdateBody": {
@@ -24678,7 +28423,7 @@
                 "prompt_text"
               ]
             },
-            "maxItems": 25,
+            "maxItems": 100,
             "description": "Full desired set of prompts after the update. Prompts omitted from this list are deleted; new prompts (no `id`) are appended in body order. Existing prompts retain their original position — reordering is not supported on this endpoint. At most 25 prompts total."
           }
         }
@@ -25033,6 +28778,22 @@
             "description": "The prompt text that was evaluated.",
             "example": "What are the top 5 products by revenue?"
           },
+          "query_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of warehouse queries the underlying job ran. Null for runs executed before this metric was recorded.",
+            "example": 4
+          },
+          "query_timing_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Total wall-clock time (milliseconds) the underlying job spent running warehouse queries — a proxy for query execution time. Null for runs executed before this metric was recorded.",
+            "example": 1800
+          },
           "score": {
             "type": [
               "number",
@@ -25054,7 +28815,7 @@
               "integer",
               "null"
             ],
-            "description": "Wall-clock duration of the underlying job in milliseconds.",
+            "description": "Total AI time in milliseconds — all LLM processing and tool calls. Shown as \"AI time\" in the UI.",
             "example": 4321
           }
         },
@@ -25065,6 +28826,8 @@
           "expectation",
           "id",
           "prompt",
+          "query_count",
+          "query_timing_ms",
           "score",
           "scoring_cost",
           "timing_ms"
@@ -25929,6 +29692,257 @@
             "description": "Mark as verified label. Requires admin permissions to modify."
           }
         }
+      },
+      "ModelSuggestionsListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelSuggestion"
+            }
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "ModelSuggestion": {
+        "type": "object",
+        "properties": {
+          "aiModifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of the last AI write (create or AI update). Unaffected by dismiss/restore."
+          },
+          "category": {
+            "type": "string",
+            "description": "Suggestion category, e.g. `missing_context`.",
+            "example": "missing_context"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of when the suggestion was created."
+          },
+          "evidence": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SuggestionEvidenceItem"
+            },
+            "description": "Source evidence for the suggestion. Null for rows created before evidence was tracked; `[]` when none was cited."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the suggestion."
+          },
+          "ignoreReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional free-text reason recorded when the suggestion was dismissed."
+          },
+          "ignoredAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of dismissal, or null if active."
+          },
+          "ignoredBy": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "User id that dismissed the suggestion, or null if active."
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Priority from 1 (highest) to 10 (lowest).",
+            "example": 1
+          },
+          "proposedChanges": {
+            "$ref": "#/components/schemas/SuggestionProposedChanges"
+          },
+          "rationale": {
+            "type": "string",
+            "description": "Explanation of why the suggestion was made."
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable title."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of the last write of any kind, including dismiss/restore."
+          }
+        },
+        "required": [
+          "aiModifiedAt",
+          "category",
+          "createdAt",
+          "evidence",
+          "id",
+          "ignoreReason",
+          "ignoredAt",
+          "ignoredBy",
+          "priority",
+          "proposedChanges",
+          "rationale",
+          "title",
+          "updatedAt"
+        ]
+      },
+      "SuggestionEvidenceItem": {
+        "type": "object",
+        "properties": {
+          "capturedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of when the evidence was captured."
+          },
+          "chatAiSessionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Chat session that motivated the suggestion."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ai_chat"
+            ]
+          }
+        },
+        "required": [
+          "capturedAt",
+          "chatAiSessionId",
+          "type"
+        ]
+      },
+      "SuggestionProposedChanges": {
+        "type": "object",
+        "properties": {
+          "edits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuggestionContextEdit"
+            }
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "context_edits"
+            ]
+          }
+        },
+        "required": [
+          "edits",
+          "kind"
+        ],
+        "description": "The change(s) the suggestion would apply to the model."
+      },
+      "SuggestionContextEdit": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The model field being edited (e.g. `ai_context`).",
+            "example": "ai_context"
+          },
+          "target": {
+            "type": "string",
+            "description": "Dot-path identifying what the edit applies to, e.g. `views.orders.fields.status`.",
+            "example": "views.orders"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "description": "The proposed value for the field."
+          }
+        },
+        "required": [
+          "field",
+          "target",
+          "value"
+        ]
+      },
+      "ScheduleSuggestionsResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The schedule (trigger) id."
+          },
+          "sharedModelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model the schedule generates suggestions for."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "enabled"
+            ]
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone the schedule runs in.",
+            "example": "America/New_York"
+          }
+        },
+        "required": [
+          "id",
+          "sharedModelId",
+          "status",
+          "timezone"
+        ]
+      },
+      "ScheduleSuggestionsBody": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "default": "UTC",
+            "description": "IANA timezone the schedule fires in (e.g. `America/New_York`). Generation currently runs once daily at ~2 AM in this timezone. Defaults to `UTC`.",
+            "example": "America/New_York"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IgnoreSuggestionBody": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "maxLength": 4000,
+            "description": "Optional free-text reason for dismissing the suggestion.",
+            "example": "Already covered by an existing field description."
+          }
+        },
+        "additionalProperties": false
       },
       "ModelsListResponse": {
         "type": "object",
@@ -27946,6 +31960,12 @@
             "description": "Cache policy for query execution. Controls whether to use cached results.",
             "example": "normal"
           },
+          "environmentConnectionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Connection ID of the environment to run the query against, overriding the connection environment inherited from the (target) user's session or default. Must be a configured environment of the query model's connection that the user can access. Obtain valid IDs from the `connectionId` field of `GET /api/v1/connection-environments`.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
           "formatResults": {
             "type": "boolean",
             "description": "Whether to format result values (e.g., apply number formatting). Only valid when resultType is specified."
@@ -28200,7 +32220,7 @@
             "example": false
           },
           "metadata": {
-            "description": "Schedule metadata including format options and delivery settings"
+            "description": "Schedule metadata including format options and delivery settings. Includes `timezoneOverride` (IANA timezone applied to query execution at render time, or null when no override is set)."
           },
           "name": {
             "type": "string",
@@ -30287,6 +34307,117 @@
         "required": [
           "roleName"
         ]
+      },
+      "WhoamiResponse": {
+        "type": "object",
+        "properties": {
+          "keyScope": {
+            "type": "string",
+            "enum": [
+              "user",
+              "organization"
+            ],
+            "description": "Scope of the API key in use. A separate axis from role: a user-scoped key (PAT/OAuth) acts as a single user and cannot use SCIM, regardless of the user's org role."
+          },
+          "orgRole": {
+            "type": "string",
+            "enum": [
+              "MEMBER",
+              "ORG_ADMIN"
+            ],
+            "description": "The caller's organization role.",
+            "example": "MEMBER"
+          },
+          "rolesByModel": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WhoamiModelRole"
+            },
+            "description": "Resolved role and effective permissions per model, keyed by model id. Connection role resolves per shared model, so this is per-model rather than a single global role."
+          },
+          "rolesByModelTruncated": {
+            "type": "boolean",
+            "description": "Present and `true` when `rolesByModel` was truncated because the caller can access more models than the unfiltered limit. Pass a `modelId` filter to retrieve specific models."
+          },
+          "user": {
+            "$ref": "#/components/schemas/WhoamiUser"
+          }
+        },
+        "required": [
+          "keyScope",
+          "orgRole",
+          "rolesByModel",
+          "user"
+        ]
+      },
+      "WhoamiModelRole": {
+        "type": "object",
+        "properties": {
+          "baseRole": {
+            "type": "string",
+            "description": "The resolved base role (for custom roles, the base role they extend).",
+            "example": "QUERIER"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "The connection this model belongs to"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "QUERY_FULL_MODEL",
+                "QUERY_SQL",
+                "VIEW_SQL",
+                "QUERY_TOPICS",
+                "RUN_CONTENT_QUERIES",
+                "DOWNLOAD_CONTENT_QUERY",
+                "UPLOAD_CSV",
+                "SCHEDULE",
+                "SAVE_SPREADSHEETS",
+                "USE_AI",
+                "USE_WORKBOOKS",
+                "UPDATE",
+                "UPDATE_RESTRICTED"
+              ]
+            },
+            "description": "The caller's resolved/effective permissions on this model, reflecting custom roles. This is a capability signal for the directly-roleable model kinds (schema / shared / extension). It does not enumerate the permissions you derive on branch, workbook, and query models from your role on the base model they descend from — absence here does not mean you lack access on those derived models. MANAGE_MODEL, READ, and REFRESH_SCHEMA are also not reported: they derive from connection / sibling-model roles rather than a per-model rule.",
+            "example": [
+              "QUERY_TOPICS",
+              "QUERY_SQL",
+              "USE_WORKBOOKS"
+            ]
+          },
+          "roleName": {
+            "type": "string",
+            "description": "The resolved role name (informational; may be a custom role). Use `permissions` to decide capability.",
+            "example": "QUERIER"
+          }
+        },
+        "required": [
+          "baseRole",
+          "connectionId",
+          "permissions",
+          "roleName"
+        ]
+      },
+      "WhoamiUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The caller's user id"
+          },
+          "membershipId": {
+            "type": "string",
+            "description": "The caller's own membership id within this organization. This is the id accepted by the admin `GET /api/v1/users/{id}/model-roles` endpoint (it is distinct from the user id)."
+          }
+        },
+        "required": [
+          "id",
+          "membershipId"
+        ]
       }
     },
     "parameters": {}
@@ -31085,6 +35216,687 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/credit-controls": {
+      "get": {
+        "description": "Get the organization's AI credit controls: the downgrade and shutoff thresholds, plus read-only context (the credit limit, usage so far this billing period, and the period bounds). This is the API mirror of the AI Hub credit controls page and requires the same AI-admin permission.",
+        "operationId": "aiCreditControlsGet",
+        "summary": "Get AI credit controls",
+        "tags": [
+          "AI"
+        ],
+        "responses": {
+          "200": {
+            "description": "Current credit controls. Thresholds are `null` when the corresponding control is off.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditControlsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or AI credit controls are not enabled for the organization. Requires AI-admin access.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update the organization's AI credit thresholds. Both fields are optional and tri-state: omit a field to leave it unchanged, send `null` to turn that control off, or send a non-negative number to set it. At least one field is required. The `downgradeCredits <= shutoffCredits` invariant is enforced against the merged result. Returns the full current state, the same shape as GET.",
+        "operationId": "aiCreditControlsUpdate",
+        "summary": "Update AI credit controls",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiCreditControlsUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Thresholds updated. Returns the full current state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditControlsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: empty body, a negative threshold, an unknown field, or downgradeCredits above shutoffCredits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or AI credit controls are not enabled. Requires AI-admin access.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/routines": {
+      "get": {
+        "description": "List routines for the calling user, newest first. Includes routines paused by the owner or disabled by Omni, but excludes deleted routines. Use `pageInfo.nextCursor` from one response as the `cursor` query parameter on the next request. Organization API keys can pass `?userId=<membershipId>` to list routines for a specific organization member.",
+        "operationId": "routinesList",
+        "summary": "List routines",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc",
+              "description": "Sort direction for results",
+              "example": "desc"
+            },
+            "required": false,
+            "description": "Sort direction for results",
+            "name": "sortDirection",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Field to sort results by"
+            },
+            "required": false,
+            "description": "Field to sort results by",
+            "name": "sortField",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of routines.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutinesListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid pagination cursor or `userId` value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to list routines for another user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The `userId` membership was not found in the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a routine that runs a saved prompt on a schedule and delivers the AI response through a single email destination. Each scheduled run executes once using the routine owner's permissions, and every recipient receives the same result. Organization API keys can pass `?userId=<membershipId>` to create the routine for a specific organization member.",
+        "operationId": "routineCreate",
+        "summary": "Create a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutineCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Routine created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body, recipient configuration, schedule, or timezone. Also returned when the schedule is more frequent than the organization allows.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or the API key cannot act on behalf of the requested user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Model, branch, or topic not found, or not accessible to the requested user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The resolved user already has the maximum number of active routines.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError429"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/routines/{id}": {
+      "get": {
+        "description": "Get a single routine, including the status of its most recent completed run.",
+        "operationId": "routineGet",
+        "summary": "Get a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Routine details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to access another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Routine not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a routine. All request fields are optional, and only supplied fields are changed. Supplying `destination` replaces the full recipient configuration.",
+        "operationId": "routineUpdate",
+        "summary": "Update a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutineUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated routine details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID, request body, recipient configuration, schedule, or timezone.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to update another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Routine not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a routine. It stops running immediately and no longer appears in list or get responses.",
+        "operationId": "routineDelete",
+        "summary": "Delete a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Routine deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to delete another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Routine not found or has already been deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/routines/{id}/trigger": {
+      "post": {
+        "description": "Run a routine immediately, in addition to its schedule. The run executes once using the routine owner's permissions and delivers the AI response to every configured recipient — it is not a private preview. Returns once the run has started; the result is delivered asynchronously. Organization API keys can pass `?userId=<membershipId>` to act on behalf of a specific organization member.",
+        "operationId": "routineTrigger",
+        "summary": "Run a routine now",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The run has started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineTriggerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID, or the routine cannot run as configured (e.g. its model, branch, or owner is no longer accessible).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to run another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The routine does not exist or cannot be triggered (deleted, paused, or disabled by Omni).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A run is already in progress for this routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError409"
                 }
               }
             }
@@ -32434,7 +37246,7 @@
                       "string",
                       "null"
                     ],
-                    "description": "dbt version to use. Supported: Auto, 1.10, 1.11",
+                    "description": "dbt version to use. Supported: Auto, 1.11, 1.12",
                     "example": "1.11"
                   },
                   "enableSemanticLayer": {
@@ -34531,7 +39343,7 @@
       },
       "put": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
         "operationId": "documentsPut",
         "summary": "Replace document (full replacement)",
         "tags": [
@@ -34562,6 +39374,37 @@
         "responses": {
           "200": {
             "description": "Document replaced successfully",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -34589,7 +39432,7 @@
       },
       "patch": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
         "operationId": "documentsUpdate",
         "summary": "Rename document",
         "tags": [
@@ -34620,6 +39463,37 @@
         "responses": {
           "200": {
             "description": "Document updated successfully",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -35819,7 +40693,7 @@
     },
     "/api/v2/documents": {
       "post": {
-        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nWhen `containers` is omitted, every dashboard-eligible tile is auto-placed in a default layout. When `containers` is present, it fully defines the layout — tiles it does not reference are stored but not rendered.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
+        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nWhen `containers` is omitted, every dashboard-eligible tile is auto-placed in a default layout. When `containers` is present, it fully defines the layout — tiles it does not reference are stored but not rendered. Send `containers: null` to create a workbook-only document with no dashboard (`controls` and `settings` must then be omitted); an empty `containers: []` is rejected.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
         "operationId": "documentsV2Create",
         "summary": "Create document",
         "tags": [
@@ -35883,6 +40757,22 @@
             "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
             "name": "identifier",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1",
+                "true",
+                "false"
+              ],
+              "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless."
+            },
+            "required": false,
+            "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless.",
+            "name": "pretty",
+            "in": "query"
           }
         ],
         "responses": {
@@ -36006,6 +40896,22 @@
             "description": "Published document identifier.",
             "name": "identifier",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1",
+                "true",
+                "false"
+              ],
+              "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless."
+            },
+            "required": false,
+            "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless.",
+            "name": "pretty",
+            "in": "query"
           }
         ],
         "responses": {
@@ -36349,6 +41255,16 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Prompt count exceeds the organization's per-set cap (default 25, higher for orgs with the `ai-eval-extra-prompts` flag).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError422"
+                }
+              }
+            }
           }
         }
       }
@@ -36511,7 +41427,7 @@
             }
           },
           "422": {
-            "description": "A `prompts[].id` in the request does not belong to this prompt set.",
+            "description": "A `prompts[].id` in the request does not belong to this prompt set, or the prompt count exceeds the organization's per-set cap (default 25, higher for orgs with the `ai-eval-extra-prompts` flag).",
             "content": {
               "application/json": {
                 "schema": {
@@ -37919,6 +42835,405 @@
           },
           "409": {
             "description": "Cannot delete label that is applied to documents"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions": {
+      "get": {
+        "description": "Lists AI-generated model suggestions for a shared model, filtered by dismissal status. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsList",
+        "summary": "List model suggestions",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Cursor for pagination: the `nextCursor` from the previous response (the last suggestion id)."
+            },
+            "required": false,
+            "description": "Cursor for pagination: the `nextCursor` from the previous response (the last suggestion id).",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "ignored",
+                "all"
+              ],
+              "default": "active",
+              "description": "Which suggestions to return: `active` (default, not dismissed), `ignored` (dismissed only), or `all`.",
+              "example": "active"
+            },
+            "required": false,
+            "description": "Which suggestions to return: `active` (default, not dismissed), `ignored` (dismissed only), or `all`.",
+            "name": "status",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of suggestions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelSuggestionsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters or malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/schedule": {
+      "put": {
+        "description": "Enables the daily schedule that generates suggestions for the shared model. Idempotent — re-enabling leaves an existing schedule untouched. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsScheduleEnable",
+        "summary": "Enable the suggestion schedule",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleSuggestionsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schedule is enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleSuggestionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid timezone or malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      },
+      "delete": {
+        "description": "Disables the daily generation schedule for the shared model. Idempotent. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsScheduleDisable",
+        "summary": "Disable the suggestion schedule",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The schedule is disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/{suggestionId}/ignore": {
+      "post": {
+        "description": "Dismisses (ignores) a suggestion, optionally with a reason. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsIgnore",
+        "summary": "Ignore a suggestion",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestion belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestion belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the suggestion",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the suggestion",
+            "name": "suggestionId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IgnoreSuggestionBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The suggestion was dismissed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Suggestion or model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/{suggestionId}/restore": {
+      "post": {
+        "description": "Restores a previously dismissed suggestion back to the active list. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsRestore",
+        "summary": "Restore a suggestion",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestion belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestion belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the suggestion",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the suggestion",
+            "name": "suggestionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The suggestion was restored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Suggestion or model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/{suggestionId}": {
+      "delete": {
+        "description": "Permanently deletes a suggestion. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsDelete",
+        "summary": "Delete a suggestion",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestion belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestion belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the suggestion",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the suggestion",
+            "name": "suggestionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The suggestion was deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Suggestion or model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
           }
         }
       }
@@ -39999,10 +45314,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Optional branch ID to validate"
+              "format": "uuid",
+              "description": "Optional branch ID to validate against. Non-UUID values return 400."
             },
             "required": false,
-            "description": "Optional branch ID to validate",
+            "description": "Optional branch ID to validate against. Non-UUID values return 400.",
             "name": "branch_id",
             "in": "query"
           },
@@ -41016,6 +46332,14 @@
                     "type": "string",
                     "description": "IANA timezone for the schedule",
                     "example": "America/New_York"
+                  },
+                  "timezoneOverride": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Optional IANA timezone applied to query execution at render time. Distinct from `timezone` (which controls *when* the schedule fires). Omit or pass null for no override.",
+                    "example": "Europe/Paris"
                   },
                   "webhookUrl": {
                     "type": "string",
@@ -43023,6 +48347,47 @@
           },
           "404": {
             "description": "User group, model, or connection not found"
+          }
+        }
+      }
+    },
+    "/api/v1/whoami": {
+      "get": {
+        "description": "Returns the authenticated caller's own identity, API key scope, organization role, and resolved per-model permissions. Self-scoped and available to non-admins: it lets a caller decide whether an action is permitted without attempting it. Pass `modelId` to scope `rolesByModel` to specific models.",
+        "operationId": "whoami",
+        "summary": "Get current identity and permissions (whoami)",
+        "tags": [
+          "Whoami"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional model filter. A single model id or a comma-separated list. When provided, `rolesByModel` contains only these models. When omitted, models the caller can access are returned (up to a limit; see `rolesByModelTruncated`).",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Optional model filter. A single model id or a comma-separated list. When provided, `rolesByModel` contains only these models. When omitted, models the caller can access are returned (up to a limit; see `rolesByModelTruncated`).",
+            "name": "modelId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Caller's identity, key scope, org role, and per-model permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WhoamiResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "404": {
+            "description": "One or more requested `modelId`s do not exist or are not accessible to the caller"
           }
         }
       }

--- a/cmd/omni/openapi.json
+++ b/cmd/omni/openapi.json
@@ -16,8 +16,16 @@
       "name": "AI"
     },
     {
+      "description": "Saved AI prompts that fire on a schedule and deliver the response to email recipients.",
+      "name": "AI Routines"
+    },
+    {
       "description": "AI evaluation: manage prompt sets and runs used to score AI quality against curated prompt suites.",
       "name": "AI Eval"
+    },
+    {
+      "description": "AI-generated model suggestions: list, generate, schedule, and manage suggested improvements to a shared model.",
+      "name": "AI Model Suggestions"
     },
     {
       "description": "API token management",
@@ -82,6 +90,10 @@
     {
       "description": "User and group management",
       "name": "Users"
+    },
+    {
+      "description": "Self-introspection: the authenticated caller can discover their own identity, key scope, org role, and resolved per-model permissions.",
+      "name": "Whoami"
     }
   ],
   "components": {
@@ -696,7 +708,7 @@
           "detail": {
             "type": "string",
             "description": "Human-readable error message describing what went wrong.",
-            "example": "The AI agent is currently unavailable. Contact your administrator to re-enable."
+            "example": "The AI credit limit has been reached. Contact your administrator for assistance."
           },
           "status": {
             "type": "integer",
@@ -982,7 +994,7 @@
           "modelId": {
             "type": "string",
             "format": "uuid",
-            "description": "The UUID of the shared model to query against. Only shared models are supported.",
+            "description": "The UUID of the model to query against. Must be a shared model, or a shared-extension model usable as a workbook base.",
             "example": "770e8400-e29b-41d4-a716-446655440002"
           },
           "progressWebhookEnabled": {
@@ -1019,7 +1031,7 @@
           "webhookUrl": {
             "type": "string",
             "format": "uri",
-            "description": "URL to receive webhook POSTs. Always receives a terminal event (job.complete or job.failed) when the job finishes. When progressWebhookEnabled is true, also receives real-time progress events during execution.",
+            "description": "URL to receive webhook POSTs. Always receives a terminal event (job.complete, job.failed, or job.denied) when the job finishes; a job.denied event (e.g. the organization is over its AI credit limit) additionally carries a reason field. When progressWebhookEnabled is true, also receives real-time progress events during execution.",
             "example": "https://example.com/webhooks/omni"
           }
         },
@@ -1595,6 +1607,476 @@
           "omniChatUrl",
           "role",
           "text"
+        ]
+      },
+      "AiCreditControlsResponse": {
+        "type": "object",
+        "properties": {
+          "accountCreditLimit": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Monthly AI credit limit for the whole Omni account (shared across every org under the same Salesforce account), not just this org. 0 when no limit is configured.",
+            "example": 2000
+          },
+          "creditsUsed": {
+            "type": "number",
+            "minimum": 0,
+            "description": "This org's credit usage in the current billing period.",
+            "example": 450
+          },
+          "downgradeCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Downgrade threshold, or `null` if the downgrade control is off.",
+            "example": 800
+          },
+          "periodEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "periodStart": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "shutoffCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Shutoff threshold, or `null` if the shutoff control is off.",
+            "example": 1200
+          }
+        },
+        "required": [
+          "accountCreditLimit",
+          "creditsUsed",
+          "downgradeCredits",
+          "periodEnd",
+          "periodStart",
+          "shutoffCredits"
+        ]
+      },
+      "AiCreditControlsUpdateBody": {
+        "type": "object",
+        "properties": {
+          "downgradeCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Credit usage at which AI downgrades to a cheaper model. Omit to leave unchanged, `null` to turn off, or a non-negative number to set. Must be at or below shutoffCredits.",
+            "example": 800
+          },
+          "shutoffCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Credit usage at which AI shuts off entirely. Omit to leave unchanged, `null` to turn off, or a non-negative number to set.",
+            "example": 1200
+          }
+        },
+        "additionalProperties": false
+      },
+      "RoutinesListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineResponse"
+            },
+            "description": "Routines returned for this request, newest first."
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "RoutineResponse": {
+        "type": "object",
+        "properties": {
+          "branchId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Branch of the shared model the prompt runs against, or null."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp when the routine was created."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display-only notes about the routine, or null."
+          },
+          "destination": {
+            "$ref": "#/components/schemas/RoutineEmailDestination"
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the owner has paused the routine."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the routine."
+          },
+          "lastRun": {
+            "$ref": "#/components/schemas/RoutineLastRun"
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model the prompt runs against."
+          },
+          "name": {
+            "type": "string",
+            "description": "Customer-visible name of the routine, used as the email subject."
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Natural language prompt Omni runs on each scheduled run."
+          },
+          "recipientCount": {
+            "type": "integer",
+            "description": "Number of distinct deliverable recipients after expanding user groups and removing duplicates."
+          },
+          "schedule": {
+            "type": "string",
+            "description": "Six-field cron expression (minute, hour, day-of-month, month, day-of-week, year; use `?` for an unspecified day field)."
+          },
+          "systemDisabled": {
+            "type": "boolean",
+            "description": "Whether Omni disabled the routine because it could no longer run successfully or safely."
+          },
+          "systemDisabledReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reason Omni disabled the routine, or null."
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone identifier used to evaluate the schedule."
+          },
+          "topicName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Topic scoping query generation, or null."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp when the routine was last updated."
+          }
+        },
+        "required": [
+          "branchId",
+          "createdAt",
+          "description",
+          "destination",
+          "disabled",
+          "id",
+          "lastRun",
+          "modelId",
+          "name",
+          "prompt",
+          "recipientCount",
+          "schedule",
+          "systemDisabled",
+          "systemDisabledReason",
+          "timezone",
+          "topicName",
+          "updatedAt"
+        ]
+      },
+      "RoutineEmailDestination": {
+        "type": "object",
+        "properties": {
+          "recipientEmails": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 100,
+            "default": [],
+            "description": "Email addresses that receive each scheduled run of the routine.",
+            "example": [
+              "alice@example.com",
+              "bob@example.com"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "email"
+            ],
+            "description": "Destination type. Only `email` is supported.",
+            "example": "email"
+          },
+          "userGroupIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "maxItems": 100,
+            "default": [],
+            "description": "User group IDs whose active members receive each scheduled run. Omni expands each group to the members' current email addresses when the routine runs.",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440000"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false,
+        "description": "Email delivery configuration for the routine."
+      },
+      "RoutineLastRun": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "completedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 timestamp the last completed run finished."
+          },
+          "label": {
+            "type": "string",
+            "description": "Customer-visible status of the last completed run.",
+            "example": "Delivered"
+          },
+          "state": {
+            "type": "string",
+            "description": "Machine-readable status of the last completed run.",
+            "example": "COMPLETE"
+          }
+        },
+        "required": [
+          "completedAt",
+          "label",
+          "state"
+        ],
+        "description": "Most recent completed run, or null if the routine has never completed a run."
+      },
+      "RoutineCreateResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier for the newly created routine.",
+            "example": "880e8400-e29b-41d4-a716-446655440003"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "ApiError429": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "User has reached the maximum of 100 routines"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 429
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
+      "RoutineCreateBody": {
+        "type": "object",
+        "properties": {
+          "branchId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional branch ID for the model. Must be a branch of the shared model specified by modelId.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2000,
+            "description": "Optional human-readable notes about the routine. Display-only — never used as model input.",
+            "example": "Weekly signups summary for the growth team."
+          },
+          "modelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The UUID of the shared model the prompt runs against. Only shared models are supported.",
+            "example": "770e8400-e29b-41d4-a716-446655440002"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "description": "Customer-visible name of the routine. Used as the email subject for each scheduled run.",
+            "example": "Weekly user signups"
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Natural language prompt Omni runs on each scheduled run.",
+            "example": "How many users signed up last week?"
+          },
+          "schedule": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Six-field cron expression (minute, hour, day-of-month, month, day-of-week, year; use `?` for an unspecified day field). Minimum frequency is once per hour; contact Omni support if you need more frequent scheduling.",
+            "example": "0 9 ? * MON *"
+          },
+          "timezone": {
+            "type": "string",
+            "minLength": 1,
+            "description": "IANA timezone identifier used to evaluate the schedule.",
+            "example": "America/New_York"
+          },
+          "topicName": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Topic name to scope query generation. If omitted, the AI picks the best topic.",
+            "example": "users"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/RoutineDestination"
+          }
+        },
+        "required": [
+          "modelId",
+          "name",
+          "prompt",
+          "schedule",
+          "timezone",
+          "destination"
+        ],
+        "additionalProperties": false
+      },
+      "RoutineDestination": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/RoutineEmailDestination"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "email": "#/components/schemas/RoutineEmailDestination"
+          }
+        },
+        "description": "Single delivery destination for the routine. To send results to multiple destinations, create one routine per destination. Omni runs the prompt once per scheduled run using the routine owner's permissions, and every recipient receives the same result regardless of their own permissions."
+      },
+      "RoutineUpdateBody": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 2000,
+            "description": "Display-only notes about the routine. Pass null to clear it."
+          },
+          "destination": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineDestination"
+              },
+              {
+                "description": "Replaces the routine's full recipient configuration with the supplied destination."
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "description": "New customer-visible name of the routine, used as the email subject."
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New natural language prompt Omni runs on each scheduled run."
+          },
+          "schedule": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New six-field cron expression (minute, hour, day-of-month, month, day-of-week, year; use `?` for an unspecified day field). Minimum frequency is once per hour."
+          },
+          "timezone": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New IANA timezone identifier used to evaluate the schedule."
+          }
+        },
+        "additionalProperties": false
+      },
+      "RoutineDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always true on a successful delete."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The deleted routine’s ID."
+          }
+        },
+        "required": [
+          "deleted",
+          "id"
+        ]
+      },
+      "RoutineTriggerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The ID of the run (scheduled job) that was started.",
+            "example": "990e8400-e29b-41d4-a716-446655440004"
+          }
+        },
+        "required": [
+          "id"
         ]
       },
       "ApiKeyListResponse": {
@@ -2949,8 +3431,7 @@
               "omni-spreadsheet",
               "spreadsheet-tab",
               "summary-value",
-              "omni-table",
-              "app"
+              "omni-table"
             ],
             "description": "Visualization type (e.g. basic, omni-markdown, omni-table)"
           }
@@ -3899,7 +4380,7 @@
         "type": "object",
         "properties": {
           "containers": {
-            "$ref": "#/components/schemas/Containers"
+            "$ref": "#/components/schemas/ContainersOnCreate"
           },
           "controls": {
             "$ref": "#/components/schemas/ControlsPatchExternal"
@@ -3950,7 +4431,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 255,
-            "description": "Caller-supplied note describing the create, written to the history audit trail. Defaults to \"Created document\" when omitted."
+            "description": "Optional. Caller-supplied note describing the create, written to the history audit trail. When omitted, the server auto-fills it with \"Created document\"."
           }
         },
         "required": [
@@ -3959,8 +4440,11 @@
         ],
         "additionalProperties": false
       },
-      "Containers": {
-        "type": "array",
+      "ContainersOnCreate": {
+        "type": [
+          "array",
+          "null"
+        ],
         "items": {
           "anyOf": [
             {
@@ -3974,7 +4458,7 @@
             }
           ]
         },
-        "description": "Container layout array (grid / stack / page / reference containers, recursively nested). The server validates the full structure on apply."
+        "description": "Container layout array, or `null` to create a workbook-only document with no dashboard. When `null`, `controls` and `settings` must be omitted."
       },
       "GridContainer": {
         "type": "object",
@@ -9087,6 +9571,1622 @@
                           "type": "object",
                           "properties": {
                             "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "size": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 2000,
+                              "description": "Fixed size in px along the parent stack axis (default 16). In grids the size comes from gridPosition; ignored when style.fillSpace is true."
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-spacer"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
+                              "type": "string",
+                              "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                            },
+                            "padding": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "prefixItems": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            0.5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            2
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            3
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            4
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            5
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            6
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            7
+                                          ]
+                                        },
+                                        {
+                                          "type": "number",
+                                          "enum": [
+                                            8
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preset": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$",
+                              "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                            },
+                            "align": {
+                              "type": "string",
+                              "enum": [
+                                "start",
+                                "center",
+                                "end"
+                              ],
+                              "description": "Placement of the line within its slot along the cross axis (default center): horizontal → top/center/bottom, vertical → left/center/right"
+                            },
+                            "color": {
+                              "type": "string",
+                              "enum": [
+                                "border1",
+                                "border4",
+                                "text1",
+                                "text4"
+                              ],
+                              "description": "Theme color for the line, subtle → bold (default border4)"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "horizontal",
+                                "vertical"
+                              ],
+                              "description": "Line orientation (default horizontal)"
+                            },
+                            "style": {
+                              "type": "object",
+                              "properties": {
+                                "aspectRatio": {
+                                  "type": "string"
+                                },
+                                "fillSpace": {
+                                  "type": "boolean"
+                                },
+                                "height": {
+                                  "type": "string"
+                                },
+                                "maxHeight": {
+                                  "type": "string"
+                                },
+                                "maxWidth": {
+                                  "type": "string"
+                                },
+                                "minHeight": {
+                                  "type": "string"
+                                },
+                                "minWidth": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "thickness": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                }
+                              ],
+                              "description": "Line thickness in px (default 1)"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "inline-divider"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "instanceKey",
+                            "type"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "instanceKey": {
                               "type": "string"
                             },
                             "type": {
@@ -9176,6 +11276,14 @@
               "attachedQueryKey": {
                 "type": "string",
                 "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              },
+              "generatedHeading": {
+                "type": "boolean",
+                "description": "Marks the auto-injected heading wrapper (title + description row) created for a tile, so it can be labeled generically and treated as managed."
+              },
+              "locked": {
+                "type": "boolean",
+                "description": "Locks the container's internal arrangement so its children cannot be dragged, reordered, resized, or have new items dropped in. Cascades to all descendants. Does not lock the container's own position/size."
               }
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
@@ -14919,6 +17027,1622 @@
                   "type": "object",
                   "properties": {
                     "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "size": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 2000,
+                      "description": "Fixed size in px along the parent stack axis (default 16). In grids the size comes from gridPosition; ignored when style.fillSpace is true."
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-spacer"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
+                      "type": "string",
+                      "description": "Unique identifier for this specific placement of the content item. Use this key (not the query id) when repositioning or removing items."
+                    },
+                    "padding": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            0
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            0.5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            3
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            5
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            6
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            7
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            8
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    0.5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    1
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    2
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    3
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    4
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    5
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    6
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    7
+                                  ]
+                                },
+                                {
+                                  "type": "number",
+                                  "enum": [
+                                    8
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "preset": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9-]+$",
+                      "description": "Visual preset for the content item (e.g., \"tile-align\" for outer spacing to align with tile containers)"
+                    },
+                    "align": {
+                      "type": "string",
+                      "enum": [
+                        "start",
+                        "center",
+                        "end"
+                      ],
+                      "description": "Placement of the line within its slot along the cross axis (default center): horizontal → top/center/bottom, vertical → left/center/right"
+                    },
+                    "color": {
+                      "type": "string",
+                      "enum": [
+                        "border1",
+                        "border4",
+                        "text1",
+                        "text4"
+                      ],
+                      "description": "Theme color for the line, subtle → bold (default border4)"
+                    },
+                    "direction": {
+                      "type": "string",
+                      "enum": [
+                        "horizontal",
+                        "vertical"
+                      ],
+                      "description": "Line orientation (default horizontal)"
+                    },
+                    "style": {
+                      "type": "object",
+                      "properties": {
+                        "aspectRatio": {
+                          "type": "string"
+                        },
+                        "fillSpace": {
+                          "type": "boolean"
+                        },
+                        "height": {
+                          "type": "string"
+                        },
+                        "maxHeight": {
+                          "type": "string"
+                        },
+                        "maxWidth": {
+                          "type": "string"
+                        },
+                        "minHeight": {
+                          "type": "string"
+                        },
+                        "minWidth": {
+                          "type": "string"
+                        },
+                        "width": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "thickness": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            2
+                          ]
+                        },
+                        {
+                          "type": "number",
+                          "enum": [
+                            4
+                          ]
+                        }
+                      ],
+                      "description": "Line thickness in px (default 1)"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "inline-divider"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "instanceKey",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "instanceKey": {
                       "type": "string"
                     },
                     "type": {
@@ -15087,6 +18811,14 @@
               "attachedQueryKey": {
                 "type": "string",
                 "description": "Set by the auto-add-tile flow when this container was generated for a specific workbook tab. The server removes containers with a matching `attachedQueryKey` when that tab is deleted. The reducer clears this when the user adds unrelated content (a different query, filter, text tile, page switcher, or sub-container)."
+              },
+              "generatedHeading": {
+                "type": "boolean",
+                "description": "Marks the auto-injected heading wrapper (title + description row) created for a tile, so it can be labeled generically and treated as managed."
+              },
+              "locked": {
+                "type": "boolean",
+                "description": "Locks the container's internal arrangement so its children cannot be dragged, reordered, resized, or have new items dropped in. Cascades to all descendants. Does not lock the container's own position/size."
               }
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
@@ -19811,8 +23543,7 @@
               "sql",
               "dbt",
               "query-view",
-              "linked",
-              "app"
+              "linked"
             ],
             "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
           },
@@ -19901,7 +23632,6 @@
                       "spreadsheet-tab",
                       "summary-value",
                       "omni-table",
-                      "app",
                       null
                     ],
                     "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
@@ -20011,6 +23741,23 @@
           "name",
           "queryPresentations"
         ]
+      },
+      "Containers": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/components/schemas/GridContainer"
+            },
+            {
+              "$ref": "#/components/schemas/PageContainer"
+            },
+            {
+              "$ref": "#/components/schemas/StackContainer"
+            }
+          ]
+        },
+        "description": "Container layout array (grid / stack / page / reference containers, recursively nested). The server validates the full structure on apply."
       },
       "ControlsReadExternal": {
         "type": "object",
@@ -23868,8 +27615,7 @@
               "sql",
               "dbt",
               "query-view",
-              "linked",
-              "app"
+              "linked"
             ],
             "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
           },
@@ -23958,7 +27704,6 @@
                       "spreadsheet-tab",
                       "summary-value",
                       "omni-table",
-                      "app",
                       null
                     ],
                     "description": "The visualization type (e.g. \"basic\", \"omni-table\")."
@@ -24139,7 +27884,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 255,
-            "description": "Caller-supplied description of what this patch changes, written to the history audit trail. When absent, the server generates one from the touched sections."
+            "description": "Optional. Caller-supplied description of what this patch changes, written to the history audit trail. When omitted, the server auto-generates one from the touched sections."
           }
         },
         "additionalProperties": false
@@ -24520,6 +28265,25 @@
           "updated_at"
         ]
       },
+      "EvalApiError422": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "A prompt being updated does not belong to this prompt set"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 422
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
       "EvalPromptSetsCreateBody": {
         "type": "object",
         "properties": {
@@ -24571,7 +28335,7 @@
                 "prompt_text"
               ]
             },
-            "maxItems": 25,
+            "maxItems": 100,
             "default": [],
             "description": "Initial prompts for the set. Defaults to an empty list. At most 25 prompts."
           },
@@ -24609,25 +28373,6 @@
         },
         "required": [
           "prompt_set"
-        ]
-      },
-      "EvalApiError422": {
-        "type": "object",
-        "properties": {
-          "detail": {
-            "type": "string",
-            "description": "Human-readable error message describing what went wrong.",
-            "example": "A prompt being updated does not belong to this prompt set"
-          },
-          "status": {
-            "type": "integer",
-            "description": "HTTP status code of the error.",
-            "example": 422
-          }
-        },
-        "required": [
-          "detail",
-          "status"
         ]
       },
       "EvalPromptSetsUpdateBody": {
@@ -24678,7 +28423,7 @@
                 "prompt_text"
               ]
             },
-            "maxItems": 25,
+            "maxItems": 100,
             "description": "Full desired set of prompts after the update. Prompts omitted from this list are deleted; new prompts (no `id`) are appended in body order. Existing prompts retain their original position — reordering is not supported on this endpoint. At most 25 prompts total."
           }
         }
@@ -25033,6 +28778,22 @@
             "description": "The prompt text that was evaluated.",
             "example": "What are the top 5 products by revenue?"
           },
+          "query_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of warehouse queries the underlying job ran. Null for runs executed before this metric was recorded.",
+            "example": 4
+          },
+          "query_timing_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Total wall-clock time (milliseconds) the underlying job spent running warehouse queries — a proxy for query execution time. Null for runs executed before this metric was recorded.",
+            "example": 1800
+          },
           "score": {
             "type": [
               "number",
@@ -25054,7 +28815,7 @@
               "integer",
               "null"
             ],
-            "description": "Wall-clock duration of the underlying job in milliseconds.",
+            "description": "Total AI time in milliseconds — all LLM processing and tool calls. Shown as \"AI time\" in the UI.",
             "example": 4321
           }
         },
@@ -25065,6 +28826,8 @@
           "expectation",
           "id",
           "prompt",
+          "query_count",
+          "query_timing_ms",
           "score",
           "scoring_cost",
           "timing_ms"
@@ -25929,6 +29692,257 @@
             "description": "Mark as verified label. Requires admin permissions to modify."
           }
         }
+      },
+      "ModelSuggestionsListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelSuggestion"
+            }
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "ModelSuggestion": {
+        "type": "object",
+        "properties": {
+          "aiModifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of the last AI write (create or AI update). Unaffected by dismiss/restore."
+          },
+          "category": {
+            "type": "string",
+            "description": "Suggestion category, e.g. `missing_context`.",
+            "example": "missing_context"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of when the suggestion was created."
+          },
+          "evidence": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SuggestionEvidenceItem"
+            },
+            "description": "Source evidence for the suggestion. Null for rows created before evidence was tracked; `[]` when none was cited."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the suggestion."
+          },
+          "ignoreReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional free-text reason recorded when the suggestion was dismissed."
+          },
+          "ignoredAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of dismissal, or null if active."
+          },
+          "ignoredBy": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "User id that dismissed the suggestion, or null if active."
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Priority from 1 (highest) to 10 (lowest).",
+            "example": 1
+          },
+          "proposedChanges": {
+            "$ref": "#/components/schemas/SuggestionProposedChanges"
+          },
+          "rationale": {
+            "type": "string",
+            "description": "Explanation of why the suggestion was made."
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable title."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of the last write of any kind, including dismiss/restore."
+          }
+        },
+        "required": [
+          "aiModifiedAt",
+          "category",
+          "createdAt",
+          "evidence",
+          "id",
+          "ignoreReason",
+          "ignoredAt",
+          "ignoredBy",
+          "priority",
+          "proposedChanges",
+          "rationale",
+          "title",
+          "updatedAt"
+        ]
+      },
+      "SuggestionEvidenceItem": {
+        "type": "object",
+        "properties": {
+          "capturedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of when the evidence was captured."
+          },
+          "chatAiSessionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Chat session that motivated the suggestion."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ai_chat"
+            ]
+          }
+        },
+        "required": [
+          "capturedAt",
+          "chatAiSessionId",
+          "type"
+        ]
+      },
+      "SuggestionProposedChanges": {
+        "type": "object",
+        "properties": {
+          "edits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuggestionContextEdit"
+            }
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "context_edits"
+            ]
+          }
+        },
+        "required": [
+          "edits",
+          "kind"
+        ],
+        "description": "The change(s) the suggestion would apply to the model."
+      },
+      "SuggestionContextEdit": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The model field being edited (e.g. `ai_context`).",
+            "example": "ai_context"
+          },
+          "target": {
+            "type": "string",
+            "description": "Dot-path identifying what the edit applies to, e.g. `views.orders.fields.status`.",
+            "example": "views.orders"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "description": "The proposed value for the field."
+          }
+        },
+        "required": [
+          "field",
+          "target",
+          "value"
+        ]
+      },
+      "ScheduleSuggestionsResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The schedule (trigger) id."
+          },
+          "sharedModelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The shared model the schedule generates suggestions for."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "enabled"
+            ]
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone the schedule runs in.",
+            "example": "America/New_York"
+          }
+        },
+        "required": [
+          "id",
+          "sharedModelId",
+          "status",
+          "timezone"
+        ]
+      },
+      "ScheduleSuggestionsBody": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "default": "UTC",
+            "description": "IANA timezone the schedule fires in (e.g. `America/New_York`). Generation currently runs once daily at ~2 AM in this timezone. Defaults to `UTC`.",
+            "example": "America/New_York"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IgnoreSuggestionBody": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "maxLength": 4000,
+            "description": "Optional free-text reason for dismissing the suggestion.",
+            "example": "Already covered by an existing field description."
+          }
+        },
+        "additionalProperties": false
       },
       "ModelsListResponse": {
         "type": "object",
@@ -27946,6 +31960,12 @@
             "description": "Cache policy for query execution. Controls whether to use cached results.",
             "example": "normal"
           },
+          "environmentConnectionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Connection ID of the environment to run the query against, overriding the connection environment inherited from the (target) user's session or default. Must be a configured environment of the query model's connection that the user can access. Obtain valid IDs from the `connectionId` field of `GET /api/v1/connection-environments`.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
           "formatResults": {
             "type": "boolean",
             "description": "Whether to format result values (e.g., apply number formatting). Only valid when resultType is specified."
@@ -28200,7 +32220,7 @@
             "example": false
           },
           "metadata": {
-            "description": "Schedule metadata including format options and delivery settings"
+            "description": "Schedule metadata including format options and delivery settings. Includes `timezoneOverride` (IANA timezone applied to query execution at render time, or null when no override is set)."
           },
           "name": {
             "type": "string",
@@ -30287,6 +34307,117 @@
         "required": [
           "roleName"
         ]
+      },
+      "WhoamiResponse": {
+        "type": "object",
+        "properties": {
+          "keyScope": {
+            "type": "string",
+            "enum": [
+              "user",
+              "organization"
+            ],
+            "description": "Scope of the API key in use. A separate axis from role: a user-scoped key (PAT/OAuth) acts as a single user and cannot use SCIM, regardless of the user's org role."
+          },
+          "orgRole": {
+            "type": "string",
+            "enum": [
+              "MEMBER",
+              "ORG_ADMIN"
+            ],
+            "description": "The caller's organization role.",
+            "example": "MEMBER"
+          },
+          "rolesByModel": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WhoamiModelRole"
+            },
+            "description": "Resolved role and effective permissions per model, keyed by model id. Connection role resolves per shared model, so this is per-model rather than a single global role."
+          },
+          "rolesByModelTruncated": {
+            "type": "boolean",
+            "description": "Present and `true` when `rolesByModel` was truncated because the caller can access more models than the unfiltered limit. Pass a `modelId` filter to retrieve specific models."
+          },
+          "user": {
+            "$ref": "#/components/schemas/WhoamiUser"
+          }
+        },
+        "required": [
+          "keyScope",
+          "orgRole",
+          "rolesByModel",
+          "user"
+        ]
+      },
+      "WhoamiModelRole": {
+        "type": "object",
+        "properties": {
+          "baseRole": {
+            "type": "string",
+            "description": "The resolved base role (for custom roles, the base role they extend).",
+            "example": "QUERIER"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "The connection this model belongs to"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "QUERY_FULL_MODEL",
+                "QUERY_SQL",
+                "VIEW_SQL",
+                "QUERY_TOPICS",
+                "RUN_CONTENT_QUERIES",
+                "DOWNLOAD_CONTENT_QUERY",
+                "UPLOAD_CSV",
+                "SCHEDULE",
+                "SAVE_SPREADSHEETS",
+                "USE_AI",
+                "USE_WORKBOOKS",
+                "UPDATE",
+                "UPDATE_RESTRICTED"
+              ]
+            },
+            "description": "The caller's resolved/effective permissions on this model, reflecting custom roles. This is a capability signal for the directly-roleable model kinds (schema / shared / extension). It does not enumerate the permissions you derive on branch, workbook, and query models from your role on the base model they descend from — absence here does not mean you lack access on those derived models. MANAGE_MODEL, READ, and REFRESH_SCHEMA are also not reported: they derive from connection / sibling-model roles rather than a per-model rule.",
+            "example": [
+              "QUERY_TOPICS",
+              "QUERY_SQL",
+              "USE_WORKBOOKS"
+            ]
+          },
+          "roleName": {
+            "type": "string",
+            "description": "The resolved role name (informational; may be a custom role). Use `permissions` to decide capability.",
+            "example": "QUERIER"
+          }
+        },
+        "required": [
+          "baseRole",
+          "connectionId",
+          "permissions",
+          "roleName"
+        ]
+      },
+      "WhoamiUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The caller's user id"
+          },
+          "membershipId": {
+            "type": "string",
+            "description": "The caller's own membership id within this organization. This is the id accepted by the admin `GET /api/v1/users/{id}/model-roles` endpoint (it is distinct from the user id)."
+          }
+        },
+        "required": [
+          "id",
+          "membershipId"
+        ]
       }
     },
     "parameters": {}
@@ -31085,6 +35216,687 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/credit-controls": {
+      "get": {
+        "description": "Get the organization's AI credit controls: the downgrade and shutoff thresholds, plus read-only context (the credit limit, usage so far this billing period, and the period bounds). This is the API mirror of the AI Hub credit controls page and requires the same AI-admin permission.",
+        "operationId": "aiCreditControlsGet",
+        "summary": "Get AI credit controls",
+        "tags": [
+          "AI"
+        ],
+        "responses": {
+          "200": {
+            "description": "Current credit controls. Thresholds are `null` when the corresponding control is off.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditControlsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or AI credit controls are not enabled for the organization. Requires AI-admin access.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update the organization's AI credit thresholds. Both fields are optional and tri-state: omit a field to leave it unchanged, send `null` to turn that control off, or send a non-negative number to set it. At least one field is required. The `downgradeCredits <= shutoffCredits` invariant is enforced against the merged result. Returns the full current state, the same shape as GET.",
+        "operationId": "aiCreditControlsUpdate",
+        "summary": "Update AI credit controls",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiCreditControlsUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Thresholds updated. Returns the full current state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditControlsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: empty body, a negative threshold, an unknown field, or downgradeCredits above shutoffCredits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or AI credit controls are not enabled. Requires AI-admin access.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/routines": {
+      "get": {
+        "description": "List routines for the calling user, newest first. Includes routines paused by the owner or disabled by Omni, but excludes deleted routines. Use `pageInfo.nextCursor` from one response as the `cursor` query parameter on the next request. Organization API keys can pass `?userId=<membershipId>` to list routines for a specific organization member.",
+        "operationId": "routinesList",
+        "summary": "List routines",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc",
+              "description": "Sort direction for results",
+              "example": "desc"
+            },
+            "required": false,
+            "description": "Sort direction for results",
+            "name": "sortDirection",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Field to sort results by"
+            },
+            "required": false,
+            "description": "Field to sort results by",
+            "name": "sortField",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of routines.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutinesListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid pagination cursor or `userId` value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to list routines for another user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The `userId` membership was not found in the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a routine that runs a saved prompt on a schedule and delivers the AI response through a single email destination. Each scheduled run executes once using the routine owner's permissions, and every recipient receives the same result. Organization API keys can pass `?userId=<membershipId>` to create the routine for a specific organization member.",
+        "operationId": "routineCreate",
+        "summary": "Create a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutineCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Routine created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body, recipient configuration, schedule, or timezone. Also returned when the schedule is more frequent than the organization allows.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or the API key cannot act on behalf of the requested user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Model, branch, or topic not found, or not accessible to the requested user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The resolved user already has the maximum number of active routines.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError429"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/routines/{id}": {
+      "get": {
+        "description": "Get a single routine, including the status of its most recent completed run.",
+        "operationId": "routineGet",
+        "summary": "Get a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Routine details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to access another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Routine not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a routine. All request fields are optional, and only supplied fields are changed. Supplying `destination` replaces the full recipient configuration.",
+        "operationId": "routineUpdate",
+        "summary": "Update a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutineUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated routine details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID, request body, recipient configuration, schedule, or timezone.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to update another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Routine not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a routine. It stops running immediately and no longer appears in list or get responses.",
+        "operationId": "routineDelete",
+        "summary": "Delete a routine",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Routine deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to delete another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Routine not found or has already been deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/routines/{id}/trigger": {
+      "post": {
+        "description": "Run a routine immediately, in addition to its schedule. The run executes once using the routine owner's permissions and delivers the AI response to every configured recipient — it is not a private preview. Returns once the run has started; the result is delivered asynchronously. Organization API keys can pass `?userId=<membershipId>` to act on behalf of a specific organization member.",
+        "operationId": "routineTrigger",
+        "summary": "Run a routine now",
+        "tags": [
+          "AI Routines"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The UUID of the routine."
+            },
+            "required": true,
+            "description": "The UUID of the routine.",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The run has started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineTriggerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid routine ID, or the routine cannot run as configured (e.g. its model, branch, or owner is no longer accessible).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI routines or AI query generation are not enabled for the organization, or a user-scoped API key tried to run another user's routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The routine does not exist or cannot be triggered (deleted, paused, or disabled by Omni).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A run is already in progress for this routine.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError409"
                 }
               }
             }
@@ -32434,7 +37246,7 @@
                       "string",
                       "null"
                     ],
-                    "description": "dbt version to use. Supported: Auto, 1.10, 1.11",
+                    "description": "dbt version to use. Supported: Auto, 1.11, 1.12",
                     "example": "1.11"
                   },
                   "enableSemanticLayer": {
@@ -34531,7 +39343,7 @@
       },
       "put": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
         "operationId": "documentsPut",
         "summary": "Replace document (full replacement)",
         "tags": [
@@ -34562,6 +39374,37 @@
         "responses": {
           "200": {
             "description": "Document replaced successfully",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -34589,7 +39432,7 @@
       },
       "patch": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removal scheduled per the `Sunset` response header.\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
         "operationId": "documentsUpdate",
         "summary": "Rename document",
         "tags": [
@@ -34620,6 +39463,37 @@
         "responses": {
           "200": {
             "description": "Document updated successfully",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -35819,7 +40693,7 @@
     },
     "/api/v2/documents": {
       "post": {
-        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nWhen `containers` is omitted, every dashboard-eligible tile is auto-placed in a default layout. When `containers` is present, it fully defines the layout — tiles it does not reference are stored but not rendered.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
+        "description": "Create a brand-new document and publish it live. Accepts creation metadata (`modelId`, `name`, optional `identifier` / `description` / `folderId`) plus the same content slice as the PATCH body — `queryPresentations`, `controls`, `settings`, `containers`. The server mints internal tile identifiers, so callers omit `miniUuid`. Tiles in `queryPresentations` are merged by key over the single empty seed tile at key `\"1\"`; write to `\"1\"` (or send it as `null`) to replace the seed.\n\nWhen `containers` is omitted, every dashboard-eligible tile is auto-placed in a default layout. When `containers` is present, it fully defines the layout — tiles it does not reference are stored but not rendered. Send `containers: null` to create a workbook-only document with no dashboard (`controls` and `settings` must then be omitted); an empty `containers: []` is rejected.\n\nThe new document is published live before the response returns. As a first publish of brand-new content it is not subject to the org’s `requirePullRequestToPublish` policy (which gates edits to existing content).",
         "operationId": "documentsV2Create",
         "summary": "Create document",
         "tags": [
@@ -35883,6 +40757,22 @@
             "description": "Document identifier — either the URL slug (e.g. `abc123`) or the canonical workbook UUID.",
             "name": "identifier",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1",
+                "true",
+                "false"
+              ],
+              "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless."
+            },
+            "required": false,
+            "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless.",
+            "name": "pretty",
+            "in": "query"
           }
         ],
         "responses": {
@@ -36006,6 +40896,22 @@
             "description": "Published document identifier.",
             "name": "identifier",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1",
+                "true",
+                "false"
+              ],
+              "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless."
+            },
+            "required": false,
+            "description": "Set `true` or `1` to pretty-print (2-space indent) the response; `false` / `0` (the default) is compact. Key ordering is deterministic regardless.",
+            "name": "pretty",
+            "in": "query"
           }
         ],
         "responses": {
@@ -36349,6 +41255,16 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Prompt count exceeds the organization's per-set cap (default 25, higher for orgs with the `ai-eval-extra-prompts` flag).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalApiError422"
+                }
+              }
+            }
           }
         }
       }
@@ -36511,7 +41427,7 @@
             }
           },
           "422": {
-            "description": "A `prompts[].id` in the request does not belong to this prompt set.",
+            "description": "A `prompts[].id` in the request does not belong to this prompt set, or the prompt count exceeds the organization's per-set cap (default 25, higher for orgs with the `ai-eval-extra-prompts` flag).",
             "content": {
               "application/json": {
                 "schema": {
@@ -37919,6 +42835,405 @@
           },
           "409": {
             "description": "Cannot delete label that is applied to documents"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions": {
+      "get": {
+        "description": "Lists AI-generated model suggestions for a shared model, filtered by dismissal status. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsList",
+        "summary": "List model suggestions",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Cursor for pagination: the `nextCursor` from the previous response (the last suggestion id)."
+            },
+            "required": false,
+            "description": "Cursor for pagination: the `nextCursor` from the previous response (the last suggestion id).",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "ignored",
+                "all"
+              ],
+              "default": "active",
+              "description": "Which suggestions to return: `active` (default, not dismissed), `ignored` (dismissed only), or `all`.",
+              "example": "active"
+            },
+            "required": false,
+            "description": "Which suggestions to return: `active` (default, not dismissed), `ignored` (dismissed only), or `all`.",
+            "name": "status",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of suggestions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelSuggestionsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters or malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/schedule": {
+      "put": {
+        "description": "Enables the daily schedule that generates suggestions for the shared model. Idempotent — re-enabling leaves an existing schedule untouched. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsScheduleEnable",
+        "summary": "Enable the suggestion schedule",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleSuggestionsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schedule is enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleSuggestionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid timezone or malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      },
+      "delete": {
+        "description": "Disables the daily generation schedule for the shared model. Idempotent. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsScheduleDisable",
+        "summary": "Disable the suggestion schedule",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The schedule is disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/{suggestionId}/ignore": {
+      "post": {
+        "description": "Dismisses (ignores) a suggestion, optionally with a reason. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsIgnore",
+        "summary": "Ignore a suggestion",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestion belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestion belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the suggestion",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the suggestion",
+            "name": "suggestionId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IgnoreSuggestionBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The suggestion was dismissed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Suggestion or model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/{suggestionId}/restore": {
+      "post": {
+        "description": "Restores a previously dismissed suggestion back to the active list. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsRestore",
+        "summary": "Restore a suggestion",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestion belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestion belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the suggestion",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the suggestion",
+            "name": "suggestionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The suggestion was restored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Suggestion or model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/{suggestionId}": {
+      "delete": {
+        "description": "Permanently deletes a suggestion. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsDelete",
+        "summary": "Delete a suggestion",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestion belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestion belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the suggestion",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the suggestion",
+            "name": "suggestionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The suggestion was deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Suggestion or model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
           }
         }
       }
@@ -39999,10 +45314,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Optional branch ID to validate"
+              "format": "uuid",
+              "description": "Optional branch ID to validate against. Non-UUID values return 400."
             },
             "required": false,
-            "description": "Optional branch ID to validate",
+            "description": "Optional branch ID to validate against. Non-UUID values return 400.",
             "name": "branch_id",
             "in": "query"
           },
@@ -41016,6 +46332,14 @@
                     "type": "string",
                     "description": "IANA timezone for the schedule",
                     "example": "America/New_York"
+                  },
+                  "timezoneOverride": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Optional IANA timezone applied to query execution at render time. Distinct from `timezone` (which controls *when* the schedule fires). Omit or pass null for no override.",
+                    "example": "Europe/Paris"
                   },
                   "webhookUrl": {
                     "type": "string",
@@ -43023,6 +48347,47 @@
           },
           "404": {
             "description": "User group, model, or connection not found"
+          }
+        }
+      }
+    },
+    "/api/v1/whoami": {
+      "get": {
+        "description": "Returns the authenticated caller's own identity, API key scope, organization role, and resolved per-model permissions. Self-scoped and available to non-admins: it lets a caller decide whether an action is permitted without attempting it. Pass `modelId` to scope `rolesByModel` to specific models.",
+        "operationId": "whoami",
+        "summary": "Get current identity and permissions (whoami)",
+        "tags": [
+          "Whoami"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional model filter. A single model id or a comma-separated list. When provided, `rolesByModel` contains only these models. When omitted, models the caller can access are returned (up to a limit; see `rolesByModelTruncated`).",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Optional model filter. A single model id or a comma-separated list. When provided, `rolesByModel` contains only these models. When omitted, models the caller can access are returned (up to a limit; see `rolesByModelTruncated`).",
+            "name": "modelId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Caller's identity, key scope, org role, and per-model permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WhoamiResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "404": {
+            "description": "One or more requested `modelId`s do not exist or are not accessible to the caller"
           }
         }
       }


### PR DESCRIPTION
## Summary

Syncs the embedded OpenAPI spec from `exploreomni/omni@main`. The full sync surfaces 15 new operations across three new command groups plus additions to `ai`, and one side-effect param on existing endpoints. No operations were removed.

**New command groups / operations:**

- **`ai-routines`** — full CRUD plus trigger:
  - `routine-create` (POST `/api/v1/ai/routines`)
  - `routine-get` (GET `/api/v1/ai/routines/{id}`)
  - `routine-update` (PATCH `/api/v1/ai/routines/{id}`)
  - `routine-delete` (DELETE `/api/v1/ai/routines/{id}`)
  - `routines-list` (GET `/api/v1/ai/routines`)
  - `routine-trigger` (POST `/api/v1/ai/routines/{id}/trigger`)
- **`ai-model-suggestions`**:
  - `model-suggestions-list` (GET `/api/v1/models/{modelId}/suggestions`)
  - `model-suggestions-delete` / `model-suggestions-ignore` / `model-suggestions-restore`
  - `model-suggestions-schedule-enable` (PUT) / `model-suggestions-schedule-disable` (DELETE)
- **`ai`** — credit controls:
  - `credit-controls-get` (GET `/api/v1/ai/credit-controls`)
  - `credit-controls-update` (PATCH `/api/v1/ai/credit-controls`)
- **`whoami`**:
  - `whoami` (GET `/api/v1/whoami`) — current identity and permissions, optional `--modelid` filter

**Side-effect changes pulled in by the full sync:**

- `documents v2-get` and `documents v2-get-draft` gain a `--pretty` query flag.
- `documents v2-create` request body: `containers` is now nullable (`type: ["array", "null"]`). Passing `containers: null` creates a workbook-only document with no dashboard; in that case `controls` and `settings` must be omitted. (Body-schema change — sent via `--body`, so no flag change.)

> Note: POST/PATCH operations (e.g. `routine-create`, `routine-update`, `credit-controls-update`) take their request body via `--body`, so their body fields don't appear as individual flags. Query/path params are wired as flags/positional args.

