### PR TITLE
sync spec: model suggestions, content search, AI credit usage reads

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -979,10 +979,18 @@
       "AiJobSubmitBody": {
         "type": "object",
         "properties": {
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgenticJobAttachment"
+            },
+            "maxItems": 5,
+            "description": "Optional image or PDF attachments (e.g. a screenshot or export of a legacy BI dashboard being migrated) giving the AI additional visual context alongside the prompt. Up to 5 files, sharing a combined 50000-token budget with the rest of the prompt."
+          },
           "branchId": {
             "type": "string",
             "format": "uuid",
-            "description": "Optional branch ID for the model. Must be a branch of the shared model specified by modelId. Use this to query against in-progress model changes.",
+            "description": "Optional branch ID for the model. Must be a branch of the shared model specified by modelId. Queries run against the branch model, and if the AI makes model changes (organizations with agentic modeling enabled), they are written to this branch instead of a newly created one. If omitted and the AI makes model changes, a new branch is created automatically.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
           "conversationId": {
@@ -1038,6 +1046,31 @@
         "required": [
           "modelId",
           "prompt"
+        ]
+      },
+      "AgenticJobAttachment": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Base64-encoded file content.",
+            "example": "iVBORw0KGgoAAAANSUhEUgAA..."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "MIME type of the attachment. Must be an image type (e.g. image/png, image/jpeg) or application/pdf.",
+            "example": "image/png"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional filename, used for display/logging only.",
+            "example": "legacy-dashboard-screenshot.png"
+          }
+        },
+        "required": [
+          "data",
+          "mimeType"
         ]
       },
       "AiJobStatusResponse": {
@@ -1638,6 +1671,15 @@
             "description": "Downgrade threshold, or `null` if the downgrade control is off.",
             "example": 800
           },
+          "entityGroupDefaultCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Default per-entity-group AI credit limit, or `null` when embed entity groups are unlimited by default.",
+            "example": 100
+          },
           "periodEnd": {
             "type": "integer",
             "minimum": 0,
@@ -1671,6 +1713,7 @@
           "accountCreditLimit",
           "creditsUsed",
           "downgradeCredits",
+          "entityGroupDefaultCredits",
           "periodEnd",
           "periodStart",
           "shutoffCredits",
@@ -1688,6 +1731,15 @@
             "minimum": 0,
             "description": "Credit usage at which AI downgrades to a cheaper model. Omit to leave unchanged, `null` to turn off, or a non-negative number to set. Must be at or below shutoffCredits.",
             "example": 800
+          },
+          "entityGroupDefaultCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Default per-entity-group AI credit limit for the billing period — what every embed entity group without an individual limit gets. Omit to leave unchanged, `null` for unlimited by default, or a non-negative number to set.",
+            "example": 100
           },
           "shutoffCredits": {
             "type": [
@@ -1732,6 +1784,7 @@
                 },
                 "userId": {
                   "type": "string",
+                  "format": "uuid",
                   "description": "The user's id within this organization.",
                   "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
                 }
@@ -1768,6 +1821,7 @@
                 },
                 "userId": {
                   "type": "string",
+                  "format": "uuid",
                   "description": "The user's id within this organization.",
                   "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
                 },
@@ -1827,12 +1881,267 @@
           },
           "userId": {
             "type": "string",
+            "format": "uuid",
             "description": "The user's id within this organization.",
             "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
           }
         },
         "required": [
           "userId"
+        ],
+        "additionalProperties": false
+      },
+      "AiEntityGroupCreditLimitsResponse": {
+        "type": "object",
+        "properties": {
+          "entityGroups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditLimit": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0,
+                  "description": "The entity group's effective AI credit limit, or `null` for unlimited.",
+                  "example": 50
+                },
+                "entity": {
+                  "type": "string",
+                  "description": "The embed entity's identifier (the SSO `entity` value).",
+                  "example": "acme-corp"
+                },
+                "usesDefaultLimit": {
+                  "type": "boolean",
+                  "description": "True when the entity group has no individual limit and follows the org default."
+                }
+              },
+              "required": [
+                "creditLimit",
+                "entity",
+                "usesDefaultLimit"
+              ]
+            }
+          }
+        },
+        "required": [
+          "entityGroups"
+        ]
+      },
+      "AiEntityGroupCreditLimitsUpdateBody": {
+        "type": "object",
+        "properties": {
+          "entityGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiEntityGroupCreditLimitEntry"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Entity groups to update, at most 1000 per request. Each entry has an `entity` plus exactly one of `creditLimit` (number or `null`) or `useDefaultLimit: true`."
+          }
+        },
+        "required": [
+          "entityGroups"
+        ],
+        "additionalProperties": false
+      },
+      "AiEntityGroupCreditLimitEntry": {
+        "type": "object",
+        "properties": {
+          "creditLimit": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "The entity group's individual AI credit limit for the billing period, or `null` for unlimited. Either way this overrides the org default. Mutually exclusive with `useDefaultLimit`.",
+            "example": 50
+          },
+          "entity": {
+            "type": "string",
+            "description": "The embed entity's identifier (the SSO `entity` value).",
+            "example": "acme-corp"
+          },
+          "useDefaultLimit": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Removes the entity group's individual limit so it follows the org default. Mutually exclusive with `creditLimit`."
+          }
+        },
+        "required": [
+          "entity"
+        ],
+        "additionalProperties": false
+      },
+      "AiCreditControlsEntityGroupsListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditLimit": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0,
+                  "description": "The entity group's individual AI credit limit, or `null` for an explicit unlimited override.",
+                  "example": 50
+                },
+                "entity": {
+                  "type": "string",
+                  "description": "The embed entity's identifier (the SSO `entity` value).",
+                  "example": "acme-corp"
+                }
+              },
+              "required": [
+                "creditLimit",
+                "entity"
+              ]
+            },
+            "description": "Entity groups with an individual AI credit limit, ordered by the entity group id."
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "AiCreditUsageUsersResponse": {
+        "type": "object",
+        "properties": {
+          "periodEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "periodStart": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditsUsed": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Credits the id consumed in the current billing period. `0` when it has no usage yet.",
+                  "example": 42
+                },
+                "userId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The user's id within this organization.",
+                  "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
+                }
+              },
+              "required": [
+                "creditsUsed",
+                "userId"
+              ]
+            }
+          }
+        },
+        "required": [
+          "periodEnd",
+          "periodStart",
+          "users"
+        ]
+      },
+      "AiCreditUsageUsersBody": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The user's id within this organization.",
+              "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Users to read usage for, at most 1000 per request. Each entry is a user's id within this organization."
+          }
+        },
+        "required": [
+          "userIds"
+        ],
+        "additionalProperties": false
+      },
+      "AiCreditUsageEntityGroupsResponse": {
+        "type": "object",
+        "properties": {
+          "periodEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "periodStart": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "entityGroups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditsUsed": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Credits the id consumed in the current billing period. `0` when it has no usage yet.",
+                  "example": 42
+                },
+                "entity": {
+                  "type": "string",
+                  "description": "The embed entity's identifier (the SSO `entity` value).",
+                  "example": "acme-corp"
+                }
+              },
+              "required": [
+                "creditsUsed",
+                "entity"
+              ]
+            }
+          }
+        },
+        "required": [
+          "periodEnd",
+          "periodStart",
+          "entityGroups"
+        ]
+      },
+      "AiCreditUsageEntityGroupsBody": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The embed entity's identifier (the SSO `entity` value).",
+              "example": "acme-corp"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Entity groups to read usage for, at most 1000 per request. Each entry is an embed `entity` string."
+          }
+        },
+        "required": [
+          "entities"
         ],
         "additionalProperties": false
       },
@@ -1866,6 +2175,9 @@
             "format": "uuid",
             "description": "Branch of the shared model the prompt runs against, or null."
           },
+          "condition": {
+            "$ref": "#/components/schemas/RoutineCondition"
+          },
           "createdAt": {
             "type": "string",
             "description": "ISO 8601 timestamp when the routine was created."
@@ -1895,7 +2207,7 @@
           "modelId": {
             "type": "string",
             "format": "uuid",
-            "description": "The shared model the prompt runs against."
+            "description": "The model the prompt runs against."
           },
           "name": {
             "type": "string",
@@ -1942,6 +2254,7 @@
         },
         "required": [
           "branchId",
+          "condition",
           "createdAt",
           "description",
           "destination",
@@ -1959,6 +2272,38 @@
           "topicName",
           "updatedAt"
         ]
+      },
+      "RoutineCondition": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "conditionPrompt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The delivery condition identified in the routine's current prompt, in plain language. Null on routines created before Omni stored delivery conditions.",
+            "example": "total signups dropped more than 20% versus the prior week"
+          },
+          "conditionType": {
+            "type": "string",
+            "enum": [
+              "RESULTS_CHANGED",
+              "RESULTS_UNCHANGED",
+              "RESULTS_PRESENT",
+              "RESULTS_MISSING"
+            ],
+            "description": "How the condition query gates delivery. RESULTS_PRESENT fires when the condition query returns rows, RESULTS_MISSING when it returns none, RESULTS_CHANGED when its results differ from the previous scheduled run, RESULTS_UNCHANGED when they are identical.",
+            "example": "RESULTS_PRESENT"
+          }
+        },
+        "required": [
+          "conditionPrompt",
+          "conditionType"
+        ],
+        "description": "The condition gating delivery, or null for a routine that delivers on every scheduled run."
       },
       "RoutineDestinationResponse": {
         "oneOf": [
@@ -2099,6 +2444,37 @@
           "id"
         ]
       },
+      "RoutineCreateApiError400": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "The prompt does not state when the routine should deliver. Add a specific, measurable delivery condition, then try again."
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 400
+          },
+          "code": {
+            "type": "string",
+            "enum": [
+              "no_query",
+              "malformed_query",
+              "no_gate",
+              "dry_run_failed",
+              "no_condition_detected"
+            ],
+            "description": "A machine-readable error code returned when Omni cannot create or validate a delivery condition. This field is absent for other validation errors.",
+            "example": "no_condition_detected"
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
       "ApiError429": {
         "type": "object",
         "properties": {
@@ -2133,10 +2509,20 @@
             "description": "Optional human-readable notes about the routine. Display-only — never used as model input.",
             "example": "Weekly signups summary for the growth team."
           },
+          "gating": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "alert",
+              "unconditional"
+            ],
+            "description": "Deprecated. Delivery conditions are no longer derived from the prompt. 'auto' (the default) and 'unconditional' create a routine that delivers on every scheduled run. 'alert' declares a delivery condition Omni cannot honor from the prompt alone and fails with code no_condition_detected.",
+            "example": "unconditional"
+          },
           "modelId": {
             "type": "string",
             "format": "uuid",
-            "description": "The UUID of the shared model the prompt runs against. Only shared models are supported.",
+            "description": "The UUID of the model the prompt runs against. Must be a shared model, or a shared-extension model usable as a workbook base.",
             "example": "770e8400-e29b-41d4-a716-446655440002"
           },
           "name": {
@@ -2276,7 +2662,7 @@
           "prompt": {
             "type": "string",
             "minLength": 1,
-            "description": "New natural language prompt Omni runs on each scheduled run."
+            "description": "New natural language prompt for the routine: what Omni runs and delivers on each scheduled run."
           },
           "schedule": {
             "type": "string",
@@ -2432,6 +2818,152 @@
           "message",
           "success"
         ]
+      },
+      "ConnectionsDbtRotateSigningKeyResponse": {
+        "type": "object",
+        "properties": {
+          "authMethod": {
+            "type": "string",
+            "enum": [
+              "ssh",
+              "https_token",
+              "github_app"
+            ],
+            "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+            "example": "ssh"
+          },
+          "autogenRelationships": {
+            "type": "boolean",
+            "description": "Whether relationships are auto-generated from dbt",
+            "example": true
+          },
+          "branch": {
+            "type": "string",
+            "description": "Git branch name",
+            "example": "main"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
+          },
+          "dbtVersion": {
+            "type": "string",
+            "description": "dbt version being used",
+            "example": "Auto"
+          },
+          "enableSemanticLayer": {
+            "type": "boolean",
+            "description": "Whether the dbt semantic layer integration is enabled",
+            "example": false
+          },
+          "enableVirtualSchemas": {
+            "type": "boolean",
+            "description": "Whether virtual schemas are enabled",
+            "example": false
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null for non-github_app auth.",
+            "example": "12345678"
+          },
+          "projectRootPath": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to dbt project root",
+            "example": "dbt_project"
+          },
+          "sshUrl": {
+            "type": "string",
+            "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
+            "example": "git@github.com:org/repo.git"
+          },
+          "supportsDbt": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Indicates dbt is supported and configured",
+            "example": true
+          }
+        },
+        "required": [
+          "authMethod",
+          "autogenRelationships",
+          "branch",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
+          "dbtVersion",
+          "enableSemanticLayer",
+          "enableVirtualSchemas",
+          "githubAppInstallationId",
+          "projectRootPath",
+          "sshUrl",
+          "supportsDbt"
+        ],
+        "description": "dbt repository configuration response",
+        "title": "DbtConfiguredResponse"
+      },
+      "ConnectionsDbtRotateSigningKeyBody": {
+        "type": "object",
+        "properties": {
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
+          },
+          "signingKeyPassphrase": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Passphrase for signingPrivateKey when it is encrypted. Omni uses it once to decrypt the key, then stores the key under its own encryption at rest; the passphrase itself is not retained."
+          },
+          "signingPrivateKey": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 65536,
+            "description": "Bring-your-own ED25519 signing private key in PEM format (as produced by `ssh-keygen -t ed25519`), used instead of an Omni-generated keypair. Enables zero-downtime rotation: register the matching public key on the GitHub user first, then set it here. RSA keys are rejected — commit signing is SSHSIG over ED25519. Must be non-blank when provided; omit it to have Omni mint a fresh keypair."
+          }
+        },
+        "additionalProperties": false
       },
       "DbtEnvironmentListResponse": {
         "type": "object",
@@ -3041,7 +3573,7 @@
               "number",
               "null"
             ],
-            "description": "Number of dashboard visits"
+            "description": "Number of visits to the document's dashboard, or to its app if it has one instead. Absent until the first visit."
           }
         },
         "required": [
@@ -3056,6 +3588,69 @@
           "identifier",
           "updatedAt",
           "url"
+        ]
+      },
+      "ContentSearchResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Dashboard description, if any."
+                },
+                "folderPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Folder path of the dashboard, if any."
+                },
+                "identifier": {
+                  "type": "string",
+                  "description": "The dashboard identifier, usable with the documents and schedules endpoints.",
+                  "example": "12db1a0a"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Dashboard name."
+                },
+                "tileNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Up to 5 query names from the dashboard's workbook — the first few, not the ones that matched."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL to open the dashboard. Omitted on MCP requests when the org has `disable-ai-mcp-links` on."
+                },
+                "verified": {
+                  "type": "boolean",
+                  "description": "Whether the dashboard carries a verified label."
+                }
+              },
+              "required": [
+                "description",
+                "folderPath",
+                "identifier",
+                "name",
+                "tileNames",
+                "verified"
+              ]
+            },
+            "description": "Matching dashboards, most relevant first."
+          }
+        },
+        "required": [
+          "results"
         ]
       },
       "DashboardsDownloadResponse": {
@@ -3081,6 +3676,12 @@
       "DashboardsDownloadBody": {
         "type": "object",
         "properties": {
+          "enableConditionalFormatting": {
+            "type": "boolean",
+            "default": true,
+            "description": "Compatible with xlsx format only. Defaults to true. When true, conditional formatting rules from the visualization are included in the Excel output — provided the organization has the 'excel-conditional-formatting' feature enabled.",
+            "example": true
+          },
           "enableFormatting": {
             "type": "boolean",
             "default": false,
@@ -4093,7 +4694,7 @@
               "restricted",
               "organization"
             ],
-            "description": "Access scope for the document"
+            "description": "Access scope for the document. Optional: when omitted the destination decides — a move into a folder takes that folder's scope, and a move to the root leaves the document's current scope unchanged. When supplied it must match the destination folder's scope."
           }
         },
         "required": [
@@ -4103,14 +4704,24 @@
       "DocumentsGetPermissionsResponse": {
         "type": "object",
         "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/DocumentAbilities"
+          },
           "permits": {
-            "description": "User permits for the document"
+            "description": "User permits for the document. Present only when userId is provided."
           }
-        }
+        },
+        "required": [
+          "abilities"
+        ]
       },
-      "DocumentsUpdatePermissionSettingsBody": {
+      "DocumentAbilities": {
         "type": "object",
         "properties": {
+          "canAnalyze": {
+            "type": "boolean",
+            "description": "Allow exploring from this document"
+          },
           "canDownload": {
             "type": "boolean",
             "description": "Allow downloading"
@@ -4118,6 +4729,86 @@
           "canDrill": {
             "type": "boolean",
             "description": "Allow drill-down"
+          },
+          "canDuplicate": {
+            "type": "boolean",
+            "description": "Allow duplicating"
+          },
+          "canRequestAccess": {
+            "type": "boolean",
+            "description": "Allow requesting access"
+          },
+          "canSaveSpreadsheets": {
+            "type": "boolean",
+            "description": "Allow creating spreadsheets"
+          },
+          "canSchedule": {
+            "type": "boolean",
+            "description": "Allow scheduling"
+          },
+          "canUpload": {
+            "type": "boolean",
+            "description": "Allow uploads"
+          },
+          "canUseDashboardAi": {
+            "type": "boolean",
+            "description": "Allow using dashboard AI"
+          },
+          "canUseTimezoneOverride": {
+            "type": "boolean",
+            "description": "Allow timezone override"
+          },
+          "canViewWorkbook": {
+            "type": "boolean",
+            "description": "Allow viewing workbook"
+          },
+          "requirePullRequestToPublish": {
+            "type": "boolean",
+            "description": "Require pull request to publish changes"
+          }
+        },
+        "required": [
+          "canAnalyze",
+          "canDownload",
+          "canDrill",
+          "canDuplicate",
+          "canRequestAccess",
+          "canSaveSpreadsheets",
+          "canSchedule",
+          "canUpload",
+          "canUseDashboardAi",
+          "canUseTimezoneOverride",
+          "canViewWorkbook",
+          "requirePullRequestToPublish"
+        ],
+        "description": "Document-level ability values, as stored on the document"
+      },
+      "DocumentsUpdatePermissionSettingsBody": {
+        "type": "object",
+        "properties": {
+          "canAnalyze": {
+            "type": "boolean",
+            "description": "Allow exploring from this document"
+          },
+          "canDownload": {
+            "type": "boolean",
+            "description": "Allow downloading"
+          },
+          "canDrill": {
+            "type": "boolean",
+            "description": "Allow drill-down"
+          },
+          "canDuplicate": {
+            "type": "boolean",
+            "description": "Allow duplicating"
+          },
+          "canRequestAccess": {
+            "type": "boolean",
+            "description": "Allow requesting access"
+          },
+          "canSaveSpreadsheets": {
+            "type": "boolean",
+            "description": "Allow creating spreadsheets"
           },
           "canSchedule": {
             "type": "boolean",
@@ -4141,7 +4832,7 @@
           },
           "organizationAccessBoost": {
             "type": "boolean",
-            "description": "Boost organization access"
+            "description": "Boost organization access. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "organizationRole": {
             "type": "string",
@@ -4165,7 +4856,7 @@
           "accessBoost": {
             "type": "boolean",
             "default": false,
-            "description": "Grant access boost"
+            "description": "Grant access boost. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -4174,7 +4865,8 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
             "description": "Role to grant"
           },
@@ -4205,7 +4897,7 @@
         "properties": {
           "accessBoost": {
             "type": "boolean",
-            "description": "Access boost setting"
+            "description": "Access boost setting. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -4214,7 +4906,8 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
             "description": "Role to set"
           },
@@ -4532,7 +5225,8 @@
             "default": [],
             "description": "Labels to remove"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "DocumentsTransferOwnershipBody": {
         "type": "object",
@@ -12371,6 +13065,16 @@
               }
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
+          },
+          "mobileBehavior": {
+            "type": "string",
+            "enum": [
+              "stack",
+              "wrap",
+              "keep",
+              "hide"
+            ],
+            "description": "Overrides the automatic mobile layout: \"keep\" freezes the desktop grid arrangement, \"hide\" hides the container on mobile (\"stack\" and \"wrap\" apply to row stacks)"
           },
           "padding": {
             "anyOf": [
@@ -20711,6 +21415,16 @@
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
           },
+          "mobileBehavior": {
+            "type": "string",
+            "enum": [
+              "stack",
+              "wrap",
+              "keep",
+              "hide"
+            ],
+            "description": "Overrides the automatic mobile layout: \"stack\" flips a row to a column, \"wrap\" keeps the row and wraps items, \"keep\" freezes the desktop arrangement, \"hide\" hides the container on mobile"
+          },
           "padding": {
             "anyOf": [
               {
@@ -21641,6 +22355,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -21742,6 +22463,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -21885,6 +22613,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -21960,6 +22695,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22038,6 +22780,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22154,6 +22903,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -22225,6 +22981,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22314,6 +23077,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22533,6 +23303,13 @@
                   },
                   "label": {
                     "type": "string"
+                  },
+                  "fieldOrder": {
+                    "type": "string",
+                    "enum": [
+                      "query",
+                      "control"
+                    ]
                   },
                   "options": {
                     "type": "array",
@@ -22933,6 +23710,14 @@
             ],
             "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
           },
+          "fileUploadId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "File upload backing this tab (a CSV data-input / Source tab or a spreadsheet tab). Applies only to csv / spreadsheet tabs — rejected on patches for other tab types."
+          },
           "filterOrder": {
             "type": "array",
             "items": {
@@ -22980,6 +23765,11 @@
                       "type": "boolean",
                       "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
                     },
+                    "anchor_row": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "description": "The 1-indexed row the Excel-style formula was authored against, so row-relative references resolve to the intended offsets — e.g. a percent-of-previous \"=B4/B5\" authored on row 5. Only used when sql_expression is omitted; defaults to 1 (B1 = this row)."
+                    },
                     "calc_name": {
                       "type": "string",
                       "description": "Internal identifier for the calculation, used as the column alias."
@@ -22998,7 +23788,7 @@
                     },
                     "original_formula": {
                       "type": "string",
-                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                      "description": "The calculation formula. Prefer referencing selected fields by name (e.g. \"=SUM(orders.revenue)\") — name references are stable under column reordering and have no row semantics. Excel-style references also work: column letters map to the query's fields in table order (A = the first field) with rows anchored at row 1 (set anchor_row to author row-relative references against a different row), and calc columns can only be referenced by letter. When sql_expression is omitted, the server parses this formula on write and rejects the request if it does not parse."
                     },
                     "outside_pivot": {
                       "type": "boolean",
@@ -23016,7 +23806,7 @@
                       "description": "Compiled SQL string produced from the formula."
                     },
                     "sql_expression": {
-                      "description": "Parsed SQL expression tree (serialized)."
+                      "description": "Parsed SQL expression tree (serialized, server-internal format). Omit it to have the server parse original_formula instead."
                     },
                     "swallow_errors": {
                       "type": "boolean",
@@ -23266,6 +24056,13 @@
                         },
                         "label": {
                           "type": "string"
+                        },
+                        "fieldOrder": {
+                          "type": "string",
+                          "enum": [
+                            "query",
+                            "control"
+                          ]
                         },
                         "options": {
                           "type": "array",
@@ -23563,7 +24360,7 @@
               },
               "default_group_by": {
                 "type": "boolean",
-                "description": "When true, all dimensions are implicitly included in GROUP BY."
+                "description": "When true, all dimensions are implicitly included in GROUP BY, unless the model's default_group_by setting (never or primary_key) suppresses it."
               },
               "dimensionIndex": {
                 "type": "number",
@@ -23674,6 +24471,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -23778,6 +24582,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -23924,6 +24735,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24002,6 +24820,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24083,6 +24908,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24202,6 +25034,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24276,6 +25115,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24368,6 +25214,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24477,6 +25330,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24581,6 +25441,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24727,6 +25594,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24805,6 +25679,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24886,6 +25767,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -25005,6 +25893,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -25079,6 +25974,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -25172,6 +26074,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -25233,6 +26142,13 @@
                   "additionalProperties": {}
                 },
                 "description": "Per-field display metadata (format, label, order)."
+              },
+              "model_extension_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The query model this query is bound to — a model extension layered on this document’s workbook model. Exposed on read. Server-owned on write: a value supplied on PATCH or create is ignored and the tile keeps its existing binding, so editing a tile cannot orphan its query model. An entry that carries no `query` clears the tile’s query, dropping the binding with it. Changing a binding is a draft-scoped operation, not expressible through this field. The id is a draft-local clone and is not stable across the publish cycle — each draft re-clones its query models under a new workbook model. LINKED tabs don’t carry one: their query, and its binding, come from the source tab."
               },
               "offset": {
                 "type": "number",
@@ -25398,7 +26314,7 @@
               "userEditedSQL"
             ],
             "additionalProperties": {},
-            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). Omitted on a no-op replay; the server anchors new/changed tiles to the draft."
+            "description": "The semantic query for this tab, minus the server-owned `modelId` anchor (the server anchors new/changed tiles to the draft; a FOREIGN tab keeps its stored execution model). `model_extension_id` is server-owned too — a supplied value is ignored and the tile keeps its existing binding (see the field’s own description). Omitted on a no-op replay."
           },
           "resultConfig": {
             "type": "object",
@@ -25431,9 +26347,10 @@
               "sql",
               "dbt",
               "query-view",
-              "linked"
+              "linked",
+              "foreign"
             ],
-            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET). `foreign` is only valid when echoing an existing foreign tab at the same key — a tab cannot be created as, or converted to/from, FOREIGN through this API."
           },
           "visConfig": {
             "type": [
@@ -25539,6 +26456,13 @@
             },
             "additionalProperties": {},
             "description": "Visualization configuration for the tile."
+          },
+          "foreignModelId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present only on FOREIGN tabs: the shared model this tab’s query executes against (a different model than the document’s). Stable across publishes. Server-owned on write — a supplied value is ignored and the tab keeps its stored execution model. Omitted for every other tab type."
           },
           "sourceQueryPresentationKey": {
             "type": [
@@ -25775,6 +26699,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -25876,6 +26807,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26019,6 +26957,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -26094,6 +27039,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26172,6 +27124,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26288,6 +27247,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -26359,6 +27325,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26448,6 +27421,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26667,6 +27647,13 @@
                   },
                   "label": {
                     "type": "string"
+                  },
+                  "fieldOrder": {
+                    "type": "string",
+                    "enum": [
+                      "query",
+                      "control"
+                    ]
                   },
                   "options": {
                     "type": "array",
@@ -26946,7 +27933,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/QueryPresentationReadExternal"
             },
-            "description": "Query presentations keyed by tab ID."
+            "description": "Query presentations keyed by tab ID. A FOREIGN tab — one whose query runs against a shared model other than this document’s — carries its execution model at `foreignModelId`."
           },
           "order": {
             "type": "array",
@@ -27025,6 +28012,14 @@
             ],
             "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
           },
+          "fileUploadId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "File upload backing this tab (a CSV data-input / Source tab or a spreadsheet tab). Applies only to csv / spreadsheet tabs — rejected on patches for other tab types."
+          },
           "filterOrder": {
             "type": "array",
             "items": {
@@ -27072,6 +28067,11 @@
                       "type": "boolean",
                       "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
                     },
+                    "anchor_row": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "description": "The 1-indexed row the Excel-style formula was authored against, so row-relative references resolve to the intended offsets — e.g. a percent-of-previous \"=B4/B5\" authored on row 5. Only used when sql_expression is omitted; defaults to 1 (B1 = this row)."
+                    },
                     "calc_name": {
                       "type": "string",
                       "description": "Internal identifier for the calculation, used as the column alias."
@@ -27090,7 +28090,7 @@
                     },
                     "original_formula": {
                       "type": "string",
-                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                      "description": "The calculation formula. Prefer referencing selected fields by name (e.g. \"=SUM(orders.revenue)\") — name references are stable under column reordering and have no row semantics. Excel-style references also work: column letters map to the query's fields in table order (A = the first field) with rows anchored at row 1 (set anchor_row to author row-relative references against a different row), and calc columns can only be referenced by letter. When sql_expression is omitted, the server parses this formula on write and rejects the request if it does not parse."
                     },
                     "outside_pivot": {
                       "type": "boolean",
@@ -27108,7 +28108,7 @@
                       "description": "Compiled SQL string produced from the formula."
                     },
                     "sql_expression": {
-                      "description": "Parsed SQL expression tree (serialized)."
+                      "description": "Parsed SQL expression tree (serialized, server-internal format). Omit it to have the server parse original_formula instead."
                     },
                     "swallow_errors": {
                       "type": "boolean",
@@ -27358,6 +28358,13 @@
                         },
                         "label": {
                           "type": "string"
+                        },
+                        "fieldOrder": {
+                          "type": "string",
+                          "enum": [
+                            "query",
+                            "control"
+                          ]
                         },
                         "options": {
                           "type": "array",
@@ -27655,7 +28662,7 @@
               },
               "default_group_by": {
                 "type": "boolean",
-                "description": "When true, all dimensions are implicitly included in GROUP BY."
+                "description": "When true, all dimensions are implicitly included in GROUP BY, unless the model's default_group_by setting (never or primary_key) suppresses it."
               },
               "dimensionIndex": {
                 "type": "number",
@@ -27766,6 +28773,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -27870,6 +28884,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28016,6 +29037,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28094,6 +29122,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28175,6 +29210,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28294,6 +29336,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28368,6 +29417,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28460,6 +29516,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28569,6 +29632,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28673,6 +29743,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28819,6 +29896,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28897,6 +29981,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28978,6 +30069,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -29097,6 +30195,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -29171,6 +30276,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -29264,6 +30376,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -29325,6 +30444,13 @@
                   "additionalProperties": {}
                 },
                 "description": "Per-field display metadata (format, label, order)."
+              },
+              "model_extension_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The query model this query is bound to — a model extension layered on this document’s workbook model. Exposed on read. Server-owned on write: a value supplied on PATCH or create is ignored and the tile keeps its existing binding, so editing a tile cannot orphan its query model. An entry that carries no `query` clears the tile’s query, dropping the binding with it. Changing a binding is a draft-scoped operation, not expressible through this field. The id is a draft-local clone and is not stable across the publish cycle — each draft re-clones its query models under a new workbook model. LINKED tabs don’t carry one: their query, and its binding, come from the source tab."
               },
               "offset": {
                 "type": "number",
@@ -29490,7 +30616,7 @@
               "userEditedSQL"
             ],
             "additionalProperties": {},
-            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). For LINKED-type tabs this field is read-only."
+            "description": "The semantic query for this tab, minus the server-owned `modelId` anchor (the workbook id, echoed at the document root; a FOREIGN tab’s execution model surfaces as the tile-level `foreignModelId` instead). Its `model_extension_id` — the query-model binding — is exposed here but is server-owned on write (see the field’s own description). For LINKED-type tabs this field is read-only."
           },
           "resultConfig": {
             "type": "object",
@@ -29523,9 +30649,10 @@
               "sql",
               "dbt",
               "query-view",
-              "linked"
+              "linked",
+              "foreign"
             ],
-            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET). `foreign` is only valid when echoing an existing foreign tab at the same key — a tab cannot be created as, or converted to/from, FOREIGN through this API."
           },
           "visConfig": {
             "type": [
@@ -29631,6 +30758,10 @@
             },
             "additionalProperties": {},
             "description": "Visualization configuration for the tile."
+          },
+          "foreignModelId": {
+            "type": "string",
+            "description": "Present only on FOREIGN tabs: the shared model this tab’s query executes against (a different model than the document’s). Stable across publishes. Server-owned on write — a supplied value is ignored and the tab keeps its stored execution model. Omitted for every other tab type."
           },
           "sourceQueryPresentationKey": {
             "type": [
@@ -29815,6 +30946,20 @@
         },
         "additionalProperties": false
       },
+      "DocumentsV2BindQueryModelBody": {
+        "type": "object",
+        "properties": {
+          "queryModelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The query model to bind this tile to. Must be a query model layered on this draft’s workbook model, not already bound to another tile. LINKED and FOREIGN tabs are rejected: a LINKED tab inherits its source’s binding, and a FOREIGN tab’s query runs against a different model."
+          }
+        },
+        "required": [
+          "queryModelId"
+        ],
+        "additionalProperties": false
+      },
       "DocumentsV2PublishDraftResponse": {
         "type": "object",
         "properties": {
@@ -29923,8 +31068,39 @@
           },
           "userAttributes": {
             "type": "object",
-            "additionalProperties": {},
-            "description": "Optional user attributes for row-level security"
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number",
+                  "minimum": -1.7976931348623157e+308,
+                  "maximum": 1.7976931348623157e+308
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number",
+                        "minimum": -1.7976931348623157e+308,
+                        "maximum": 1.7976931348623157e+308
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "description": "Optional user attributes for row-level security. Values are a string, a number, or an array of strings/numbers. Numbers are converted to strings on receipt, so send anything beyond the JSON safe integer range (2^53 - 1) as a string or it loses precision before Omni sees it.",
+            "example": {
+              "account_id": "9007199254740993",
+              "region": "us-east",
+              "tier": 2
+            }
           }
         },
         "required": [
@@ -30532,6 +31708,11 @@
             "description": "The prompt set this run was created from.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
+          "repeat_count": {
+            "type": "integer",
+            "description": "How many times each prompt in the set was executed.",
+            "example": 1
+          },
           "run_number": {
             "type": "integer",
             "description": "Sequential, per-prompt-set run number.",
@@ -30561,6 +31742,7 @@
           "is_archived",
           "model_id",
           "prompt_set_id",
+          "repeat_count",
           "run_number",
           "stats",
           "status"
@@ -30576,7 +31758,7 @@
           },
           "total": {
             "type": "integer",
-            "description": "Total number of per-prompt jobs in the run.",
+            "description": "Total number of jobs in the run (prompts × the repeat count).",
             "example": 12
           }
         },
@@ -30590,7 +31772,7 @@
         "properties": {
           "job_count": {
             "type": "integer",
-            "description": "Number of per-prompt agentic jobs created for this run (one per prompt that fanned out successfully). Enqueue onto the work queue happens after creation and is best-effort, so this count reflects jobs created, not necessarily those successfully enqueued.",
+            "description": "Number of agentic jobs created for this run (one per prompt execution — prompts × repeat count — that fanned out successfully). Enqueue onto the work queue happens after creation and is best-effort, so this count reflects jobs created, not necessarily those successfully enqueued.",
             "example": 12
           },
           "run": {
@@ -30669,12 +31851,17 @@
             "description": "The prompt set this run was created from.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
+          "repeat_count": {
+            "type": "integer",
+            "description": "How many times each prompt in the set was executed. Results carry a `repeat_index` when this is greater than 1.",
+            "example": 1
+          },
           "results": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EvalRunResult"
             },
-            "description": "Per-prompt results for this run, ordered by their creation order in the prompt set."
+            "description": "Per-execution results for this run (one per prompt, times the repeat count). No guaranteed order — group executions by `eval_prompt_id` and order by `repeat_index`."
           },
           "run_number": {
             "type": "integer",
@@ -30702,6 +31889,7 @@
           "is_archived",
           "model_id",
           "prompt_set_id",
+          "repeat_count",
           "results",
           "run_number",
           "status"
@@ -30738,6 +31926,15 @@
             "description": "Failure reason string for prompts whose underlying job failed.",
             "example": null
           },
+          "eval_prompt_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Snapshot of the prompt id this result was executed for — repeated executions of the same prompt share it, and it survives later prompt deletion. Null on runs created before repeats existed.",
+            "example": "bb0e8400-e29b-41d4-a716-446655440007"
+          },
           "expectation": {
             "type": [
               "string",
@@ -30773,6 +31970,14 @@
             "description": "Total wall-clock time (milliseconds) the underlying job spent running warehouse queries — a proxy for query execution time. Null for runs executed before this metric was recorded.",
             "example": 1800
           },
+          "repeat_index": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "0-based repeat number of this execution within the run (see the run's `repeat_count`). Null on runs created before repeats existed.",
+            "example": 0
+          },
           "score": {
             "type": [
               "number",
@@ -30802,7 +32007,7 @@
               "integer",
               "null"
             ],
-            "description": "Inner-loop tool latency in milliseconds — time spent running tools the model invoked (model and field-value lookups, query planning), excluding the warehouse query itself (`query_timing_ms`). Null for runs recorded before per-tool latency was tracked.",
+            "description": "Inner-loop tool latency in milliseconds — time spent running tools the model invoked (model and field-value lookups, query planning) plus any provider call that failed before a tool was attempted, excluding the warehouse query itself (`query_timing_ms`). Null for runs recorded before per-tool latency was tracked.",
             "example": 200
           }
         },
@@ -30811,11 +32016,13 @@
           "ai_timing_ms",
           "cost",
           "error_reason",
+          "eval_prompt_id",
           "expectation",
           "id",
           "prompt",
           "query_count",
           "query_timing_ms",
+          "repeat_index",
           "score",
           "scoring_cost",
           "timing_ms",
@@ -30924,6 +32131,13 @@
                 "format": "uuid",
                 "description": "Optional branch ID to run against. Must be a branch of the prompt set's model.",
                 "example": "440e8400-e29b-41d4-a716-446655440006"
+              },
+              "repeat_count": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": "How many times to execute each prompt in the set (defaults to 1). Between 1 and 10; prompts × repeats may not exceed the per-run job limit.",
+                "example": 1
               }
             },
             "description": "Per-run configuration. Optional — omit if no overrides."
@@ -30973,13 +32187,13 @@
                 "$ref": "#/components/schemas/EvalRunDetail"
               },
               {
-                "description": "The cancelled run. `status: CANCELLED` and `is_archived: true` after this call."
+                "description": "The cancelled run. `status: CANCELLED` and `is_archived: false` after this call."
               }
             ]
           },
           "total": {
             "type": "integer",
-            "description": "Total number of per-prompt jobs in the run.",
+            "description": "Total number of jobs in the run (prompts × the repeat count).",
             "example": 12
           }
         },
@@ -31092,6 +32306,10 @@
       "FoldersCreateResponse": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "Whether breadcrumbs start at this folder"
+          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -31120,6 +32338,7 @@
           }
         },
         "required": [
+          "breadcrumbRoot",
           "id",
           "name",
           "ownerId",
@@ -31130,6 +32349,10 @@
       "FoldersCreateBody": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "When true, breadcrumbs for content in this folder start at this folder, hiding parent folders"
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -31174,6 +32397,10 @@
       "FoldersUpdateResponse": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "Whether breadcrumbs start at this folder"
+          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -31189,6 +32416,7 @@
           }
         },
         "required": [
+          "breadcrumbRoot",
           "id",
           "name",
           "path"
@@ -31197,6 +32425,10 @@
       "FoldersUpdateBody": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "When true, breadcrumbs for content in this folder start at this folder, hiding parent folders"
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -31215,7 +32447,45 @@
             "default": false,
             "description": "When true, automatically resolves path collisions with existing folders by appending a numeric suffix (e.g., my-path-1). When false (default), returns 409 Conflict if the path is already taken. Does not apply to reserved paths, which are always rejected with 400."
           }
-        }
+        },
+        "additionalProperties": false
+      },
+      "FoldersBulkUpdateLabelsResponse": {
+        "type": "object",
+        "properties": {
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The folder's labels after the update"
+          }
+        },
+        "required": [
+          "labels"
+        ]
+      },
+      "FoldersBulkUpdateLabelsBody": {
+        "type": "object",
+        "properties": {
+          "add": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Label names to add to the folder"
+          },
+          "remove": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Label names to remove from the folder"
+          }
+        },
+        "additionalProperties": false
       },
       "FoldersGetPermissionsResponse": {
         "type": "object",
@@ -31231,7 +32501,7 @@
                 },
                 "role": {
                   "type": "string",
-                  "description": "Content role (e.g., VIEWER, EDITOR, MANAGER)",
+                  "description": "Content role (e.g., VIEWER, EDITOR, MANAGER, OWNER)",
                   "example": "VIEWER"
                 },
                 "userGroupId": {
@@ -31273,7 +32543,7 @@
           "accessBoost": {
             "type": "boolean",
             "default": false,
-            "description": "Whether to grant access boost"
+            "description": "Whether to grant access boost. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -31282,9 +32552,10 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
-            "description": "Content role to assign (VIEWER, EDITOR, or MANAGER)",
+            "description": "Content role to assign (NO_ACCESS, VIEWER, EXPLORER, EDITOR, MANAGER, or OWNER). OWNER may only be granted to users, never to groups, and never with an expiry.",
             "example": "VIEWER"
           },
           "userGroupIds": {
@@ -31327,7 +32598,7 @@
         "properties": {
           "accessBoost": {
             "type": "boolean",
-            "description": "Whether to grant access boost"
+            "description": "Whether to grant access boost. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -31336,7 +32607,8 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
             "description": "New content role to assign"
           },
@@ -31877,6 +33149,167 @@
           "value"
         ]
       },
+      "GenerateSuggestionsResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the created generation run. Poll `GET /suggestions/runs/{runId}` for status."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued"
+            ],
+            "description": "The generation run was enqueued. Generation runs asynchronously."
+          }
+        },
+        "required": [
+          "runId",
+          "status"
+        ]
+      },
+      "SuggestionsCooldownResponse": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "lastCompletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the most recent run completed."
+          },
+          "retryAfterSeconds": {
+            "type": "integer",
+            "description": "Seconds to wait before a new run is allowed."
+          },
+          "status": {
+            "type": "integer",
+            "example": 429
+          }
+        },
+        "required": [
+          "detail",
+          "lastCompletedAt",
+          "retryAfterSeconds",
+          "status"
+        ]
+      },
+      "SuggestionRun": {
+        "type": "object",
+        "properties": {
+          "completedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the run reached a terminal state."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the run was created (queued)."
+          },
+          "error": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Failure details when `status` is `failed`; null otherwise."
+          },
+          "executionStartedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the worker started executing; null while queued."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The run id."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "executing",
+              "complete",
+              "failed"
+            ],
+            "description": "Run status. Terminal states are `complete` and `failed`."
+          },
+          "triggerSource": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "scheduled"
+            ],
+            "description": "Whether the run was triggered manually or by the schedule."
+          },
+          "triggeredBy": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "userId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "name",
+              "userId"
+            ],
+            "description": "The user who triggered a manual run; null for scheduled runs."
+          }
+        },
+        "required": [
+          "completedAt",
+          "createdAt",
+          "error",
+          "executionStartedAt",
+          "id",
+          "status",
+          "triggerSource",
+          "triggeredBy"
+        ]
+      },
+      "SuggestionRunLatestResponse": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuggestionRun"
+              },
+              {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "The most recent run for this model, or null if none exists."
+              }
+            ]
+          }
+        },
+        "required": [
+          "run"
+        ]
+      },
       "ScheduleSuggestionsResponse": {
         "type": "object",
         "properties": {
@@ -32376,8 +33809,29 @@
           },
           "filters": {
             "type": "object",
-            "additionalProperties": {},
-            "description": "Filters for the field"
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "string",
+                    "number",
+                    "date",
+                    "boolean",
+                    "null",
+                    "composite",
+                    "query",
+                    "user_attribute"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": {}
+            },
+            "description": "Filters for the field, keyed by filter id"
           },
           "format": {
             "type": "string",
@@ -32387,9 +33841,27 @@
             "type": "array",
             "items": {
               "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "string",
+                    "number",
+                    "date",
+                    "boolean",
+                    "null",
+                    "composite",
+                    "query",
+                    "user_attribute"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ],
               "additionalProperties": {}
             },
-            "description": "Group filters"
+            "description": "Group filters, one filter per entry in groupNames"
           },
           "groupLabel": {
             "type": "string",
@@ -32545,7 +34017,62 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "additionalProperties": {}
+                  "properties": {
+                    "bidirectional": {
+                      "type": "boolean"
+                    },
+                    "extension_model_id": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "ignored": {
+                      "type": "boolean"
+                    },
+                    "join_type": {
+                      "type": "string"
+                    },
+                    "left_view_alias": {
+                      "type": "string"
+                    },
+                    "left_view_label": {
+                      "type": "string"
+                    },
+                    "left_view_name": {
+                      "type": "string"
+                    },
+                    "original_on_sql": {
+                      "type": "string"
+                    },
+                    "right_view_alias": {
+                      "type": "string"
+                    },
+                    "right_view_label": {
+                      "type": "string"
+                    },
+                    "right_view_name": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "yaml_path_prefix": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "join_type",
+                    "left_view_name",
+                    "original_on_sql",
+                    "right_view_name",
+                    "sql",
+                    "type"
+                  ]
                 },
                 "description": "Relationships for the topic"
               },
@@ -32553,6 +34080,148 @@
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "properties": {
+                    "ai_context": {
+                      "type": "string"
+                    },
+                    "aliases": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "catalog": {
+                      "type": "string"
+                    },
+                    "default_drill_fields": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "dimensions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field_name": {
+                            "type": "string",
+                            "description": "Field name"
+                          }
+                        },
+                        "required": [
+                          "field_name"
+                        ],
+                        "additionalProperties": {}
+                      }
+                    },
+                    "display_order": {
+                      "type": "number"
+                    },
+                    "extension_model_id": {
+                      "type": "string"
+                    },
+                    "fields_limited": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "filter_only_fields": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field_name": {
+                            "type": "string",
+                            "description": "Field name"
+                          }
+                        },
+                        "required": [
+                          "field_name"
+                        ],
+                        "additionalProperties": {}
+                      }
+                    },
+                    "folder": {
+                      "type": "string"
+                    },
+                    "hidden": {
+                      "type": "boolean"
+                    },
+                    "ide_file_name": {
+                      "type": "string"
+                    },
+                    "ignored": {
+                      "type": "boolean"
+                    },
+                    "is_pseudo_display_view": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "measures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field_name": {
+                            "type": "string",
+                            "description": "Field name"
+                          }
+                        },
+                        "required": [
+                          "field_name"
+                        ],
+                        "additionalProperties": {}
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "schema_label": {
+                      "type": "string"
+                    },
+                    "table_name": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "topic_scope": {
+                      "type": "string"
+                    },
+                    "yaml_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "dimensions",
+                    "filter_only_fields",
+                    "ide_file_name",
+                    "measures",
+                    "name",
+                    "yaml_path"
+                  ],
                   "additionalProperties": {}
                 },
                 "description": "Views available in the topic"
@@ -32902,6 +34571,122 @@
           "dbt_environment_id"
         ]
       },
+      "ModelsBranchDbtGetResponse": {
+        "type": "object",
+        "properties": {
+          "git_branch": {
+            "type": "string",
+            "description": "The dbt git branch the environment compiles against. When none is pinned, this is the resolved default: for a non-production environment on a branch, a git branch named after the Omni branch; otherwise the dbt repo's default branch. If the named branch doesn't exist in the dbt repo, compilation falls back to the repo's default branch.",
+            "example": "feature/new-metrics"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the dbt environment the branch resolves to",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "is_default_environment": {
+            "type": "boolean",
+            "description": "True when the branch resolves to the connection's default (production) environment — typically because the branch has no dbt environment of its own."
+          },
+          "is_deferral_enabled": {
+            "type": "boolean"
+          },
+          "manifest_status": {
+            "type": "string",
+            "enum": [
+              "NOT_FOUND",
+              "OUTDATED",
+              "UP_TO_DATE"
+            ],
+            "description": "Whether the environment's compiled dbt manifest is up to date"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "Production"
+          },
+          "owner_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "User id the environment belongs to (a personal development environment), or null"
+          },
+          "target_database": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_role": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_schema": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelsBranchDbtEnvironmentVariable"
+            }
+          }
+        },
+        "required": [
+          "git_branch",
+          "id",
+          "is_default_environment",
+          "is_deferral_enabled",
+          "manifest_status",
+          "name",
+          "owner_id",
+          "target_database",
+          "target_name",
+          "target_role",
+          "target_schema",
+          "variables"
+        ]
+      },
+      "ModelsBranchDbtEnvironmentVariable": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "is_secret": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Always null when is_secret is true."
+          }
+        },
+        "required": [
+          "id",
+          "is_secret",
+          "name",
+          "value"
+        ]
+      },
       "JobCreatedResponse": {
         "type": "object",
         "properties": {
@@ -33104,9 +34889,10 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
-            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33124,6 +34910,30 @@
             "description": "Clone URL of the git repository (SSH or HTTPS)",
             "example": "git@github.com:org/repo.git"
           },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
           "gitFollower": {
             "type": "boolean",
             "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
@@ -33133,6 +34943,14 @@
             "type": "string",
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
           },
           "modelPath": {
             "type": [
@@ -33188,8 +35006,12 @@
           "baseBranch",
           "branchPerPullRequest",
           "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
           "gitFollower",
           "gitServiceProvider",
+          "githubAppInstallationId",
           "modelPath",
           "publicKey",
           "requirePullRequest",
@@ -33205,9 +35027,10 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
-            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33225,6 +35048,30 @@
             "description": "Clone URL of the git repository (SSH or HTTPS)",
             "example": "git@github.com:org/repo.git"
           },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
           "gitFollower": {
             "type": "boolean",
             "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
@@ -33234,6 +35081,14 @@
             "type": "string",
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
           },
           "modelPath": {
             "type": [
@@ -33289,8 +35144,12 @@
           "baseBranch",
           "branchPerPullRequest",
           "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
           "gitFollower",
           "gitServiceProvider",
+          "githubAppInstallationId",
           "modelPath",
           "publicKey",
           "requirePullRequest",
@@ -33306,10 +35165,11 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
             "default": "ssh",
-            "description": "Authentication method. \"ssh\" for deploy key (default), \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key (default), \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation (github.com only).",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33327,8 +35187,28 @@
           "cloneUrl": {
             "type": "string",
             "minLength": 1,
-            "description": "Clone URL of the git repository. SSH (git@...) for deploy key auth, HTTPS (https://...) for token auth.",
+            "description": "Clone URL of the git repository. SSH (git@...) for deploy key auth, HTTPS (https://...) for token or GitHub App auth.",
             "example": "git@github.com:org/repo.git"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
           },
           "deployKeyPassphrase": {
             "type": "string",
@@ -33359,6 +35239,12 @@
             "default": "auto",
             "description": "The git provider type. Use \"auto\" for automatic detection. Defaults to \"auto\"",
             "example": "auto"
+          },
+          "githubAppInstallationId": {
+            "type": "string",
+            "pattern": "^[0-9]+$",
+            "description": "Numeric GitHub App installation ID (the value in the URL after installing the Omni GitHub App on the repo). Required when authMethod is \"github_app\".",
+            "example": "12345678"
           },
           "modelPath": {
             "type": "string",
@@ -33403,9 +35289,10 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
-            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33423,6 +35310,30 @@
             "description": "Clone URL of the git repository (SSH or HTTPS)",
             "example": "git@github.com:org/repo.git"
           },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
           "gitFollower": {
             "type": "boolean",
             "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
@@ -33432,6 +35343,14 @@
             "type": "string",
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
           },
           "modelPath": {
             "type": [
@@ -33487,8 +35406,12 @@
           "baseBranch",
           "branchPerPullRequest",
           "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
           "gitFollower",
           "gitServiceProvider",
+          "githubAppInstallationId",
           "modelPath",
           "publicKey",
           "requirePullRequest",
@@ -33504,7 +35427,8 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
             "description": "Authentication method to change to.",
             "example": "ssh"
@@ -33524,6 +35448,26 @@
             "minLength": 1,
             "description": "Clone URL of the git repository (SSH or HTTPS).",
             "example": "git@github.com:org/repo.git"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
           },
           "deployKeyPassphrase": {
             "type": "string",
@@ -33552,6 +35496,12 @@
             ],
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": "string",
+            "pattern": "^[0-9]+$",
+            "description": "Numeric GitHub App installation ID (the value in the URL after installing the Omni GitHub App on the repo). Required when authMethod is \"github_app\".",
+            "example": "12345678"
           },
           "modelPath": {
             "type": "string",
@@ -33646,6 +35596,181 @@
             "example": "Update model schema"
           }
         }
+      },
+      "ModelsGitRotateSigningKeyResponse": {
+        "type": "object",
+        "properties": {
+          "authMethod": {
+            "type": "string",
+            "enum": [
+              "ssh",
+              "https_token",
+              "github_app"
+            ],
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+            "example": "ssh"
+          },
+          "baseBranch": {
+            "type": "string",
+            "description": "The target branch for Omni pull requests",
+            "example": "main"
+          },
+          "branchPerPullRequest": {
+            "type": "boolean",
+            "description": "If true, all pull requests will create a branch in Omni, even those created outside of the tool",
+            "example": false
+          },
+          "cloneUrl": {
+            "type": "string",
+            "description": "Clone URL of the git repository (SSH or HTTPS)",
+            "example": "git@github.com:org/repo.git"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
+          "gitFollower": {
+            "type": "boolean",
+            "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
+            "example": false
+          },
+          "gitServiceProvider": {
+            "type": "string",
+            "description": "The git provider type",
+            "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
+          },
+          "modelPath": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to model files in the repository",
+            "example": "omni/my_model"
+          },
+          "publicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSH public key for repository access (deploy key). Null for HTTPS token auth.",
+            "example": "ssh-ed25519 AAAA..."
+          },
+          "requirePullRequest": {
+            "type": "string",
+            "enum": [
+              "always",
+              "users-only",
+              "never"
+            ],
+            "description": "When pull requests are required: \"always\" for all changes, \"users-only\" for user-initiated changes only, \"never\" for direct commits.",
+            "example": "users-only"
+          },
+          "sshUrl": {
+            "type": "string",
+            "deprecated": true,
+            "description": "Deprecated — use cloneUrl. Clone URL of the git repository."
+          },
+          "webUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Custom web URL for the git repository, or null if not set",
+            "example": "https://github.com/org/repo"
+          },
+          "webhookSecret": {
+            "type": "string",
+            "description": "Webhook secret for signature verification. Only included if requested via ?include=webhookSecret"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "description": "Webhook URL to configure in your git provider",
+            "example": "https://app.omni.co/api/webhooks/model/..."
+          }
+        },
+        "required": [
+          "authMethod",
+          "baseBranch",
+          "branchPerPullRequest",
+          "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
+          "gitFollower",
+          "gitServiceProvider",
+          "githubAppInstallationId",
+          "modelPath",
+          "publicKey",
+          "requirePullRequest",
+          "sshUrl",
+          "webUrl",
+          "webhookUrl"
+        ]
+      },
+      "ModelsGitRotateSigningKeyBody": {
+        "type": "object",
+        "properties": {
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
+          },
+          "signingKeyPassphrase": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Passphrase for signingPrivateKey when it is encrypted. Omni uses it once to decrypt the key, then stores the key under its own encryption at rest; the passphrase itself is not retained."
+          },
+          "signingPrivateKey": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 65536,
+            "description": "Bring-your-own ED25519 signing private key in PEM format (as produced by `ssh-keygen -t ed25519`), used instead of an Omni-generated keypair. Enables zero-downtime rotation: register the matching public key on the GitHub user first, then set it here. RSA keys are rejected — commit signing is SSHSIG over ED25519. Must be non-blank when provided; omit it to have Omni mint a fresh keypair."
+          }
+        },
+        "additionalProperties": false
       },
       "ModelsContentValidatorGetResponse": {
         "type": "object",
@@ -33757,7 +35882,7 @@
               "TOPIC",
               "VIEW"
             ],
-            "description": "Type of find/replace operation."
+            "description": "Type of find/replace operation. A FIELD replacement also rewrites references to the field through the join aliases of its view (with users joined as sellers, users.age → users.age2 also rewrites sellers.age → sellers.age2); an alias that names a different view in some other topic is only rewritten in content known to be in the topic that aliases it. VIEW replacements do not touch aliases."
           },
           "folder_paths": {
             "type": "array",
@@ -33814,8 +35939,10 @@
           },
           "viewNames": {
             "type": "object",
-            "additionalProperties": {},
-            "description": "View name mappings"
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Mapping of file name to view name"
           }
         },
         "required": [
@@ -33920,29 +36047,146 @@
           "prompt"
         ]
       },
-      "QueryRunResponse": {
+      "QueryRunStreamLine": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/QueryStreamJobsSubmittedLine"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamJobLine"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamFooterLine"
+          }
+        ],
+        "description": "One line of the query/run NDJSON stream: a jobs_submitted header, then one line per job, then a footer."
+      },
+      "QueryStreamJobsSubmittedLine": {
         "type": "object",
         "properties": {
-          "completedQueries": {
-            "type": "array",
-            "items": {},
-            "description": "Queries that completed synchronously with their results."
+          "jobs_submitted": {
+            "type": "object",
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "description": "Map of submitted job ID to the client result ID for that job (null when the job has no client result ID). Job IDs are the keys to poll via /api/v1/query/wait."
+          }
+        },
+        "required": [
+          "jobs_submitted"
+        ],
+        "description": "First line of the query/run stream: the jobs accepted for execution."
+      },
+      "QueryStreamJobLine": {
+        "type": "object",
+        "properties": {
+          "cache_metadata": {
+            "description": "Cache metadata for the result (row count, byte size, freshness timestamps, requery plan key)."
           },
-          "jobIds": {
+          "client_result_id": {
+            "type": "string",
+            "description": "Client-supplied result ID echoed back for correlating jobs to queries."
+          },
+          "column_name_mapping": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "error": {
+            "description": "Structured error details, e.g. an OAuth re-authentication requirement."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Human-readable error message. Present on failed jobs.",
+            "example": "No such view \"order_items\""
+          },
+          "error_type": {
+            "type": "string",
+            "description": "Machine-readable error category (e.g. PLAN, SQL). Present on failed jobs.",
+            "example": "PLAN"
+          },
+          "job_id": {
+            "type": "string",
+            "description": "ID of the query job this line reports on."
+          },
+          "kill_reason": {
+            "type": "string",
+            "description": "Why the job was killed, when it was cancelled."
+          },
+          "query": {
+            "description": "The query that was executed."
+          },
+          "requery_fallback_sql": {
+            "type": "string"
+          },
+          "requery_sql": {
+            "type": "string",
+            "description": "SQL to re-query the cached result set, when the result supports requery."
+          },
+          "requery_table_name": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string",
+            "description": "Result rows as a base64-encoded Arrow IPC stream. Present on completed jobs. Decode with any Arrow IPC reader and use summary.fields to interpret the columns."
+          },
+          "status": {
+            "type": "string",
+            "description": "Job status. Known values include COMPLETE, ERROR, FAILED, and MISSING; new values may be added over time.",
+            "example": "COMPLETE"
+          },
+          "stream_stats": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Server-side streaming latency stats, in milliseconds."
+          },
+          "summary": {
+            "description": "Execution summary. summary.fields maps field names to their metadata and is needed to interpret the decoded Arrow table; also carries the generated SQL and cache type."
+          },
+          "used_keys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "description": "Per-job line emitted as each job reaches a terminal state. A completed job carries the result set as base64-encoded Arrow IPC in `result`; a failed job carries `error_type` and `error_message` instead."
+      },
+      "QueryStreamFooterLine": {
+        "type": "object",
+        "properties": {
+          "remaining_job_ids": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Job IDs for queries running asynchronously. Use /api/v1/query/wait to poll for results.",
-            "example": [
-              "job_abc123",
-              "job_def456"
-            ]
+            "description": "Job IDs that had not completed when the wait window elapsed. Poll /api/v1/query/wait with these IDs until the list is empty.",
+            "example": []
           },
-          "plan": {
-            "description": "Query execution plan (only present if planOnly is true)."
+          "timed_out": {
+            "type": "string",
+            "enum": [
+              "false",
+              "true"
+            ],
+            "description": "Whether the wait window elapsed before every job completed. Note: a string (\"true\"/\"false\"), not a boolean.",
+            "example": "false"
           }
-        }
+        },
+        "required": [
+          "remaining_job_ids",
+          "timed_out"
+        ],
+        "description": "Last line of the stream."
       },
       "QueryTimeoutResponse": {
         "type": "object",
@@ -34025,21 +36269,23 @@
             "format": "uuid",
             "description": "Alternate location for the `?userId=` query parameter. Prefer the query parameter — this body field exists for backwards compatibility. Supplying both forms results in a 400. Only valid for org-scoped API keys; when set, the user's attributes are applied for row-level security and connection-environment switching.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workbookUrl": {
+            "type": "boolean",
+            "description": "If true, creates an ephemeral workbook for the query and returns its URL in the `X-Omni-Workbook-Url` response header, for all resultType modes. Requires the workbooks permission on the query's model for the (target) user; the header is silently omitted otherwise. Cannot be combined with planOnly."
           }
         }
       },
-      "QueryWaitResponse": {
-        "type": "object",
-        "properties": {
-          "results": {
-            "type": "array",
-            "items": {},
-            "description": "Array of completed query results. Each result contains the query data or an error."
+      "QueryWaitStreamLine": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/QueryStreamJobLine"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamFooterLine"
           }
-        },
-        "required": [
-          "results"
-        ]
+        ],
+        "description": "One line of the query/wait NDJSON stream: one line per completed job, then a footer. Unlike query/run, there is no jobs_submitted header line."
       },
       "SchedulesListItem": {
         "type": "object",
@@ -35811,6 +38057,68 @@
           "success"
         ]
       },
+      "UploadPutResponse": {
+        "type": "object",
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "description": "File name of the replacement upload",
+            "example": "users_updated.csv"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The upload id — unchanged by the data swap"
+          },
+          "inDbAsTableName": {
+            "type": "string",
+            "description": "Database table name in the scratch schema (empty for S3-only connections)"
+          },
+          "refreshedModelIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Models whose view of this upload was re-pointed at the new data (the upload's workbook model, or the connection's shared models holding a view backed by this upload)"
+          },
+          "rowCount": {
+            "type": "integer",
+            "description": "Number of rows in the replacement file"
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "Whether the file was truncated due to row limit"
+          },
+          "viewName": {
+            "type": "string",
+            "description": "View name — unchanged by the data swap"
+          }
+        },
+        "required": [
+          "fileName",
+          "id",
+          "inDbAsTableName",
+          "refreshedModelIds",
+          "rowCount",
+          "truncated",
+          "viewName"
+        ]
+      },
+      "UploadPutBody": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "The replacement CSV file. Fully replaces the existing data. Column renames/removals may break content referencing the old columns.",
+            "format": "binary"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "additionalProperties": false
+      },
       "UsersGetModelRolesResponse": {
         "type": "object",
         "properties": {
@@ -36412,6 +38720,7 @@
                 "USE_AI",
                 "USE_IDE",
                 "USE_WORKBOOKS",
+                "CREATE_APPS",
                 "UPDATE",
                 "UPDATE_RESTRICTED"
               ]
@@ -36459,7 +38768,7 @@
   "paths": {
     "/api/v1/ai/generate-query": {
       "post": {
-        "description": "Generate an Omni semantic query from a natural language prompt. Optionally executes the generated query and returns results. The AI analyzes the prompt, selects appropriate fields and filters from the model, and constructs a query. Requires the querier role on the target model.",
+        "description": "Generate an Omni semantic query from a natural language prompt. Optionally executes the generated query and returns results. The AI analyzes the prompt, selects appropriate fields and filters from the model, and constructs a query. Requires the querier role on the target model. The effective user's per-connector AI toggles (set in the chat + menu) govern which integration tools the agent may use.",
         "operationId": "aiGenerateQuery",
         "summary": "Generate query from natural language",
         "tags": [
@@ -36684,7 +38993,7 @@
     },
     "/api/v1/ai/jobs": {
       "post": {
-        "description": "Submit a new AI job for asynchronous execution. The AI will analyze the prompt, generate and execute queries against the specified model, and produce a summarized answer. Jobs are processed by a background worker and typically complete within 15–60 seconds. Use GET /api/v1/ai/jobs/{jobId} to poll for status, or configure a webhookUrl to receive a notification when the job completes. Optionally continue an existing conversation by providing a conversationId.",
+        "description": "Submit a new AI job for asynchronous execution. The AI will analyze the prompt, generate and execute queries against the specified model, and produce a summarized answer. Jobs are processed by a background worker and typically complete within 15–60 seconds. Use GET /api/v1/ai/jobs/{jobId} to poll for status, or configure a webhookUrl to receive a notification when the job completes. Optionally continue an existing conversation by providing a conversationId. The effective user's per-connector AI toggles (set in the chat + menu) govern which integration tools the agent may use.",
         "operationId": "aiJobSubmit",
         "summary": "Submit an AI job",
         "tags": [
@@ -37289,7 +39598,7 @@
     },
     "/api/v1/ai/credit-controls": {
       "get": {
-        "description": "Get the organization's AI credit controls: the downgrade and shutoff thresholds, the default per-user credit limit, plus read-only context (the credit limit, usage so far this billing period, and the period bounds). This is the API mirror of the AI Hub credit controls page and requires the same AI-admin permission.",
+        "description": "Get the organization's AI credit controls: the downgrade and shutoff thresholds, the default per-user and per-entity-group credit limits, plus read-only context (the credit limit, usage so far this billing period, and the period bounds). This is the API mirror of the AI Hub credit controls page and requires the same AI-admin permission.",
         "operationId": "aiCreditControlsGet",
         "summary": "Get AI credit controls",
         "tags": [
@@ -37329,7 +39638,7 @@
         }
       },
       "patch": {
-        "description": "Update the organization's AI credit controls: the downgrade and shutoff thresholds and the default per-user credit limit (userDefaultCredits). All fields are optional and tri-state: omit a field to leave it unchanged, send `null` to turn that control off (for userDefaultCredits: unlimited by default), or send a non-negative number to set it. At least one field is required. The `downgradeCredits <= shutoffCredits` invariant is enforced against the merged result. Returns the full current state, the same shape as GET.",
+        "description": "Update the organization's AI credit controls: the downgrade and shutoff thresholds, the default per-user credit limit (userDefaultCredits), and the default per-entity-group credit limit (entityGroupDefaultCredits). All fields are optional and tri-state: omit a field to leave it unchanged, send `null` to turn that control off (for the defaults: unlimited by default), or send a non-negative number to set it. At least one field is required. The `downgradeCredits <= shutoffCredits` invariant is enforced against the merged result. Returns the full current state, the same shape as GET.",
         "operationId": "aiCreditControlsUpdate",
         "summary": "Update AI credit controls",
         "tags": [
@@ -37538,6 +39847,299 @@
         }
       }
     },
+    "/api/v1/ai/credit-controls/entity-groups": {
+      "patch": {
+        "description": "Set individual embed entity groups' AI credit limits in bulk. Each entry names an entity group by its embed `entity` string and either sets an individual limit (`creditLimit`: a non-negative number, or `null` for unlimited) or removes one (`useDefaultLimit: true`) so the entity group follows the org default. Each entity may appear at most once and must have an entity group in the organization. All updates are applied in one transaction, so either every entry takes effect or none do — an unknown entity fails the whole request with a 404 naming it. Requires the same add/remove-users permission as the group settings page and the embed-entity credit-limit feature flag.",
+        "operationId": "aiCreditControlsEntityGroupsUpdate",
+        "summary": "Set individual entity groups' AI credit limits",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiEntityGroupCreditLimitsUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "All entries applied. Returns each entity group's effective limit, in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiEntityGroupCreditLimitsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: an empty entityGroups array, more than 1000 entries, an entry with both creditLimit and useDefaultLimit (or neither), a negative creditLimit, or a duplicated entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, per-entity-group AI credit limits are not enabled, or credit controls editing is disabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "An entity has no entity group in the organization; the response names the first invalid entity. No limits are changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "List the organization's active individual embed entity-group AI credit limits, keyed by the embed `entity` string. Only entity groups with an individual limit appear — everyone else follows the org default. A `null` creditLimit is an explicit unlimited override, distinct from following the default. Paginated via opaque cursors: pass `pageInfo.nextCursor` from one response as the `cursor` query parameter on the next request. Requires the same add/remove-users permission as the PATCH.",
+        "operationId": "aiCreditControlsEntityGroupsList",
+        "summary": "List individual entity groups' AI credit limits",
+        "tags": [
+          "AI"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One page of entity groups' individual AI credit limits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditControlsEntityGroupsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid cursor or pageSize.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or per-entity-group AI credit limits are not enabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/credit-usage/users": {
+      "post": {
+        "description": "Read individual users' AI credit usage for the current billing period. Names the users by userId (the user's membership id in this organization); each id must be a member of the organization. Returns each user's credits used, in request order, plus the billing-period bounds. A user with no usage yet reports 0. At most 1000 ids per request; each userId may appear at most once. An unknown userId fails the whole request with a 404 naming it. This is a read, so it works even when credit-controls editing is disabled; it requires the same manage-user-attributes permission and per-user credit-limit feature flag as the per-user limit endpoints.",
+        "operationId": "aiCreditUsageUsersRead",
+        "summary": "Read individual users' AI credit usage",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiCreditUsageUsersBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Each requested user's credit usage for the current billing period, in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditUsageUsersResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: an empty userIds array, more than 1000 ids, or a duplicated userId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or per-user AI credit limits are not enabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A userId is not a member of the organization; the response names the first invalid id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/credit-usage/entity-groups": {
+      "post": {
+        "description": "Read individual embed entity groups' AI credit usage for the current billing period. Names the entity groups by their embed `entity` string; each must have an entity group in the organization. Returns each entity group's credits used (summed across every member sharing that entity string), in request order, plus the billing-period bounds. An entity with no usage yet reports 0. At most 1000 entities per request; each entity may appear at most once. An unknown entity fails the whole request with a 404 naming it. This is a read, so it works even when credit-controls editing is disabled; it requires the same add/remove-users permission and embed-entity credit-limit feature flag as the per-entity-group limit endpoints.",
+        "operationId": "aiCreditUsageEntityGroupsRead",
+        "summary": "Read individual entity groups' AI credit usage",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiCreditUsageEntityGroupsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Each requested entity group's credit usage for the current billing period, in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditUsageEntityGroupsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: an empty entities array, more than 1000 entities, or a duplicated entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or per-entity-group AI credit limits are not enabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "An entity has no entity group in the organization; the response names the first invalid entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/ai/routines": {
       "get": {
         "description": "List routines for the calling user, newest first. Includes routines paused by the owner or disabled by Omni, but excludes deleted routines. Use `pageInfo.nextCursor` from one response as the `cursor` query parameter on the next request. Organization API keys can pass `?userId=<membershipId>` to list routines for a specific organization member.",
@@ -37705,11 +40307,11 @@
             }
           },
           "400": {
-            "description": "Invalid request body, recipient configuration, schedule, or timezone. Also returned when the schedule is more frequent than the organization allows.",
+            "description": "Invalid request body, recipient configuration, schedule, or timezone. Also returned when the schedule is more frequent than the organization allows, and, with code `no_condition_detected`, for `gating: \"alert\"` (no delivery condition can be honored from the prompt alone).",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError400"
+                  "$ref": "#/components/schemas/RoutineCreateApiError400"
                 }
               }
             }
@@ -37725,7 +40327,7 @@
             }
           },
           "403": {
-            "description": "AI routines or AI query generation are not enabled for the organization, or the API key cannot act on behalf of the requested user.",
+            "description": "AI routines or AI query generation are not enabled for the organization, the API key cannot act on behalf of the requested user, the request used `gating: \"alert\"` but conditional routines are not enabled for the organization, or the target user is an embed user (embed users cannot own routines).",
             "content": {
               "application/json": {
                 "schema": {
@@ -37735,7 +40337,7 @@
             }
           },
           "404": {
-            "description": "Model, branch, or topic not found, or not accessible to the requested user.",
+            "description": "Model, branch, or topic not found, or not accessible to the requested user. Also returned when the `userId` membership has not accepted its invitation to the organization yet.",
             "content": {
               "application/json": {
                 "schema": {
@@ -37899,7 +40501,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError400"
+                  "$ref": "#/components/schemas/RoutineCreateApiError400"
                 }
               }
             }
@@ -38023,7 +40625,7 @@
     },
     "/api/v1/ai/routines/{id}/trigger": {
       "post": {
-        "description": "Run a routine immediately, in addition to its schedule. The run executes once using the routine owner's permissions and delivers the AI response to every configured recipient — it is not a private preview. Returns once the run has started; the result is delivered asynchronously. Organization API keys can pass `?userId=<membershipId>` to act on behalf of a specific organization member.",
+        "description": "Run a routine immediately, in addition to its schedule. The run executes once using the routine owner's permissions and delivers the AI response to every configured recipient — it is not a private preview. A conditional routine evaluates its delivery condition first, so the run may complete without delivering. Because runs execute as the owner, the owner's per-connector AI toggles (set in the chat + menu) govern which integration tools the agent may use. Returns once the run has started; the result is delivered asynchronously. Organization API keys can pass `?userId=<membershipId>` to act on behalf of a specific organization member.",
         "operationId": "routineTrigger",
         "summary": "Run a routine now",
         "tags": [
@@ -38055,7 +40657,7 @@
         ],
         "responses": {
           "202": {
-            "description": "The run has started.",
+            "description": "The run has started. For a conditional routine this is the condition evaluation, which delivers only if the condition holds.",
             "content": {
               "application/json": {
                 "schema": {
@@ -38467,6 +41069,14 @@
                       "items": {
                         "type": "object",
                         "properties": {
+                          "acceptsLicense": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether license terms have been accepted (Oracle)",
+                            "example": false
+                          },
                           "allowBranchConnectionEnvironments": {
                             "type": [
                               "boolean",
@@ -38474,6 +41084,38 @@
                             ],
                             "description": "Whether a branch may select its own connection environment. When user-attribute environment selection is also enabled, a branch selection overrides the user attribute.",
                             "example": false
+                          },
+                          "allowsUserSpecificTimezones": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether users may specify their own timezones",
+                            "example": false
+                          },
+                          "alwaysScopeViewNames": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether generated view names always include catalog/schema scoping",
+                            "example": false
+                          },
+                          "authenticationType": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`.",
+                            "example": "snowflake-password"
+                          },
+                          "awsRoleArn": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "AWS IAM role ARN (Athena)",
+                            "example": null
                           },
                           "baseRole": {
                             "type": [
@@ -38502,7 +41144,7 @@
                               "string",
                               "null"
                             ],
-                            "description": "Database name",
+                            "description": "Database/catalog name (project ID for BigQuery)",
                             "example": "analytics_db"
                           },
                           "defaultSchema": {
@@ -38518,30 +41160,48 @@
                               "string",
                               "null"
                             ],
-                            "description": "Timestamp when connection was deleted (ISO 8601)",
+                            "description": "Timestamp when connection was archived (ISO 8601)",
                             "example": null
                           },
                           "dialect": {
                             "type": "string",
                             "enum": [
-                              "snowflake",
                               "bigquery",
-                              "redshift",
-                              "postgres",
                               "mysql",
-                              "mariadb",
+                              "postgres",
+                              "redshift",
+                              "exasol",
+                              "snowflake",
+                              "motherduck",
+                              "mssql",
                               "databricks",
                               "databricks_lakebase",
+                              "clickhouse",
                               "trino",
                               "athena",
-                              "duckdb",
-                              "motherduck",
-                              "sqlserver",
-                              "clickhouse",
-                              "singlestore"
+                              "starrocks",
+                              "mariadb",
+                              "oracle",
+                              "sap_hana"
                             ],
-                            "description": "Database dialect type",
+                            "description": "Database dialect",
                             "example": "snowflake"
+                          },
+                          "enableDbSemanticLayerIntegration": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether the dialect-native semantic layer integration is enabled (Snowflake, Databricks)",
+                            "example": false
+                          },
+                          "enableDbSemanticLayerTopics": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether dialect-native semantic layer topics are generated (Snowflake, Databricks)",
+                            "example": false
                           },
                           "environmentConnectionSwitchesSchemaModel": {
                             "type": [
@@ -38551,21 +41211,209 @@
                             "description": "Whether environment connections switch schema model",
                             "example": false
                           },
+                          "externalOauthAudience": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "External OAuth audience claim (Snowflake)",
+                            "example": null
+                          },
+                          "externalOauthAuthorizationUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "External OAuth authorization URL (Snowflake)",
+                            "example": null
+                          },
+                          "externalOauthTokenUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "External OAuth token URL (Snowflake)",
+                            "example": null
+                          },
+                          "host": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Hostname or IP of the database server (account identifier for Snowflake)",
+                            "example": "myaccount"
+                          },
+                          "hostOverride": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Custom Snowflake host, overriding the account identifier",
+                            "example": null
+                          },
                           "id": {
                             "type": "string",
                             "format": "uuid",
                             "description": "Unique connection identifier",
                             "example": "550e8400-e29b-41d4-a716-446655440000"
                           },
+                          "includeOtherCatalogs": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Additional catalogs/databases included in schema refresh",
+                            "example": null
+                          },
+                          "includeSchemas": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Schemas included in schema refresh. Null means all schemas are included.",
+                            "example": [
+                              "public",
+                              "analytics"
+                            ]
+                          },
+                          "inferRelationshipsFromColumnNames": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether relationships are inferred from column-name conventions during schema refresh",
+                            "example": true
+                          },
+                          "inferRelationshipsFromForeignKeys": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether relationships are inferred from declared foreign keys during schema refresh",
+                            "example": false
+                          },
+                          "maxBillingBytes": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Maximum bytes billed for a query, as a string (BigQuery). Null when unset.",
+                            "example": null
+                          },
                           "name": {
                             "type": "string",
                             "description": "Connection display name",
                             "example": "Production Snowflake"
                           },
+                          "oauthClientId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "OAuth client ID for admin schema refresh (non-secret)",
+                            "example": null
+                          },
+                          "offloadedSchemas": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Schemas queried via the offloaded engine",
+                            "example": null
+                          },
+                          "port": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "description": "Port number for the database connection",
+                            "example": 5432
+                          },
+                          "queryTimeoutSeconds": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "description": "Query timeout in seconds",
+                            "example": 900
+                          },
+                          "queryTimezone": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Timezone used for query results",
+                            "example": null
+                          },
+                          "region": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Region (BigQuery, Athena)",
+                            "example": null
+                          },
+                          "scratchSchema": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Schema used for data input (upload) tables",
+                            "example": null
+                          },
+                          "systemTimezone": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Timezone of the database",
+                            "example": null
+                          },
+                          "trustServerCertificate": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether to trust the server certificate",
+                            "example": false
+                          },
                           "updatedAt": {
                             "type": "string",
                             "description": "Timestamp when connection was last updated (ISO 8601)",
                             "example": "2024-01-15T10:30:00Z"
+                          },
+                          "useMachineAuth": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether machine (M2M OAuth) credentials are used",
+                            "example": null
+                          },
+                          "useReadScaling": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether read scaling is enabled (MotherDuck)",
+                            "example": null
+                          },
+                          "useSessionHint": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether session hints are applied (MotherDuck)",
+                            "example": null
                           },
                           "userAttributeNameForConnectionEnvironments": {
                             "type": [
@@ -38573,7 +41421,7 @@
                               "null"
                             ],
                             "description": "User attribute name used for connection environments",
-                            "example": "region"
+                            "example": null
                           },
                           "userAttributeValuesForDefaultEnvironment": {
                             "type": [
@@ -38584,14 +41432,32 @@
                               "type": "string"
                             },
                             "description": "Default user attribute values for the base environment",
-                            "example": [
-                              "us-east",
-                              "us-west"
-                            ]
+                            "example": null
+                          },
+                          "username": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Username to authenticate with (client email for BigQuery service accounts)",
+                            "example": "analytics_user"
+                          },
+                          "warehouse": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Warehouse (Snowflake) or HTTP path (Databricks)",
+                            "example": "COMPUTE_WH"
                           }
                         },
                         "required": [
+                          "acceptsLicense",
                           "allowBranchConnectionEnvironments",
+                          "allowsUserSpecificTimezones",
+                          "alwaysScopeViewNames",
+                          "authenticationType",
+                          "awsRoleArn",
                           "baseRole",
                           "branchConnectionEnvironmentOverridesUserAttr",
                           "createdAt",
@@ -38599,12 +41465,38 @@
                           "defaultSchema",
                           "deletedAt",
                           "dialect",
+                          "enableDbSemanticLayerIntegration",
+                          "enableDbSemanticLayerTopics",
                           "environmentConnectionSwitchesSchemaModel",
+                          "externalOauthAudience",
+                          "externalOauthAuthorizationUrl",
+                          "externalOauthTokenUrl",
+                          "host",
+                          "hostOverride",
                           "id",
+                          "includeOtherCatalogs",
+                          "includeSchemas",
+                          "inferRelationshipsFromColumnNames",
+                          "inferRelationshipsFromForeignKeys",
+                          "maxBillingBytes",
                           "name",
+                          "oauthClientId",
+                          "offloadedSchemas",
+                          "port",
+                          "queryTimeoutSeconds",
+                          "queryTimezone",
+                          "region",
+                          "scratchSchema",
+                          "systemTimezone",
+                          "trustServerCertificate",
                           "updatedAt",
+                          "useMachineAuth",
+                          "useReadScaling",
+                          "useSessionHint",
                           "userAttributeNameForConnectionEnvironments",
-                          "userAttributeValuesForDefaultEnvironment"
+                          "userAttributeValuesForDefaultEnvironment",
+                          "username",
+                          "warehouse"
                         ],
                         "description": "Connection object",
                         "title": "Connection"
@@ -38660,7 +41552,7 @@
                   },
                   "authenticationType": {
                     "type": "string",
-                    "description": "Authentication type. Applicable for BigQuery, MSSQL, Snowflake, Databricks, and Athena.",
+                    "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`. Applicable for BigQuery, MSSQL, Snowflake, Databricks, and Athena.",
                     "example": "snowflake-password"
                   },
                   "awsRoleArn": {
@@ -38688,29 +41580,29 @@
                   },
                   "defaultSchema": {
                     "type": "string",
-                    "description": "The default schema to use. Required for MSSQL.",
+                    "description": "The default schema to use. Tables in it are queried without a schema prefix.",
                     "example": "public"
                   },
                   "dialect": {
                     "type": "string",
                     "enum": [
-                      "athena",
                       "bigquery",
-                      "clickhouse",
-                      "databricks",
-                      "databricks_lakebase",
-                      "exasol",
-                      "mariadb",
-                      "motherduck",
-                      "mssql",
                       "mysql",
-                      "oracle",
                       "postgres",
                       "redshift",
-                      "sap_hana",
+                      "exasol",
                       "snowflake",
+                      "motherduck",
+                      "mssql",
+                      "databricks",
+                      "databricks_lakebase",
+                      "clickhouse",
+                      "trino",
+                      "athena",
                       "starrocks",
-                      "trino"
+                      "mariadb",
+                      "oracle",
+                      "sap_hana"
                     ],
                     "description": "The database dialect",
                     "example": "snowflake"
@@ -38936,7 +41828,7 @@
     },
     "/api/v1/connections/{id}": {
       "get": {
-        "description": "Fetch a single connection by ID.",
+        "description": "Fetch a single connection by ID, including its full non-secret configuration. Credentials (password, OAuth client secret, keypairs) are never returned.",
         "operationId": "connectionsGet",
         "summary": "Get connection",
         "tags": [
@@ -38967,6 +41859,14 @@
                     "connection": {
                       "type": "object",
                       "properties": {
+                        "acceptsLicense": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether license terms have been accepted (Oracle)",
+                          "example": false
+                        },
                         "allowBranchConnectionEnvironments": {
                           "type": [
                             "boolean",
@@ -38974,6 +41874,38 @@
                           ],
                           "description": "Whether a branch may select its own connection environment. When user-attribute environment selection is also enabled, a branch selection overrides the user attribute.",
                           "example": false
+                        },
+                        "allowsUserSpecificTimezones": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether users may specify their own timezones",
+                          "example": false
+                        },
+                        "alwaysScopeViewNames": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether generated view names always include catalog/schema scoping",
+                          "example": false
+                        },
+                        "authenticationType": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`.",
+                          "example": "snowflake-password"
+                        },
+                        "awsRoleArn": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "AWS IAM role ARN (Athena)",
+                          "example": null
                         },
                         "baseRole": {
                           "type": [
@@ -39002,7 +41934,7 @@
                             "string",
                             "null"
                           ],
-                          "description": "Database name",
+                          "description": "Database/catalog name (project ID for BigQuery)",
                           "example": "analytics_db"
                         },
                         "defaultSchema": {
@@ -39018,30 +41950,48 @@
                             "string",
                             "null"
                           ],
-                          "description": "Timestamp when connection was deleted (ISO 8601)",
+                          "description": "Timestamp when connection was archived (ISO 8601)",
                           "example": null
                         },
                         "dialect": {
                           "type": "string",
                           "enum": [
-                            "snowflake",
                             "bigquery",
-                            "redshift",
-                            "postgres",
                             "mysql",
-                            "mariadb",
+                            "postgres",
+                            "redshift",
+                            "exasol",
+                            "snowflake",
+                            "motherduck",
+                            "mssql",
                             "databricks",
                             "databricks_lakebase",
+                            "clickhouse",
                             "trino",
                             "athena",
-                            "duckdb",
-                            "motherduck",
-                            "sqlserver",
-                            "clickhouse",
-                            "singlestore"
+                            "starrocks",
+                            "mariadb",
+                            "oracle",
+                            "sap_hana"
                           ],
-                          "description": "Database dialect type",
+                          "description": "Database dialect",
                           "example": "snowflake"
+                        },
+                        "enableDbSemanticLayerIntegration": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether the dialect-native semantic layer integration is enabled (Snowflake, Databricks)",
+                          "example": false
+                        },
+                        "enableDbSemanticLayerTopics": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether dialect-native semantic layer topics are generated (Snowflake, Databricks)",
+                          "example": false
                         },
                         "environmentConnectionSwitchesSchemaModel": {
                           "type": [
@@ -39051,21 +42001,209 @@
                           "description": "Whether environment connections switch schema model",
                           "example": false
                         },
+                        "externalOauthAudience": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "External OAuth audience claim (Snowflake)",
+                          "example": null
+                        },
+                        "externalOauthAuthorizationUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "External OAuth authorization URL (Snowflake)",
+                          "example": null
+                        },
+                        "externalOauthTokenUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "External OAuth token URL (Snowflake)",
+                          "example": null
+                        },
+                        "host": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Hostname or IP of the database server (account identifier for Snowflake)",
+                          "example": "myaccount"
+                        },
+                        "hostOverride": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Custom Snowflake host, overriding the account identifier",
+                          "example": null
+                        },
                         "id": {
                           "type": "string",
                           "format": "uuid",
                           "description": "Unique connection identifier",
                           "example": "550e8400-e29b-41d4-a716-446655440000"
                         },
+                        "includeOtherCatalogs": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Additional catalogs/databases included in schema refresh",
+                          "example": null
+                        },
+                        "includeSchemas": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Schemas included in schema refresh. Null means all schemas are included.",
+                          "example": [
+                            "public",
+                            "analytics"
+                          ]
+                        },
+                        "inferRelationshipsFromColumnNames": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether relationships are inferred from column-name conventions during schema refresh",
+                          "example": true
+                        },
+                        "inferRelationshipsFromForeignKeys": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether relationships are inferred from declared foreign keys during schema refresh",
+                          "example": false
+                        },
+                        "maxBillingBytes": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Maximum bytes billed for a query, as a string (BigQuery). Null when unset.",
+                          "example": null
+                        },
                         "name": {
                           "type": "string",
                           "description": "Connection display name",
                           "example": "Production Snowflake"
                         },
+                        "oauthClientId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "OAuth client ID for admin schema refresh (non-secret)",
+                          "example": null
+                        },
+                        "offloadedSchemas": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Schemas queried via the offloaded engine",
+                          "example": null
+                        },
+                        "port": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Port number for the database connection",
+                          "example": 5432
+                        },
+                        "queryTimeoutSeconds": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Query timeout in seconds",
+                          "example": 900
+                        },
+                        "queryTimezone": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Timezone used for query results",
+                          "example": null
+                        },
+                        "region": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Region (BigQuery, Athena)",
+                          "example": null
+                        },
+                        "scratchSchema": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Schema used for data input (upload) tables",
+                          "example": null
+                        },
+                        "systemTimezone": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Timezone of the database",
+                          "example": null
+                        },
+                        "trustServerCertificate": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether to trust the server certificate",
+                          "example": false
+                        },
                         "updatedAt": {
                           "type": "string",
                           "description": "Timestamp when connection was last updated (ISO 8601)",
                           "example": "2024-01-15T10:30:00Z"
+                        },
+                        "useMachineAuth": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether machine (M2M OAuth) credentials are used",
+                          "example": null
+                        },
+                        "useReadScaling": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether read scaling is enabled (MotherDuck)",
+                          "example": null
+                        },
+                        "useSessionHint": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether session hints are applied (MotherDuck)",
+                          "example": null
                         },
                         "userAttributeNameForConnectionEnvironments": {
                           "type": [
@@ -39073,7 +42211,7 @@
                             "null"
                           ],
                           "description": "User attribute name used for connection environments",
-                          "example": "region"
+                          "example": null
                         },
                         "userAttributeValuesForDefaultEnvironment": {
                           "type": [
@@ -39084,14 +42222,32 @@
                             "type": "string"
                           },
                           "description": "Default user attribute values for the base environment",
-                          "example": [
-                            "us-east",
-                            "us-west"
-                          ]
+                          "example": null
+                        },
+                        "username": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Username to authenticate with (client email for BigQuery service accounts)",
+                          "example": "analytics_user"
+                        },
+                        "warehouse": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Warehouse (Snowflake) or HTTP path (Databricks)",
+                          "example": "COMPUTE_WH"
                         }
                       },
                       "required": [
+                        "acceptsLicense",
                         "allowBranchConnectionEnvironments",
+                        "allowsUserSpecificTimezones",
+                        "alwaysScopeViewNames",
+                        "authenticationType",
+                        "awsRoleArn",
                         "baseRole",
                         "branchConnectionEnvironmentOverridesUserAttr",
                         "createdAt",
@@ -39099,12 +42255,38 @@
                         "defaultSchema",
                         "deletedAt",
                         "dialect",
+                        "enableDbSemanticLayerIntegration",
+                        "enableDbSemanticLayerTopics",
                         "environmentConnectionSwitchesSchemaModel",
+                        "externalOauthAudience",
+                        "externalOauthAuthorizationUrl",
+                        "externalOauthTokenUrl",
+                        "host",
+                        "hostOverride",
                         "id",
+                        "includeOtherCatalogs",
+                        "includeSchemas",
+                        "inferRelationshipsFromColumnNames",
+                        "inferRelationshipsFromForeignKeys",
+                        "maxBillingBytes",
                         "name",
+                        "oauthClientId",
+                        "offloadedSchemas",
+                        "port",
+                        "queryTimeoutSeconds",
+                        "queryTimezone",
+                        "region",
+                        "scratchSchema",
+                        "systemTimezone",
+                        "trustServerCertificate",
                         "updatedAt",
+                        "useMachineAuth",
+                        "useReadScaling",
+                        "useSessionHint",
                         "userAttributeNameForConnectionEnvironments",
-                        "userAttributeValuesForDefaultEnvironment"
+                        "userAttributeValuesForDefaultEnvironment",
+                        "username",
+                        "warehouse"
                       ],
                       "description": "Connection object",
                       "title": "Connection"
@@ -39131,7 +42313,7 @@
         }
       },
       "patch": {
-        "description": "Update connection settings including base role, environment user attributes, and credentials.\n\nCredential fields:\n- `passwordUnencrypted`: Update password (all dialects) or service account JSON (BigQuery)\n- `privateKey`: Add/rotate RSA keypair for Snowflake keypair authentication\n\nNote: Credentials are encrypted at rest and never returned in API responses.",
+        "description": "Update connection settings, including the non-secret configuration fields returned by GET, plus base role, environment user attributes, and credentials. Round-trips with GET so a connection can be managed as code. `dialect` cannot be changed.\n\nCredential fields (write-only, never returned):\n- `passwordUnencrypted`: Update password (all dialects) or service account JSON (BigQuery)\n- `privateKey`: Add/rotate RSA keypair for Snowflake keypair authentication\n- `oauthClientSecretUnencrypted`: Update OAuth client secret (Snowflake, Databricks)\n\nChanging `host` or `port` is subject to the same SSH tunnel and PrivateLink restrictions as connection create: you may only point a connection at an SSH tunnel already provisioned for your organization, and a PrivateLink host must belong to your organization. Requests that violate this return 400.\n\nNote: Credentials are encrypted at rest and never returned in API responses.",
         "operationId": "connectionsUpdate",
         "summary": "Update connection",
         "tags": [
@@ -39157,10 +42339,56 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "acceptsLicense": {
+                    "type": "boolean",
+                    "description": "Acceptance of the license terms (Oracle)",
+                    "example": true
+                  },
+                  "allowsUserSpecificTimezones": {
+                    "type": "boolean",
+                    "description": "Whether users may specify their own timezones",
+                    "example": false
+                  },
+                  "alwaysScopeViewNames": {
+                    "type": "boolean",
+                    "description": "Whether generated view names always include catalog/schema scoping",
+                    "example": true
+                  },
+                  "authenticationType": {
+                    "type": "string",
+                    "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`.",
+                    "example": "snowflake-password"
+                  },
+                  "awsRoleArn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN (Athena)",
+                    "example": "arn:aws:iam::123456789012:role/OmniAthenaRole"
+                  },
                   "baseRole": {
                     "type": "string",
                     "description": "Default role to assign to this connection",
                     "example": "QUERIER"
+                  },
+                  "database": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Database/catalog name (project ID for BigQuery)",
+                    "example": "analytics_db"
+                  },
+                  "defaultSchema": {
+                    "type": "string",
+                    "description": "Default schema for the connection",
+                    "example": "public"
+                  },
+                  "enableDbSemanticLayerIntegration": {
+                    "type": "boolean",
+                    "description": "Enable the dialect-native semantic layer integration (Snowflake, Databricks)",
+                    "example": false
+                  },
+                  "enableDbSemanticLayerTopics": {
+                    "type": "boolean",
+                    "description": "Enable dialect-native semantic layer topics (Snowflake, Databricks)",
+                    "example": false
                   },
                   "environmentUserAttribute": {
                     "type": [
@@ -39194,16 +42422,176 @@
                     ],
                     "description": "User attribute settings for connection environments"
                   },
+                  "externalOauthAudience": {
+                    "type": "string",
+                    "description": "External OAuth audience claim (Snowflake)"
+                  },
+                  "externalOauthAuthorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth authorization URL, HTTPS (Snowflake)",
+                    "example": "https://oauth.example.com/authorize"
+                  },
+                  "externalOauthTokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth token URL, HTTPS (Snowflake)",
+                    "example": "https://oauth.example.com/token"
+                  },
+                  "host": {
+                    "type": "string",
+                    "description": "Hostname or IP of the database server (account identifier for Snowflake)",
+                    "example": "myaccount"
+                  },
+                  "hostOverride": {
+                    "type": "string",
+                    "description": "Custom Snowflake host, overriding the account identifier",
+                    "example": "myaccount.snowflakecomputing.com"
+                  },
+                  "includeOtherCatalogs": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Additional catalogs/databases to include. Comma-separated string or array.",
+                    "example": [
+                      "other_project"
+                    ]
+                  },
+                  "includeSchemas": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Schemas to include in schema refresh. Comma-separated string or array; empty means all schemas.",
+                    "example": [
+                      "public",
+                      "analytics"
+                    ]
+                  },
+                  "inferRelationshipsFromColumnNames": {
+                    "type": "boolean",
+                    "description": "Infer relationships from column-name conventions",
+                    "example": true
+                  },
+                  "inferRelationshipsFromForeignKeys": {
+                    "type": "boolean",
+                    "description": "Infer relationships from declared foreign keys",
+                    "example": false
+                  },
+                  "maxBillingBytes": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "description": "Maximum bytes billed for a query (BigQuery)",
+                    "example": "1000000000"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Connection display name",
+                    "example": "Production Snowflake"
+                  },
+                  "oauthClientId": {
+                    "type": "string",
+                    "description": "OAuth client ID for admin schema refresh (Snowflake, Databricks)"
+                  },
+                  "oauthClientSecretUnencrypted": {
+                    "type": "string",
+                    "description": "OAuth client secret for admin schema refresh (Snowflake, Databricks). Write-only; never returned."
+                  },
+                  "offloadedSchemas": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Schemas queried via the offloaded engine. Comma-separated string or array.",
+                    "example": [
+                      "analytics_archive"
+                    ]
+                  },
                   "passwordUnencrypted": {
                     "type": "string",
                     "description": "New password or service account key. For BigQuery, this must be the JSON service account key file content."
                   },
+                  "port": {
+                    "type": "integer",
+                    "description": "Port number for the database connection",
+                    "example": 5432
+                  },
                   "privateKey": {
                     "type": "string",
                     "description": "RSA private key for keypair authentication (Snowflake only). Must be PEM-encoded PKCS#8 format, minimum 2048-bit."
+                  },
+                  "queryTimeoutSeconds": {
+                    "type": "integer",
+                    "maximum": 3600,
+                    "description": "Query timeout in seconds (max 3600)",
+                    "example": 900
+                  },
+                  "queryTimezone": {
+                    "type": "string",
+                    "description": "Timezone used for query results",
+                    "example": "NONE"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Region (BigQuery, Athena)",
+                    "example": "us-east-1"
+                  },
+                  "scratchSchema": {
+                    "type": "string",
+                    "description": "Schema used for data input (upload) tables",
+                    "example": "omni_scratch"
+                  },
+                  "systemTimezone": {
+                    "type": "string",
+                    "description": "Timezone of the database",
+                    "example": "UTC"
+                  },
+                  "trustServerCertificate": {
+                    "type": "boolean",
+                    "description": "Whether to trust the server certificate",
+                    "example": false
+                  },
+                  "useMachineAuth": {
+                    "type": "boolean",
+                    "description": "Authenticate using machine (M2M OAuth) credentials",
+                    "example": false
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "Username to authenticate with (client email for BigQuery service accounts)",
+                    "example": "analytics_user"
+                  },
+                  "warehouse": {
+                    "type": "string",
+                    "description": "Warehouse (Snowflake) or HTTP path (Databricks)",
+                    "example": "COMPUTE_WH"
                   }
                 },
-                "description": "Request body for updating connection attributes and credentials. At least one field must be provided.",
+                "additionalProperties": false,
+                "description": "Request body for updating connection settings and credentials. At least one field must be provided. Secrets are write-only and never returned.",
                 "title": "ConnectionsUpdateBody"
               }
             }
@@ -39348,6 +42736,16 @@
                     {
                       "type": "object",
                       "properties": {
+                        "authMethod": {
+                          "type": "string",
+                          "enum": [
+                            "ssh",
+                            "https_token",
+                            "github_app"
+                          ],
+                          "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+                          "example": "ssh"
+                        },
                         "autogenRelationships": {
                           "type": "boolean",
                           "description": "Whether relationships are auto-generated from dbt",
@@ -39357,6 +42755,29 @@
                           "type": "string",
                           "description": "Git branch name",
                           "example": "main"
+                        },
+                        "commitSigningCommitterEmail": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+                          "example": "omni-bot@example.com"
+                        },
+                        "commitSigningCommitterName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+                          "example": "Omni Bot"
+                        },
+                        "commitSigningPublicKey": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
                         },
                         "dbtVersion": {
                           "type": "string",
@@ -39373,6 +42794,14 @@
                           "description": "Whether virtual schemas are enabled",
                           "example": false
                         },
+                        "githubAppInstallationId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "GitHub App installation ID. Null for non-github_app auth.",
+                          "example": "12345678"
+                        },
                         "projectRootPath": {
                           "type": [
                             "string",
@@ -39383,7 +42812,7 @@
                         },
                         "sshUrl": {
                           "type": "string",
-                          "description": "SSH URL for git repository",
+                          "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
                           "example": "git@github.com:org/repo.git"
                         },
                         "supportsDbt": {
@@ -39396,11 +42825,16 @@
                         }
                       },
                       "required": [
+                        "authMethod",
                         "autogenRelationships",
                         "branch",
+                        "commitSigningCommitterEmail",
+                        "commitSigningCommitterName",
+                        "commitSigningPublicKey",
                         "dbtVersion",
                         "enableSemanticLayer",
                         "enableVirtualSchemas",
+                        "githubAppInstallationId",
                         "projectRootPath",
                         "sshUrl",
                         "supportsDbt"
@@ -39473,6 +42907,16 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "authMethod": {
+                    "type": "string",
+                    "enum": [
+                      "ssh",
+                      "https_token",
+                      "github_app"
+                    ],
+                    "description": "Authentication method for the git repository: \"ssh\" (deploy key), \"https_token\" (deploy token or PAT), or \"github_app\" (GitHub App installation, github.com only). Omit to keep the connected repository's method (SSH for a first-time setup).",
+                    "example": "ssh"
+                  },
                   "autogenRelationships": {
                     "type": "boolean",
                     "description": "Automatically generate relationships from dbt",
@@ -39483,6 +42927,20 @@
                     "minLength": 1,
                     "description": "Git branch name",
                     "example": "main"
+                  },
+                  "commitSigningCommitterEmail": {
+                    "type": "string",
+                    "maxLength": 320,
+                    "format": "email",
+                    "description": "Verified email of the GitHub user that owns the registered signing key (github_app auth only). Omit to leave the stored value unchanged. Must be set together with commitSigningCommitterName.",
+                    "example": "omni-bot@example.com"
+                  },
+                  "commitSigningCommitterName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Display name written into signed commits (github_app auth only). Omit to leave the stored value unchanged. Must be set together with commitSigningCommitterEmail.",
+                    "example": "Omni Bot"
                   },
                   "dbtVersion": {
                     "type": [
@@ -39502,6 +42960,12 @@
                     "type": "boolean",
                     "description": "Enable virtual schemas from dbt",
                     "example": false
+                  },
+                  "githubAppInstallationId": {
+                    "type": "string",
+                    "pattern": "^[0-9]+$",
+                    "description": "Numeric GitHub App installation ID. Required when connecting a repository with authMethod \"github_app\"; may be omitted on updates that keep the connected repository.",
+                    "example": "12345678"
                   },
                   "projectRootPath": {
                     "anyOf": [
@@ -39535,14 +42999,20 @@
                   "rotateKeys": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Rotate SSH deploy keys",
+                    "description": "Rotate SSH deploy keys (ssh auth only)",
                     "example": false
                   },
                   "sshUrl": {
                     "type": "string",
                     "minLength": 1,
-                    "description": "SSH URL for git repository",
+                    "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
                     "example": "git@github.com:org/repo.git"
+                  },
+                  "token": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "pattern": "^[a-zA-Z0-9_\\-.]+$",
+                    "description": "HTTPS access token (deploy token value, PAT, etc.). Required when connecting a repository with authMethod \"https_token\"; omit on updates that keep the stored token."
                   }
                 },
                 "required": [
@@ -39565,23 +43035,227 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "message": {
+                    "authMethod": {
                       "type": "string",
-                      "description": "Success message",
-                      "example": "dbt configuration updated successfully"
+                      "enum": [
+                        "ssh",
+                        "https_token",
+                        "github_app"
+                      ],
+                      "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+                      "example": "ssh"
                     },
-                    "success": {
+                    "autogenRelationships": {
                       "type": "boolean",
-                      "description": "Whether the operation succeeded",
+                      "description": "Whether relationships are auto-generated from dbt",
+                      "example": true
+                    },
+                    "branch": {
+                      "type": "string",
+                      "description": "Git branch name",
+                      "example": "main"
+                    },
+                    "commitSigningCommitterEmail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "omni-bot@example.com"
+                    },
+                    "commitSigningCommitterName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "Omni Bot"
+                    },
+                    "commitSigningPublicKey": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
+                    },
+                    "dbtVersion": {
+                      "type": "string",
+                      "description": "dbt version being used",
+                      "example": "Auto"
+                    },
+                    "enableSemanticLayer": {
+                      "type": "boolean",
+                      "description": "Whether the dbt semantic layer integration is enabled",
+                      "example": false
+                    },
+                    "enableVirtualSchemas": {
+                      "type": "boolean",
+                      "description": "Whether virtual schemas are enabled",
+                      "example": false
+                    },
+                    "githubAppInstallationId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "GitHub App installation ID. Null for non-github_app auth.",
+                      "example": "12345678"
+                    },
+                    "projectRootPath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Path to dbt project root",
+                      "example": "dbt_project"
+                    },
+                    "sshUrl": {
+                      "type": "string",
+                      "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
+                      "example": "git@github.com:org/repo.git"
+                    },
+                    "supportsDbt": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ],
+                      "description": "Indicates dbt is supported and configured",
                       "example": true
                     }
                   },
                   "required": [
-                    "message",
-                    "success"
+                    "authMethod",
+                    "autogenRelationships",
+                    "branch",
+                    "commitSigningCommitterEmail",
+                    "commitSigningCommitterName",
+                    "commitSigningPublicKey",
+                    "dbtVersion",
+                    "enableSemanticLayer",
+                    "enableVirtualSchemas",
+                    "githubAppInstallationId",
+                    "projectRootPath",
+                    "sshUrl",
+                    "supportsDbt"
                   ],
-                  "description": "dbt update response",
-                  "title": "ConnectionsDbtUpdateResponse"
+                  "description": "dbt repository configuration response",
+                  "title": "DbtConfiguredResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "dbt configuration created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "authMethod": {
+                      "type": "string",
+                      "enum": [
+                        "ssh",
+                        "https_token",
+                        "github_app"
+                      ],
+                      "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+                      "example": "ssh"
+                    },
+                    "autogenRelationships": {
+                      "type": "boolean",
+                      "description": "Whether relationships are auto-generated from dbt",
+                      "example": true
+                    },
+                    "branch": {
+                      "type": "string",
+                      "description": "Git branch name",
+                      "example": "main"
+                    },
+                    "commitSigningCommitterEmail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "omni-bot@example.com"
+                    },
+                    "commitSigningCommitterName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "Omni Bot"
+                    },
+                    "commitSigningPublicKey": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
+                    },
+                    "dbtVersion": {
+                      "type": "string",
+                      "description": "dbt version being used",
+                      "example": "Auto"
+                    },
+                    "enableSemanticLayer": {
+                      "type": "boolean",
+                      "description": "Whether the dbt semantic layer integration is enabled",
+                      "example": false
+                    },
+                    "enableVirtualSchemas": {
+                      "type": "boolean",
+                      "description": "Whether virtual schemas are enabled",
+                      "example": false
+                    },
+                    "githubAppInstallationId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "GitHub App installation ID. Null for non-github_app auth.",
+                      "example": "12345678"
+                    },
+                    "projectRootPath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Path to dbt project root",
+                      "example": "dbt_project"
+                    },
+                    "sshUrl": {
+                      "type": "string",
+                      "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
+                      "example": "git@github.com:org/repo.git"
+                    },
+                    "supportsDbt": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ],
+                      "description": "Indicates dbt is supported and configured",
+                      "example": true
+                    }
+                  },
+                  "required": [
+                    "authMethod",
+                    "autogenRelationships",
+                    "branch",
+                    "commitSigningCommitterEmail",
+                    "commitSigningCommitterName",
+                    "commitSigningPublicKey",
+                    "dbtVersion",
+                    "enableSemanticLayer",
+                    "enableVirtualSchemas",
+                    "githubAppInstallationId",
+                    "projectRootPath",
+                    "sshUrl",
+                    "supportsDbt"
+                  ],
+                  "description": "dbt repository configuration response",
+                  "title": "DbtConfiguredResponse"
                 }
               }
             }
@@ -39657,6 +43331,66 @@
           },
           "404": {
             "description": "Connection not found or dbt not configured"
+          }
+        }
+      }
+    },
+    "/api/v1/connections/{connectionId}/dbt/rotate-signing-key": {
+      "post": {
+        "description": "Rotate the commit signing keypair for a GitHub App dbt connection and return the dbt configuration with the new commitSigningPublicKey to register on the committer’s GitHub user. Omni mints a fresh Ed25519 keypair unless signingPrivateKey supplies your own (with signingKeyPassphrase when encrypted), enabling zero-downtime rotation: register the matching public key on GitHub first, then set it here. The committer identity can be changed in the same call, so signing can be moved to a different GitHub user in one step. Commits already signed with the old key stay Verified only while the old public key remains registered on GitHub. Only valid for github_app auth.",
+        "operationId": "connectionsDbtRotateSigningKey",
+        "summary": "Rotate dbt commit signing key",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Connection ID",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Connection ID",
+            "name": "connectionId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectionsDbtRotateSigningKeyBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signing key rotated; response includes the new public key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionsDbtRotateSigningKeyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid signing key, passphrase, or committer fields"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied - connection admin role required"
+          },
+          "404": {
+            "description": "Connection not found or dbt not configured"
+          },
+          "422": {
+            "description": "Connection is not a GitHub App dbt repository"
           }
         }
       }
@@ -40973,6 +44707,61 @@
         }
       }
     },
+    "/api/v1/content/search": {
+      "get": {
+        "operationId": "contentSearch",
+        "summary": "Search dashboards",
+        "tags": [
+          "Content"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 25,
+              "default": 10,
+              "description": "Max results to return (1-25).",
+              "example": 10
+            },
+            "required": false,
+            "description": "Max results to return (1-25).",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Free-text keywords matched against dashboard names, descriptions, query names, folder names, labels, and creator names.",
+              "example": "revenue by region"
+            },
+            "required": true,
+            "description": "Free-text keywords matched against dashboard names, descriptions, query names, folder names, labels, and creator names.",
+            "name": "q",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching dashboards",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          }
+        }
+      }
+    },
     "/api/v1/dashboards/{identifier}/download": {
       "post": {
         "operationId": "dashboardsDownload",
@@ -41508,7 +45297,7 @@
       },
       "put": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removed on July 31, 2026: this endpoint now returns `410` unless your organization has been granted a migration extension. Contact support if you need one.\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
         "operationId": "documentsPut",
         "summary": "Replace document (full replacement)",
         "tags": [
@@ -41592,12 +45381,46 @@
           },
           "409": {
             "description": "Draft already exists - set clearExistingDraft to true to discard it and proceed"
+          },
+          "410": {
+            "description": "Endpoint has been removed; the organization does not hold a migration extension",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            }
           }
         }
       },
       "patch": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removed on July 31, 2026: this endpoint now returns `410` unless your organization has been granted a migration extension. Contact support if you need one.\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
         "operationId": "documentsUpdate",
         "summary": "Rename document",
         "tags": [
@@ -41681,6 +45504,40 @@
           },
           "409": {
             "description": "Draft already exists - set clearExistingDraft to true to discard it and proceed"
+          },
+          "410": {
+            "description": "Endpoint has been removed; the organization does not hold a migration extension",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            }
           }
         }
       },
@@ -41748,7 +45605,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of queries in the document",
+            "description": "Every query in the document — the dashboard's query presentation collection, which mirrors the workbook's tabs. The dashboard layout decides which of these render, so a query here may not appear on the dashboard.",
             "content": {
               "application/json": {
                 "schema": {
@@ -41764,7 +45621,7 @@
             "description": "Permission denied"
           },
           "404": {
-            "description": "Document not found"
+            "description": "Document not found, or the document has no dashboard (required today; see the endpoint README)"
           }
         }
       }
@@ -41826,6 +45683,7 @@
     },
     "/api/v1/documents/{identifier}/permissions": {
       "get": {
+        "description": "Returns the document-level ability values (the Share dialog \"Abilities\" toggles), plus the resolved permits for a specific user when `userId` is provided.",
         "operationId": "documentsGetPermissions",
         "summary": "Get document permissions",
         "tags": [
@@ -41847,17 +45705,17 @@
             "schema": {
               "type": "string",
               "format": "uuid",
-              "description": "User membership ID to check permissions for"
+              "description": "User membership ID to check permissions for. When omitted, only the document-level abilities are returned."
             },
-            "required": true,
-            "description": "User membership ID to check permissions for",
+            "required": false,
+            "description": "User membership ID to check permissions for. When omitted, only the document-level abilities are returned.",
             "name": "userId",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "User permissions for the document",
+            "description": "Document abilities, plus user permits when userId is provided",
             "content": {
               "application/json": {
                 "schema": {
@@ -41923,7 +45781,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Document not found"
@@ -41976,7 +45834,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Document not found"
@@ -42029,7 +45887,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Document not found"
@@ -42522,7 +46380,7 @@
             }
           },
           "400": {
-            "description": "Invalid request - at least one label must be specified"
+            "description": "Invalid request - at least one label must be specified, or an unrecognized field was sent"
           },
           "401": {
             "description": "Authentication required"
@@ -42652,6 +46510,8 @@
     },
     "/api/v1/documents/{identifier}/transfer-ownership": {
       "put": {
+        "deprecated": true,
+        "description": "Deprecated. Ownership is a content role: grant a user the OWNER role via the permissions endpoint instead. This endpoint grants OWNER to the named user and demotes every other user holding OWNER on the document itself to MANAGER. Ownership inherited from an ancestor folder is untouched.",
         "operationId": "documentsTransferOwnership",
         "summary": "Transfer document ownership",
         "tags": [
@@ -43102,11 +46962,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
               "example": "def456"
             },
             "required": true,
-            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
             "name": "draftIdentifier",
             "in": "path"
           },
@@ -43174,11 +47034,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
               "example": "def456"
             },
             "required": true,
-            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
             "name": "draftIdentifier",
             "in": "path"
           },
@@ -43250,11 +47110,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
               "example": "def456"
             },
             "required": true,
-            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
             "name": "draftIdentifier",
             "in": "path"
           },
@@ -43298,6 +47158,166 @@
           },
           "422": {
             "description": "The document is an app, not a dashboard."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft/{draftIdentifier}/queries/{queryKey}/query-model": {
+      "put": {
+        "description": "Bind a query-presentation tile to a query model on a draft.\n\nThe query-model binding (`query.model_extension_id`) is server-owned on the whole-document PATCH surface — a supplied value there is ignored and the tile keeps its stored binding. This draft-scoped route is the way to change it, addressing one tile by its stable record key. The binding shifts on every draft (each draft re-clones its query models), so work against a draft you have already read.\n\nThe `queryModelId` must be a live query model layered on this draft’s workbook model, and not already bound to another tile — a query model is dedicated to a single query. A LINKED tile inherits its query model from its source and can’t be bound directly.",
+        "operationId": "documentsV2BindQueryModel",
+        "summary": "Bind a tile to a query model",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$",
+              "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+              "example": "1"
+            },
+            "required": true,
+            "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+            "name": "queryKey",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2BindQueryModelBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tile bound to the query model; the response carries the `draftIdentifier`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `queryKey` or body, the tile’s query is degraded (not an object) or the tile is LINKED, or the `queryModelId` is not a query model available on this draft."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the document."
+          },
+          "404": {
+            "description": "Document, draft, or tile not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document, or the query model is already bound to another tile."
+          }
+        }
+      },
+      "delete": {
+        "description": "Unbind a query-presentation tile from its query model on a draft, keeping the tile’s query. No request body.\n\nThe query-model binding (`query.model_extension_id`) is server-owned on the whole-document PATCH surface — a supplied value there is ignored and the tile keeps its stored binding. This draft-scoped route is the way to change it, addressing one tile by its stable record key. The binding shifts on every draft (each draft re-clones its query models), so work against a draft you have already read.",
+        "operationId": "documentsV2UnbindQueryModel",
+        "summary": "Unbind a tile from its query model",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$",
+              "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+              "example": "1"
+            },
+            "required": true,
+            "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+            "name": "queryKey",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tile unbound from its query model; the response carries the `draftIdentifier`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `queryKey`, or the tile is LINKED."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the document."
+          },
+          "404": {
+            "description": "Document, draft, or tile not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document."
           }
         }
       }
@@ -44041,7 +48061,7 @@
         }
       },
       "post": {
-        "description": "Create and start a new run against an existing prompt set. The run enqueues one agentic job per prompt and begins executing immediately. Returns the newly created run with its initial per-prompt result rows.",
+        "description": "Create and start a new run against an existing prompt set. The run enqueues `run_config.repeat_count` agentic jobs per prompt (default 1) and begins executing immediately. Returns the newly created run with its initial per-execution result rows.",
         "operationId": "aiEvalRunsCreate",
         "summary": "Start an eval run",
         "tags": [
@@ -44109,7 +48129,7 @@
             }
           },
           "422": {
-            "description": "`run_config.branch_id` does not belong to the prompt set's model.",
+            "description": "`run_config.branch_id` does not belong to the prompt set's model, or prompts × `run_config.repeat_count` exceeds the per-run job limit.",
             "content": {
               "application/json": {
                 "schema": {
@@ -44724,7 +48744,7 @@
             }
           },
           "400": {
-            "description": "Invalid request body (empty name, invalid path characters, reserved path, or neither field provided)"
+            "description": "Invalid request body (empty name, invalid path characters, reserved path, an unrecognized field, or neither field provided)"
           },
           "401": {
             "description": "Authentication required"
@@ -44737,6 +48757,74 @@
           },
           "409": {
             "description": "Path conflicts with an existing folder (when resolvePathConflict is false)"
+          }
+        }
+      }
+    },
+    "/api/v1/folders/{folderId}/labels": {
+      "patch": {
+        "description": "Add and remove labels on a folder in a single atomic operation. Labels must already exist in the organization - create them with POST /api/v1/labels.",
+        "operationId": "foldersBulkUpdateLabels",
+        "summary": "Bulk update folder labels",
+        "tags": [
+          "Folders"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique identifier for the folder",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Unique identifier for the folder",
+            "name": "folderId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoldersBulkUpdateLabelsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Labels updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoldersBulkUpdateLabelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - no labels specified, the same label in both add and remove, or an unrecognized field"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied - label management, or verified/homepage label permissions"
+          },
+          "404": {
+            "description": "Folder not found, label not found in the organization, or label not applied to the folder"
           }
         }
       }
@@ -44842,7 +48930,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Folder not found"
@@ -44896,7 +48984,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Folder not found"
@@ -45280,6 +49368,181 @@
         }
       }
     },
+    "/api/v1/models/{modelId}/suggestions/generate": {
+      "post": {
+        "description": "Triggers an AI suggestion generation run for the shared model and enqueues the async job. Poll `GET /suggestions/runs/{runId}` for status. Requires organization admin permissions. At most one active run per model; a cooldown applies after a completed run.",
+        "operationId": "modelSuggestionsGenerate",
+        "summary": "Generate model suggestions",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Generation run enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateSuggestionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "409": {
+            "description": "A generation run is already active for this model"
+          },
+          "429": {
+            "description": "A run completed recently; retry after the cooldown (see the `Retry-After` header)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionsCooldownResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to enqueue the generation job"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/runs/{runId}": {
+      "get": {
+        "description": "Returns the status of a specific generation run. Poll until `status` is terminal (`complete` or `failed`), then re-fetch the suggestions list. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsRunGet",
+        "summary": "Get a generation run",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the run belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the run belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the generation run",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the generation run",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generation run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionRun"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Run not found in this organization/model"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/runs/latest": {
+      "get": {
+        "description": "Returns the most recent generation run for the shared model (the active run if one is in flight, otherwise the last terminal run), or null if none exists. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsRunLatest",
+        "summary": "Get the latest generation run",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The latest generation run, or null",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionRunLatestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          }
+        }
+      }
+    },
     "/api/v1/models/{modelId}/suggestions/schedule": {
       "put": {
         "description": "Enables the daily schedule that generates suggestions for the shared model. Idempotent — re-enabling leaves an existing schedule untouched. Requires organization admin permissions.",
@@ -45627,6 +49890,22 @@
             "required": false,
             "description": "Cursor for pagination",
             "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1",
+                "true",
+                "false"
+              ],
+              "description": "When true, returns only models that can be explored directly: shared models, and shared extension models the org allows as a workbook base. Combining with a modelKind other than SHARED or SHARED_EXTENSION is a 400."
+            },
+            "required": false,
+            "description": "When true, returns only models that can be explored directly: shared models, and shared extension models the org allows as a workbook base. Combining with a modelKind other than SHARED or SHARED_EXTENSION is a 400.",
+            "name": "explorable",
             "in": "query"
           },
           {
@@ -46824,7 +51103,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - connection admin role required"
+            "description": "Permission denied - a branch refresh requires permission to update the branch; a direct refresh requires connection admin, or modeler on a connection with exactly one shared model"
           },
           "404": {
             "description": "Model not found"
@@ -47185,6 +51464,66 @@
           },
           "404": {
             "description": "Model or branch not found"
+          }
+        }
+      },
+      "get": {
+        "description": "Read the dbt environment a branch resolves to, including the dbt git branch it compiles against. A branch with no environment of its own resolves to the connection's default (production) environment, reported with is_default_environment: true.",
+        "operationId": "modelsBranchDbtGet",
+        "summary": "Read branch dbt environment",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Branch name",
+              "example": "feature/new-metrics"
+            },
+            "required": true,
+            "description": "Branch name",
+            "name": "branchName",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The dbt environment the branch resolves to",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsBranchDbtGetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "Model, branch, or dbt environment not found, or model deleted"
+          },
+          "422": {
+            "description": "The model is not a shared model"
           }
         }
       }
@@ -47710,6 +52049,66 @@
         }
       }
     },
+    "/api/v1/models/{modelId}/git/rotate-signing-key": {
+      "post": {
+        "description": "Rotate the commit signing keypair for a GitHub App connection and return the git configuration with the new commitSigningPublicKey to register on the committer’s GitHub user. Omni mints a fresh Ed25519 keypair unless signingPrivateKey supplies your own (with signingKeyPassphrase when encrypted), enabling zero-downtime rotation: register the matching public key on GitHub first, then set it here. The committer identity can be changed in the same call, so signing can be moved to a different GitHub user in one step. Commits already signed with the old key stay Verified only while the old public key remains registered on GitHub. Only valid for github_app auth.",
+        "operationId": "modelsGitRotateSigningKey",
+        "summary": "Rotate commit signing key",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelsGitRotateSigningKeyBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signing key rotated; response includes the new public key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsGitRotateSigningKeyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid signing key, passphrase, or committer fields"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "Model not found or git not configured"
+          },
+          "422": {
+            "description": "Model is not a GitHub App connection"
+          }
+        }
+      }
+    },
     "/api/v1/models/{modelId}/content-validator": {
       "get": {
         "operationId": "modelsContentValidatorGet",
@@ -47780,10 +52179,10 @@
                 "TOPIC",
                 "VIEW"
               ],
-              "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name)."
+              "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name), and also match the field through the join aliases of its view (with users joined as sellers, users.age also matches sellers.age)."
             },
             "required": false,
-            "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name).",
+            "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name), and also match the field through the join aliases of its view (with users joined as sellers, users.age also matches sellers.age).",
             "name": "find_type",
             "in": "query"
           },
@@ -48141,12 +52540,15 @@
                 },
                 {
                   "type": "string"
+                },
+                {
+                  "type": "string"
                 }
               ],
-              "description": "File name to delete (must end with '.topic' or '.view')"
+              "description": "File name to delete (must end with '.topic', '.composite_topic', or '.view')"
             },
             "required": true,
-            "description": "File name to delete (must end with '.topic' or '.view')",
+            "description": "File name to delete (must end with '.topic', '.composite_topic', or '.view')",
             "name": "fileName",
             "in": "query"
           },
@@ -48245,6 +52647,7 @@
     },
     "/api/v1/query/run": {
       "post": {
+        "description": "Runs a semantic query. By default (no `resultType`) the response is a stream of newline-delimited JSON (`Content-Type: text/ndjson`), one JSON object per line: a `jobs_submitted` header, then one line per job as it reaches a terminal state (a completed job carries the result set as base64-encoded Arrow IPC in `result`; use `summary.fields` to interpret the decoded columns), then a footer. A footer with non-empty `remaining_job_ids` means the wait window elapsed before every job finished — poll GET /api/v1/query/wait with those IDs until the list is empty. When `resultType` is set, the response is instead a single CSV, XLSX, or JSON document, and a timeout is reported as a 408.",
         "operationId": "queryRun",
         "summary": "Execute a semantic query",
         "tags": [
@@ -48274,11 +52677,45 @@
         },
         "responses": {
           "200": {
-            "description": "Query executed or started successfully",
+            "description": "Query executed or started successfully. The default response (no resultType) is a text/ndjson stream — one JSON object per line, each matching QueryRunStreamLine; it cannot be parsed as a single JSON document. When resultType is set, the body is a single CSV, XLSX, or JSON document instead.",
+            "headers": {
+              "X-Omni-Workbook-Url": {
+                "schema": {
+                  "type": "string",
+                  "description": "URL of an ephemeral workbook running this query. Present only when the request sets `workbookUrl: true` and the (target) user has the workbooks permission on the model.",
+                  "example": "https://myorg.omniapp.co/e/1:abc123DEF456/1"
+                },
+                "required": false,
+                "description": "URL of an ephemeral workbook running this query. Present only when the request sets `workbookUrl: true` and the (target) user has the workbooks permission on the model."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/QueryRunResponse"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "description": "Array of result-row objects keyed by field name. Returned only when resultType is \"json\"."
+                }
+              },
+              "application/vnd.ms-excel": {
+                "schema": {
+                  "description": "XLSX document. Returned only when resultType is \"xlsx\".",
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "description": "CSV document. Returned only when resultType is \"csv\".",
+                  "type": "string"
+                }
+              },
+              "text/ndjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryRunStreamLine"
                 }
               }
             }
@@ -48296,7 +52733,7 @@
             "description": "Model, topic, view, or branch not found"
           },
           "408": {
-            "description": "Query timed out. The response includes remaining_job_ids that can be polled via the query/wait endpoint.",
+            "description": "Query timed out. Only returned when resultType is set — the default text/ndjson response reports timeouts in-band via the footer line's remaining_job_ids instead. The response includes remaining_job_ids that can be polled via the query/wait endpoint.",
             "content": {
               "application/json": {
                 "schema": {
@@ -48313,6 +52750,7 @@
     },
     "/api/v1/query/wait": {
       "get": {
+        "description": "Waits for previously submitted query jobs and streams results as they complete. The response is a stream of newline-delimited JSON (`Content-Type: text/ndjson`): one line per job (same shape as the job lines from query/run, including the base64-encoded Arrow IPC `result`), then a footer. Unlike query/run, there is no `jobs_submitted` header line. If the footer's `remaining_job_ids` is non-empty, call this endpoint again with those IDs until it is empty.",
         "operationId": "queryWait",
         "summary": "Wait for query jobs to complete",
         "tags": [
@@ -48333,11 +52771,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Query results for completed jobs",
+            "description": "Query results for completed jobs, as a text/ndjson stream — one JSON object per line, each matching QueryWaitStreamLine; it cannot be parsed as a single JSON document.",
             "content": {
-              "application/json": {
+              "text/ndjson": {
                 "schema": {
-                  "$ref": "#/components/schemas/QueryWaitResponse"
+                  "$ref": "#/components/schemas/QueryWaitStreamLine"
                 }
               }
             }
@@ -48631,6 +53069,11 @@
                     ],
                     "description": "The delivery destination type",
                     "example": "email"
+                  },
+                  "enableConditionalFormatting": {
+                    "type": "boolean",
+                    "description": "Defaults to true. When true, conditional formatting rules are included in xlsx output — provided the organization has the 'excel-conditional-formatting' feature enabled.",
+                    "example": true
                   },
                   "enableFormatting": {
                     "type": "boolean",
@@ -49258,7 +53701,7 @@
             "description": "Schedule not found"
           },
           "409": {
-            "description": "Schedule cannot be triggered (paused, system-disabled, or another execution is in progress)"
+            "description": "Schedule cannot be triggered (paused, system-disabled, delivering to a destination type the organization has disabled, or another execution is in progress)"
           }
         }
       }
@@ -50359,6 +54802,61 @@
           },
           "400": {
             "description": "Invalid upload ID format"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "Upload not found or already deleted"
+          }
+        }
+      },
+      "put": {
+        "description": "Replace the data behind an existing CSV upload while keeping its id stable. The new file lands as fresh storage and (when the connection stages uploads) a fresh warehouse table, and the upload's pointers move to them — views and document tabs reference the upload by id, so they serve the new data with no model or document changes. Column renames/removals may break content referencing the old columns.",
+        "operationId": "uploadsReplaceData",
+        "summary": "Replace an upload's data",
+        "tags": [
+          "Uploads"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the upload to delete"
+            },
+            "required": true,
+            "description": "ID of the upload to delete",
+            "name": "uploadId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadPutBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upload data replaced successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadPutResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (missing file, invalid file type, CSV parsing failed, or a non-CSV upload)"
           },
           "401": {
             "description": "Authentication required"

--- a/cmd/omni/openapi.json
+++ b/cmd/omni/openapi.json
@@ -979,10 +979,18 @@
       "AiJobSubmitBody": {
         "type": "object",
         "properties": {
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgenticJobAttachment"
+            },
+            "maxItems": 5,
+            "description": "Optional image or PDF attachments (e.g. a screenshot or export of a legacy BI dashboard being migrated) giving the AI additional visual context alongside the prompt. Up to 5 files, sharing a combined 50000-token budget with the rest of the prompt."
+          },
           "branchId": {
             "type": "string",
             "format": "uuid",
-            "description": "Optional branch ID for the model. Must be a branch of the shared model specified by modelId. Use this to query against in-progress model changes.",
+            "description": "Optional branch ID for the model. Must be a branch of the shared model specified by modelId. Queries run against the branch model, and if the AI makes model changes (organizations with agentic modeling enabled), they are written to this branch instead of a newly created one. If omitted and the AI makes model changes, a new branch is created automatically.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
           "conversationId": {
@@ -1038,6 +1046,31 @@
         "required": [
           "modelId",
           "prompt"
+        ]
+      },
+      "AgenticJobAttachment": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Base64-encoded file content.",
+            "example": "iVBORw0KGgoAAAANSUhEUgAA..."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "MIME type of the attachment. Must be an image type (e.g. image/png, image/jpeg) or application/pdf.",
+            "example": "image/png"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional filename, used for display/logging only.",
+            "example": "legacy-dashboard-screenshot.png"
+          }
+        },
+        "required": [
+          "data",
+          "mimeType"
         ]
       },
       "AiJobStatusResponse": {
@@ -1638,6 +1671,15 @@
             "description": "Downgrade threshold, or `null` if the downgrade control is off.",
             "example": 800
           },
+          "entityGroupDefaultCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Default per-entity-group AI credit limit, or `null` when embed entity groups are unlimited by default.",
+            "example": 100
+          },
           "periodEnd": {
             "type": "integer",
             "minimum": 0,
@@ -1671,6 +1713,7 @@
           "accountCreditLimit",
           "creditsUsed",
           "downgradeCredits",
+          "entityGroupDefaultCredits",
           "periodEnd",
           "periodStart",
           "shutoffCredits",
@@ -1688,6 +1731,15 @@
             "minimum": 0,
             "description": "Credit usage at which AI downgrades to a cheaper model. Omit to leave unchanged, `null` to turn off, or a non-negative number to set. Must be at or below shutoffCredits.",
             "example": 800
+          },
+          "entityGroupDefaultCredits": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "Default per-entity-group AI credit limit for the billing period — what every embed entity group without an individual limit gets. Omit to leave unchanged, `null` for unlimited by default, or a non-negative number to set.",
+            "example": 100
           },
           "shutoffCredits": {
             "type": [
@@ -1732,6 +1784,7 @@
                 },
                 "userId": {
                   "type": "string",
+                  "format": "uuid",
                   "description": "The user's id within this organization.",
                   "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
                 }
@@ -1768,6 +1821,7 @@
                 },
                 "userId": {
                   "type": "string",
+                  "format": "uuid",
                   "description": "The user's id within this organization.",
                   "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
                 },
@@ -1827,12 +1881,267 @@
           },
           "userId": {
             "type": "string",
+            "format": "uuid",
             "description": "The user's id within this organization.",
             "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
           }
         },
         "required": [
           "userId"
+        ],
+        "additionalProperties": false
+      },
+      "AiEntityGroupCreditLimitsResponse": {
+        "type": "object",
+        "properties": {
+          "entityGroups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditLimit": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0,
+                  "description": "The entity group's effective AI credit limit, or `null` for unlimited.",
+                  "example": 50
+                },
+                "entity": {
+                  "type": "string",
+                  "description": "The embed entity's identifier (the SSO `entity` value).",
+                  "example": "acme-corp"
+                },
+                "usesDefaultLimit": {
+                  "type": "boolean",
+                  "description": "True when the entity group has no individual limit and follows the org default."
+                }
+              },
+              "required": [
+                "creditLimit",
+                "entity",
+                "usesDefaultLimit"
+              ]
+            }
+          }
+        },
+        "required": [
+          "entityGroups"
+        ]
+      },
+      "AiEntityGroupCreditLimitsUpdateBody": {
+        "type": "object",
+        "properties": {
+          "entityGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiEntityGroupCreditLimitEntry"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Entity groups to update, at most 1000 per request. Each entry has an `entity` plus exactly one of `creditLimit` (number or `null`) or `useDefaultLimit: true`."
+          }
+        },
+        "required": [
+          "entityGroups"
+        ],
+        "additionalProperties": false
+      },
+      "AiEntityGroupCreditLimitEntry": {
+        "type": "object",
+        "properties": {
+          "creditLimit": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "description": "The entity group's individual AI credit limit for the billing period, or `null` for unlimited. Either way this overrides the org default. Mutually exclusive with `useDefaultLimit`.",
+            "example": 50
+          },
+          "entity": {
+            "type": "string",
+            "description": "The embed entity's identifier (the SSO `entity` value).",
+            "example": "acme-corp"
+          },
+          "useDefaultLimit": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Removes the entity group's individual limit so it follows the org default. Mutually exclusive with `creditLimit`."
+          }
+        },
+        "required": [
+          "entity"
+        ],
+        "additionalProperties": false
+      },
+      "AiCreditControlsEntityGroupsListResponse": {
+        "type": "object",
+        "properties": {
+          "pageInfo": {
+            "$ref": "#/components/schemas/PageInfo"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditLimit": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0,
+                  "description": "The entity group's individual AI credit limit, or `null` for an explicit unlimited override.",
+                  "example": 50
+                },
+                "entity": {
+                  "type": "string",
+                  "description": "The embed entity's identifier (the SSO `entity` value).",
+                  "example": "acme-corp"
+                }
+              },
+              "required": [
+                "creditLimit",
+                "entity"
+              ]
+            },
+            "description": "Entity groups with an individual AI credit limit, ordered by the entity group id."
+          }
+        },
+        "required": [
+          "pageInfo",
+          "records"
+        ]
+      },
+      "AiCreditUsageUsersResponse": {
+        "type": "object",
+        "properties": {
+          "periodEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "periodStart": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditsUsed": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Credits the id consumed in the current billing period. `0` when it has no usage yet.",
+                  "example": 42
+                },
+                "userId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The user's id within this organization.",
+                  "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
+                }
+              },
+              "required": [
+                "creditsUsed",
+                "userId"
+              ]
+            }
+          }
+        },
+        "required": [
+          "periodEnd",
+          "periodStart",
+          "users"
+        ]
+      },
+      "AiCreditUsageUsersBody": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The user's id within this organization.",
+              "example": "f4a2b3c8-0d1e-4f5a-9b6c-7d8e9f0a1b2c"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Users to read usage for, at most 1000 per request. Each entry is a user's id within this organization."
+          }
+        },
+        "required": [
+          "userIds"
+        ],
+        "additionalProperties": false
+      },
+      "AiCreditUsageEntityGroupsResponse": {
+        "type": "object",
+        "properties": {
+          "periodEnd": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "End of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "periodStart": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Start of the current billing period as a Unix ms timestamp (UTC calendar-month boundary)."
+          },
+          "entityGroups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "creditsUsed": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Credits the id consumed in the current billing period. `0` when it has no usage yet.",
+                  "example": 42
+                },
+                "entity": {
+                  "type": "string",
+                  "description": "The embed entity's identifier (the SSO `entity` value).",
+                  "example": "acme-corp"
+                }
+              },
+              "required": [
+                "creditsUsed",
+                "entity"
+              ]
+            }
+          }
+        },
+        "required": [
+          "periodEnd",
+          "periodStart",
+          "entityGroups"
+        ]
+      },
+      "AiCreditUsageEntityGroupsBody": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The embed entity's identifier (the SSO `entity` value).",
+              "example": "acme-corp"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Entity groups to read usage for, at most 1000 per request. Each entry is an embed `entity` string."
+          }
+        },
+        "required": [
+          "entities"
         ],
         "additionalProperties": false
       },
@@ -1866,6 +2175,9 @@
             "format": "uuid",
             "description": "Branch of the shared model the prompt runs against, or null."
           },
+          "condition": {
+            "$ref": "#/components/schemas/RoutineCondition"
+          },
           "createdAt": {
             "type": "string",
             "description": "ISO 8601 timestamp when the routine was created."
@@ -1895,7 +2207,7 @@
           "modelId": {
             "type": "string",
             "format": "uuid",
-            "description": "The shared model the prompt runs against."
+            "description": "The model the prompt runs against."
           },
           "name": {
             "type": "string",
@@ -1942,6 +2254,7 @@
         },
         "required": [
           "branchId",
+          "condition",
           "createdAt",
           "description",
           "destination",
@@ -1959,6 +2272,38 @@
           "topicName",
           "updatedAt"
         ]
+      },
+      "RoutineCondition": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "conditionPrompt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The delivery condition identified in the routine's current prompt, in plain language. Null on routines created before Omni stored delivery conditions.",
+            "example": "total signups dropped more than 20% versus the prior week"
+          },
+          "conditionType": {
+            "type": "string",
+            "enum": [
+              "RESULTS_CHANGED",
+              "RESULTS_UNCHANGED",
+              "RESULTS_PRESENT",
+              "RESULTS_MISSING"
+            ],
+            "description": "How the condition query gates delivery. RESULTS_PRESENT fires when the condition query returns rows, RESULTS_MISSING when it returns none, RESULTS_CHANGED when its results differ from the previous scheduled run, RESULTS_UNCHANGED when they are identical.",
+            "example": "RESULTS_PRESENT"
+          }
+        },
+        "required": [
+          "conditionPrompt",
+          "conditionType"
+        ],
+        "description": "The condition gating delivery, or null for a routine that delivers on every scheduled run."
       },
       "RoutineDestinationResponse": {
         "oneOf": [
@@ -2099,6 +2444,37 @@
           "id"
         ]
       },
+      "RoutineCreateApiError400": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message describing what went wrong.",
+            "example": "The prompt does not state when the routine should deliver. Add a specific, measurable delivery condition, then try again."
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code of the error.",
+            "example": 400
+          },
+          "code": {
+            "type": "string",
+            "enum": [
+              "no_query",
+              "malformed_query",
+              "no_gate",
+              "dry_run_failed",
+              "no_condition_detected"
+            ],
+            "description": "A machine-readable error code returned when Omni cannot create or validate a delivery condition. This field is absent for other validation errors.",
+            "example": "no_condition_detected"
+          }
+        },
+        "required": [
+          "detail",
+          "status"
+        ]
+      },
       "ApiError429": {
         "type": "object",
         "properties": {
@@ -2133,10 +2509,20 @@
             "description": "Optional human-readable notes about the routine. Display-only — never used as model input.",
             "example": "Weekly signups summary for the growth team."
           },
+          "gating": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "alert",
+              "unconditional"
+            ],
+            "description": "Deprecated. Delivery conditions are no longer derived from the prompt. 'auto' (the default) and 'unconditional' create a routine that delivers on every scheduled run. 'alert' declares a delivery condition Omni cannot honor from the prompt alone and fails with code no_condition_detected.",
+            "example": "unconditional"
+          },
           "modelId": {
             "type": "string",
             "format": "uuid",
-            "description": "The UUID of the shared model the prompt runs against. Only shared models are supported.",
+            "description": "The UUID of the model the prompt runs against. Must be a shared model, or a shared-extension model usable as a workbook base.",
             "example": "770e8400-e29b-41d4-a716-446655440002"
           },
           "name": {
@@ -2276,7 +2662,7 @@
           "prompt": {
             "type": "string",
             "minLength": 1,
-            "description": "New natural language prompt Omni runs on each scheduled run."
+            "description": "New natural language prompt for the routine: what Omni runs and delivers on each scheduled run."
           },
           "schedule": {
             "type": "string",
@@ -2432,6 +2818,152 @@
           "message",
           "success"
         ]
+      },
+      "ConnectionsDbtRotateSigningKeyResponse": {
+        "type": "object",
+        "properties": {
+          "authMethod": {
+            "type": "string",
+            "enum": [
+              "ssh",
+              "https_token",
+              "github_app"
+            ],
+            "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+            "example": "ssh"
+          },
+          "autogenRelationships": {
+            "type": "boolean",
+            "description": "Whether relationships are auto-generated from dbt",
+            "example": true
+          },
+          "branch": {
+            "type": "string",
+            "description": "Git branch name",
+            "example": "main"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
+          },
+          "dbtVersion": {
+            "type": "string",
+            "description": "dbt version being used",
+            "example": "Auto"
+          },
+          "enableSemanticLayer": {
+            "type": "boolean",
+            "description": "Whether the dbt semantic layer integration is enabled",
+            "example": false
+          },
+          "enableVirtualSchemas": {
+            "type": "boolean",
+            "description": "Whether virtual schemas are enabled",
+            "example": false
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null for non-github_app auth.",
+            "example": "12345678"
+          },
+          "projectRootPath": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to dbt project root",
+            "example": "dbt_project"
+          },
+          "sshUrl": {
+            "type": "string",
+            "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
+            "example": "git@github.com:org/repo.git"
+          },
+          "supportsDbt": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Indicates dbt is supported and configured",
+            "example": true
+          }
+        },
+        "required": [
+          "authMethod",
+          "autogenRelationships",
+          "branch",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
+          "dbtVersion",
+          "enableSemanticLayer",
+          "enableVirtualSchemas",
+          "githubAppInstallationId",
+          "projectRootPath",
+          "sshUrl",
+          "supportsDbt"
+        ],
+        "description": "dbt repository configuration response",
+        "title": "DbtConfiguredResponse"
+      },
+      "ConnectionsDbtRotateSigningKeyBody": {
+        "type": "object",
+        "properties": {
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
+          },
+          "signingKeyPassphrase": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Passphrase for signingPrivateKey when it is encrypted. Omni uses it once to decrypt the key, then stores the key under its own encryption at rest; the passphrase itself is not retained."
+          },
+          "signingPrivateKey": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 65536,
+            "description": "Bring-your-own ED25519 signing private key in PEM format (as produced by `ssh-keygen -t ed25519`), used instead of an Omni-generated keypair. Enables zero-downtime rotation: register the matching public key on the GitHub user first, then set it here. RSA keys are rejected — commit signing is SSHSIG over ED25519. Must be non-blank when provided; omit it to have Omni mint a fresh keypair."
+          }
+        },
+        "additionalProperties": false
       },
       "DbtEnvironmentListResponse": {
         "type": "object",
@@ -3041,7 +3573,7 @@
               "number",
               "null"
             ],
-            "description": "Number of dashboard visits"
+            "description": "Number of visits to the document's dashboard, or to its app if it has one instead. Absent until the first visit."
           }
         },
         "required": [
@@ -3056,6 +3588,69 @@
           "identifier",
           "updatedAt",
           "url"
+        ]
+      },
+      "ContentSearchResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Dashboard description, if any."
+                },
+                "folderPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Folder path of the dashboard, if any."
+                },
+                "identifier": {
+                  "type": "string",
+                  "description": "The dashboard identifier, usable with the documents and schedules endpoints.",
+                  "example": "12db1a0a"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Dashboard name."
+                },
+                "tileNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Up to 5 query names from the dashboard's workbook — the first few, not the ones that matched."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL to open the dashboard. Omitted on MCP requests when the org has `disable-ai-mcp-links` on."
+                },
+                "verified": {
+                  "type": "boolean",
+                  "description": "Whether the dashboard carries a verified label."
+                }
+              },
+              "required": [
+                "description",
+                "folderPath",
+                "identifier",
+                "name",
+                "tileNames",
+                "verified"
+              ]
+            },
+            "description": "Matching dashboards, most relevant first."
+          }
+        },
+        "required": [
+          "results"
         ]
       },
       "DashboardsDownloadResponse": {
@@ -3081,6 +3676,12 @@
       "DashboardsDownloadBody": {
         "type": "object",
         "properties": {
+          "enableConditionalFormatting": {
+            "type": "boolean",
+            "default": true,
+            "description": "Compatible with xlsx format only. Defaults to true. When true, conditional formatting rules from the visualization are included in the Excel output — provided the organization has the 'excel-conditional-formatting' feature enabled.",
+            "example": true
+          },
           "enableFormatting": {
             "type": "boolean",
             "default": false,
@@ -4093,7 +4694,7 @@
               "restricted",
               "organization"
             ],
-            "description": "Access scope for the document"
+            "description": "Access scope for the document. Optional: when omitted the destination decides — a move into a folder takes that folder's scope, and a move to the root leaves the document's current scope unchanged. When supplied it must match the destination folder's scope."
           }
         },
         "required": [
@@ -4103,14 +4704,24 @@
       "DocumentsGetPermissionsResponse": {
         "type": "object",
         "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/DocumentAbilities"
+          },
           "permits": {
-            "description": "User permits for the document"
+            "description": "User permits for the document. Present only when userId is provided."
           }
-        }
+        },
+        "required": [
+          "abilities"
+        ]
       },
-      "DocumentsUpdatePermissionSettingsBody": {
+      "DocumentAbilities": {
         "type": "object",
         "properties": {
+          "canAnalyze": {
+            "type": "boolean",
+            "description": "Allow exploring from this document"
+          },
           "canDownload": {
             "type": "boolean",
             "description": "Allow downloading"
@@ -4118,6 +4729,86 @@
           "canDrill": {
             "type": "boolean",
             "description": "Allow drill-down"
+          },
+          "canDuplicate": {
+            "type": "boolean",
+            "description": "Allow duplicating"
+          },
+          "canRequestAccess": {
+            "type": "boolean",
+            "description": "Allow requesting access"
+          },
+          "canSaveSpreadsheets": {
+            "type": "boolean",
+            "description": "Allow creating spreadsheets"
+          },
+          "canSchedule": {
+            "type": "boolean",
+            "description": "Allow scheduling"
+          },
+          "canUpload": {
+            "type": "boolean",
+            "description": "Allow uploads"
+          },
+          "canUseDashboardAi": {
+            "type": "boolean",
+            "description": "Allow using dashboard AI"
+          },
+          "canUseTimezoneOverride": {
+            "type": "boolean",
+            "description": "Allow timezone override"
+          },
+          "canViewWorkbook": {
+            "type": "boolean",
+            "description": "Allow viewing workbook"
+          },
+          "requirePullRequestToPublish": {
+            "type": "boolean",
+            "description": "Require pull request to publish changes"
+          }
+        },
+        "required": [
+          "canAnalyze",
+          "canDownload",
+          "canDrill",
+          "canDuplicate",
+          "canRequestAccess",
+          "canSaveSpreadsheets",
+          "canSchedule",
+          "canUpload",
+          "canUseDashboardAi",
+          "canUseTimezoneOverride",
+          "canViewWorkbook",
+          "requirePullRequestToPublish"
+        ],
+        "description": "Document-level ability values, as stored on the document"
+      },
+      "DocumentsUpdatePermissionSettingsBody": {
+        "type": "object",
+        "properties": {
+          "canAnalyze": {
+            "type": "boolean",
+            "description": "Allow exploring from this document"
+          },
+          "canDownload": {
+            "type": "boolean",
+            "description": "Allow downloading"
+          },
+          "canDrill": {
+            "type": "boolean",
+            "description": "Allow drill-down"
+          },
+          "canDuplicate": {
+            "type": "boolean",
+            "description": "Allow duplicating"
+          },
+          "canRequestAccess": {
+            "type": "boolean",
+            "description": "Allow requesting access"
+          },
+          "canSaveSpreadsheets": {
+            "type": "boolean",
+            "description": "Allow creating spreadsheets"
           },
           "canSchedule": {
             "type": "boolean",
@@ -4141,7 +4832,7 @@
           },
           "organizationAccessBoost": {
             "type": "boolean",
-            "description": "Boost organization access"
+            "description": "Boost organization access. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "organizationRole": {
             "type": "string",
@@ -4165,7 +4856,7 @@
           "accessBoost": {
             "type": "boolean",
             "default": false,
-            "description": "Grant access boost"
+            "description": "Grant access boost. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -4174,7 +4865,8 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
             "description": "Role to grant"
           },
@@ -4205,7 +4897,7 @@
         "properties": {
           "accessBoost": {
             "type": "boolean",
-            "description": "Access boost setting"
+            "description": "Access boost setting. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -4214,7 +4906,8 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
             "description": "Role to set"
           },
@@ -4532,7 +5225,8 @@
             "default": [],
             "description": "Labels to remove"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "DocumentsTransferOwnershipBody": {
         "type": "object",
@@ -12371,6 +13065,16 @@
               }
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
+          },
+          "mobileBehavior": {
+            "type": "string",
+            "enum": [
+              "stack",
+              "wrap",
+              "keep",
+              "hide"
+            ],
+            "description": "Overrides the automatic mobile layout: \"keep\" freezes the desktop grid arrangement, \"hide\" hides the container on mobile (\"stack\" and \"wrap\" apply to row stacks)"
           },
           "padding": {
             "anyOf": [
@@ -20711,6 +21415,16 @@
             },
             "description": "Optional bookkeeping for this container (e.g. `attachedQueryKey` for auto-placed tiles)"
           },
+          "mobileBehavior": {
+            "type": "string",
+            "enum": [
+              "stack",
+              "wrap",
+              "keep",
+              "hide"
+            ],
+            "description": "Overrides the automatic mobile layout: \"stack\" flips a row to a column, \"wrap\" keeps the row and wraps items, \"keep\" freezes the desktop arrangement, \"hide\" hides the container on mobile"
+          },
           "padding": {
             "anyOf": [
               {
@@ -21641,6 +22355,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -21742,6 +22463,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -21885,6 +22613,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -21960,6 +22695,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22038,6 +22780,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22154,6 +22903,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -22225,6 +22981,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22314,6 +23077,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -22533,6 +23303,13 @@
                   },
                   "label": {
                     "type": "string"
+                  },
+                  "fieldOrder": {
+                    "type": "string",
+                    "enum": [
+                      "query",
+                      "control"
+                    ]
                   },
                   "options": {
                     "type": "array",
@@ -22933,6 +23710,14 @@
             ],
             "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
           },
+          "fileUploadId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "File upload backing this tab (a CSV data-input / Source tab or a spreadsheet tab). Applies only to csv / spreadsheet tabs — rejected on patches for other tab types."
+          },
           "filterOrder": {
             "type": "array",
             "items": {
@@ -22980,6 +23765,11 @@
                       "type": "boolean",
                       "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
                     },
+                    "anchor_row": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "description": "The 1-indexed row the Excel-style formula was authored against, so row-relative references resolve to the intended offsets — e.g. a percent-of-previous \"=B4/B5\" authored on row 5. Only used when sql_expression is omitted; defaults to 1 (B1 = this row)."
+                    },
                     "calc_name": {
                       "type": "string",
                       "description": "Internal identifier for the calculation, used as the column alias."
@@ -22998,7 +23788,7 @@
                     },
                     "original_formula": {
                       "type": "string",
-                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                      "description": "The calculation formula. Prefer referencing selected fields by name (e.g. \"=SUM(orders.revenue)\") — name references are stable under column reordering and have no row semantics. Excel-style references also work: column letters map to the query's fields in table order (A = the first field) with rows anchored at row 1 (set anchor_row to author row-relative references against a different row), and calc columns can only be referenced by letter. When sql_expression is omitted, the server parses this formula on write and rejects the request if it does not parse."
                     },
                     "outside_pivot": {
                       "type": "boolean",
@@ -23016,7 +23806,7 @@
                       "description": "Compiled SQL string produced from the formula."
                     },
                     "sql_expression": {
-                      "description": "Parsed SQL expression tree (serialized)."
+                      "description": "Parsed SQL expression tree (serialized, server-internal format). Omit it to have the server parse original_formula instead."
                     },
                     "swallow_errors": {
                       "type": "boolean",
@@ -23266,6 +24056,13 @@
                         },
                         "label": {
                           "type": "string"
+                        },
+                        "fieldOrder": {
+                          "type": "string",
+                          "enum": [
+                            "query",
+                            "control"
+                          ]
                         },
                         "options": {
                           "type": "array",
@@ -23563,7 +24360,7 @@
               },
               "default_group_by": {
                 "type": "boolean",
-                "description": "When true, all dimensions are implicitly included in GROUP BY."
+                "description": "When true, all dimensions are implicitly included in GROUP BY, unless the model's default_group_by setting (never or primary_key) suppresses it."
               },
               "dimensionIndex": {
                 "type": "number",
@@ -23674,6 +24471,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -23778,6 +24582,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -23924,6 +24735,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24002,6 +24820,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24083,6 +24908,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24202,6 +25034,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24276,6 +25115,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24368,6 +25214,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24477,6 +25330,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24581,6 +25441,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24727,6 +25594,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -24805,6 +25679,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -24886,6 +25767,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -25005,6 +25893,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -25079,6 +25974,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -25172,6 +26074,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -25233,6 +26142,13 @@
                   "additionalProperties": {}
                 },
                 "description": "Per-field display metadata (format, label, order)."
+              },
+              "model_extension_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The query model this query is bound to — a model extension layered on this document’s workbook model. Exposed on read. Server-owned on write: a value supplied on PATCH or create is ignored and the tile keeps its existing binding, so editing a tile cannot orphan its query model. An entry that carries no `query` clears the tile’s query, dropping the binding with it. Changing a binding is a draft-scoped operation, not expressible through this field. The id is a draft-local clone and is not stable across the publish cycle — each draft re-clones its query models under a new workbook model. LINKED tabs don’t carry one: their query, and its binding, come from the source tab."
               },
               "offset": {
                 "type": "number",
@@ -25398,7 +26314,7 @@
               "userEditedSQL"
             ],
             "additionalProperties": {},
-            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). Omitted on a no-op replay; the server anchors new/changed tiles to the draft."
+            "description": "The semantic query for this tab, minus the server-owned `modelId` anchor (the server anchors new/changed tiles to the draft; a FOREIGN tab keeps its stored execution model). `model_extension_id` is server-owned too — a supplied value is ignored and the tile keeps its existing binding (see the field’s own description). Omitted on a no-op replay."
           },
           "resultConfig": {
             "type": "object",
@@ -25431,9 +26347,10 @@
               "sql",
               "dbt",
               "query-view",
-              "linked"
+              "linked",
+              "foreign"
             ],
-            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET). `foreign` is only valid when echoing an existing foreign tab at the same key — a tab cannot be created as, or converted to/from, FOREIGN through this API."
           },
           "visConfig": {
             "type": [
@@ -25539,6 +26456,13 @@
             },
             "additionalProperties": {},
             "description": "Visualization configuration for the tile."
+          },
+          "foreignModelId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present only on FOREIGN tabs: the shared model this tab’s query executes against (a different model than the document’s). Stable across publishes. Server-owned on write — a supplied value is ignored and the tab keeps its stored execution model. Omitted for every other tab type."
           },
           "sourceQueryPresentationKey": {
             "type": [
@@ -25775,6 +26699,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -25876,6 +26807,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26019,6 +26957,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -26094,6 +27039,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26172,6 +27124,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26288,6 +27247,13 @@
                   "required": {
                     "type": "boolean"
                   },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
+                  },
                   "topic": {
                     "type": "string"
                   },
@@ -26359,6 +27325,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26448,6 +27421,13 @@
                   },
                   "required": {
                     "type": "boolean"
+                  },
+                  "requiredScope": {
+                    "type": "string",
+                    "enum": [
+                      "dashboard",
+                      "tiles"
+                    ]
                   },
                   "topic": {
                     "type": "string"
@@ -26667,6 +27647,13 @@
                   },
                   "label": {
                     "type": "string"
+                  },
+                  "fieldOrder": {
+                    "type": "string",
+                    "enum": [
+                      "query",
+                      "control"
+                    ]
                   },
                   "options": {
                     "type": "array",
@@ -26946,7 +27933,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/QueryPresentationReadExternal"
             },
-            "description": "Query presentations keyed by tab ID."
+            "description": "Query presentations keyed by tab ID. A FOREIGN tab — one whose query runs against a shared model other than this document’s — carries its execution model at `foreignModelId`."
           },
           "order": {
             "type": "array",
@@ -27025,6 +28012,14 @@
             ],
             "description": "Pending rename of the model object being edited. Applies only to dataset / query-view tabs — omitted from reads and rejected on patches for other tab types."
           },
+          "fileUploadId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "File upload backing this tab (a CSV data-input / Source tab or a spreadsheet tab). Applies only to csv / spreadsheet tabs — rejected on patches for other tab types."
+          },
           "filterOrder": {
             "type": "array",
             "items": {
@@ -27072,6 +28067,11 @@
                       "type": "boolean",
                       "description": "Set by the Kotlin parser when this calc references fields not selected at the top level (AI SQL-gen produces these; UI-authored calcs do not)."
                     },
+                    "anchor_row": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "description": "The 1-indexed row the Excel-style formula was authored against, so row-relative references resolve to the intended offsets — e.g. a percent-of-previous \"=B4/B5\" authored on row 5. Only used when sql_expression is omitted; defaults to 1 (B1 = this row)."
+                    },
                     "calc_name": {
                       "type": "string",
                       "description": "Internal identifier for the calculation, used as the column alias."
@@ -27090,7 +28090,7 @@
                     },
                     "original_formula": {
                       "type": "string",
-                      "description": "The original Excel-style formula before parsing (e.g. \"=SUM(A1:A10)\")."
+                      "description": "The calculation formula. Prefer referencing selected fields by name (e.g. \"=SUM(orders.revenue)\") — name references are stable under column reordering and have no row semantics. Excel-style references also work: column letters map to the query's fields in table order (A = the first field) with rows anchored at row 1 (set anchor_row to author row-relative references against a different row), and calc columns can only be referenced by letter. When sql_expression is omitted, the server parses this formula on write and rejects the request if it does not parse."
                     },
                     "outside_pivot": {
                       "type": "boolean",
@@ -27108,7 +28108,7 @@
                       "description": "Compiled SQL string produced from the formula."
                     },
                     "sql_expression": {
-                      "description": "Parsed SQL expression tree (serialized)."
+                      "description": "Parsed SQL expression tree (serialized, server-internal format). Omit it to have the server parse original_formula instead."
                     },
                     "swallow_errors": {
                       "type": "boolean",
@@ -27358,6 +28358,13 @@
                         },
                         "label": {
                           "type": "string"
+                        },
+                        "fieldOrder": {
+                          "type": "string",
+                          "enum": [
+                            "query",
+                            "control"
+                          ]
                         },
                         "options": {
                           "type": "array",
@@ -27655,7 +28662,7 @@
               },
               "default_group_by": {
                 "type": "boolean",
-                "description": "When true, all dimensions are implicitly included in GROUP BY."
+                "description": "When true, all dimensions are implicitly included in GROUP BY, unless the model's default_group_by setting (never or primary_key) suppresses it."
               },
               "dimensionIndex": {
                 "type": "number",
@@ -27766,6 +28773,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -27870,6 +28884,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28016,6 +29037,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28094,6 +29122,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28175,6 +29210,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28294,6 +29336,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28368,6 +29417,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28460,6 +29516,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28569,6 +29632,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28673,6 +29743,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28819,6 +29896,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -28897,6 +29981,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -28978,6 +30069,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -29097,6 +30195,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -29171,6 +30276,13 @@
                         },
                         "required": {
                           "type": "boolean"
+                        },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
                         },
                         "topic": {
                           "type": "string"
@@ -29264,6 +30376,13 @@
                         "required": {
                           "type": "boolean"
                         },
+                        "requiredScope": {
+                          "type": "string",
+                          "enum": [
+                            "dashboard",
+                            "tiles"
+                          ]
+                        },
                         "topic": {
                           "type": "string"
                         },
@@ -29325,6 +30444,13 @@
                   "additionalProperties": {}
                 },
                 "description": "Per-field display metadata (format, label, order)."
+              },
+              "model_extension_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The query model this query is bound to — a model extension layered on this document’s workbook model. Exposed on read. Server-owned on write: a value supplied on PATCH or create is ignored and the tile keeps its existing binding, so editing a tile cannot orphan its query model. An entry that carries no `query` clears the tile’s query, dropping the binding with it. Changing a binding is a draft-scoped operation, not expressible through this field. The id is a draft-local clone and is not stable across the publish cycle — each draft re-clones its query models under a new workbook model. LINKED tabs don’t carry one: their query, and its binding, come from the source tab."
               },
               "offset": {
                 "type": "number",
@@ -29490,7 +30616,7 @@
               "userEditedSQL"
             ],
             "additionalProperties": {},
-            "description": "The semantic query for this tab, minus the server-owned workbook model anchors (modelId / model_extension_id). For LINKED-type tabs this field is read-only."
+            "description": "The semantic query for this tab, minus the server-owned `modelId` anchor (the workbook id, echoed at the document root; a FOREIGN tab’s execution model surfaces as the tile-level `foreignModelId` instead). Its `model_extension_id` — the query-model binding — is exposed here but is server-owned on write (see the field’s own description). For LINKED-type tabs this field is read-only."
           },
           "resultConfig": {
             "type": "object",
@@ -29523,9 +30649,10 @@
               "sql",
               "dbt",
               "query-view",
-              "linked"
+              "linked",
+              "foreign"
             ],
-            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET)."
+            "description": "The query presentation type (e.g. SEMANTIC, SQL, LINKED, SPREADSHEET). `foreign` is only valid when echoing an existing foreign tab at the same key — a tab cannot be created as, or converted to/from, FOREIGN through this API."
           },
           "visConfig": {
             "type": [
@@ -29631,6 +30758,10 @@
             },
             "additionalProperties": {},
             "description": "Visualization configuration for the tile."
+          },
+          "foreignModelId": {
+            "type": "string",
+            "description": "Present only on FOREIGN tabs: the shared model this tab’s query executes against (a different model than the document’s). Stable across publishes. Server-owned on write — a supplied value is ignored and the tab keeps its stored execution model. Omitted for every other tab type."
           },
           "sourceQueryPresentationKey": {
             "type": [
@@ -29815,6 +30946,20 @@
         },
         "additionalProperties": false
       },
+      "DocumentsV2BindQueryModelBody": {
+        "type": "object",
+        "properties": {
+          "queryModelId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The query model to bind this tile to. Must be a query model layered on this draft’s workbook model, not already bound to another tile. LINKED and FOREIGN tabs are rejected: a LINKED tab inherits its source’s binding, and a FOREIGN tab’s query runs against a different model."
+          }
+        },
+        "required": [
+          "queryModelId"
+        ],
+        "additionalProperties": false
+      },
       "DocumentsV2PublishDraftResponse": {
         "type": "object",
         "properties": {
@@ -29923,8 +31068,39 @@
           },
           "userAttributes": {
             "type": "object",
-            "additionalProperties": {},
-            "description": "Optional user attributes for row-level security"
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number",
+                  "minimum": -1.7976931348623157e+308,
+                  "maximum": 1.7976931348623157e+308
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number",
+                        "minimum": -1.7976931348623157e+308,
+                        "maximum": 1.7976931348623157e+308
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "description": "Optional user attributes for row-level security. Values are a string, a number, or an array of strings/numbers. Numbers are converted to strings on receipt, so send anything beyond the JSON safe integer range (2^53 - 1) as a string or it loses precision before Omni sees it.",
+            "example": {
+              "account_id": "9007199254740993",
+              "region": "us-east",
+              "tier": 2
+            }
           }
         },
         "required": [
@@ -30532,6 +31708,11 @@
             "description": "The prompt set this run was created from.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
+          "repeat_count": {
+            "type": "integer",
+            "description": "How many times each prompt in the set was executed.",
+            "example": 1
+          },
           "run_number": {
             "type": "integer",
             "description": "Sequential, per-prompt-set run number.",
@@ -30561,6 +31742,7 @@
           "is_archived",
           "model_id",
           "prompt_set_id",
+          "repeat_count",
           "run_number",
           "stats",
           "status"
@@ -30576,7 +31758,7 @@
           },
           "total": {
             "type": "integer",
-            "description": "Total number of per-prompt jobs in the run.",
+            "description": "Total number of jobs in the run (prompts × the repeat count).",
             "example": 12
           }
         },
@@ -30590,7 +31772,7 @@
         "properties": {
           "job_count": {
             "type": "integer",
-            "description": "Number of per-prompt agentic jobs created for this run (one per prompt that fanned out successfully). Enqueue onto the work queue happens after creation and is best-effort, so this count reflects jobs created, not necessarily those successfully enqueued.",
+            "description": "Number of agentic jobs created for this run (one per prompt execution — prompts × repeat count — that fanned out successfully). Enqueue onto the work queue happens after creation and is best-effort, so this count reflects jobs created, not necessarily those successfully enqueued.",
             "example": 12
           },
           "run": {
@@ -30669,12 +31851,17 @@
             "description": "The prompt set this run was created from.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
+          "repeat_count": {
+            "type": "integer",
+            "description": "How many times each prompt in the set was executed. Results carry a `repeat_index` when this is greater than 1.",
+            "example": 1
+          },
           "results": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EvalRunResult"
             },
-            "description": "Per-prompt results for this run, ordered by their creation order in the prompt set."
+            "description": "Per-execution results for this run (one per prompt, times the repeat count). No guaranteed order — group executions by `eval_prompt_id` and order by `repeat_index`."
           },
           "run_number": {
             "type": "integer",
@@ -30702,6 +31889,7 @@
           "is_archived",
           "model_id",
           "prompt_set_id",
+          "repeat_count",
           "results",
           "run_number",
           "status"
@@ -30738,6 +31926,15 @@
             "description": "Failure reason string for prompts whose underlying job failed.",
             "example": null
           },
+          "eval_prompt_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Snapshot of the prompt id this result was executed for — repeated executions of the same prompt share it, and it survives later prompt deletion. Null on runs created before repeats existed.",
+            "example": "bb0e8400-e29b-41d4-a716-446655440007"
+          },
           "expectation": {
             "type": [
               "string",
@@ -30773,6 +31970,14 @@
             "description": "Total wall-clock time (milliseconds) the underlying job spent running warehouse queries — a proxy for query execution time. Null for runs executed before this metric was recorded.",
             "example": 1800
           },
+          "repeat_index": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "0-based repeat number of this execution within the run (see the run's `repeat_count`). Null on runs created before repeats existed.",
+            "example": 0
+          },
           "score": {
             "type": [
               "number",
@@ -30802,7 +32007,7 @@
               "integer",
               "null"
             ],
-            "description": "Inner-loop tool latency in milliseconds — time spent running tools the model invoked (model and field-value lookups, query planning), excluding the warehouse query itself (`query_timing_ms`). Null for runs recorded before per-tool latency was tracked.",
+            "description": "Inner-loop tool latency in milliseconds — time spent running tools the model invoked (model and field-value lookups, query planning) plus any provider call that failed before a tool was attempted, excluding the warehouse query itself (`query_timing_ms`). Null for runs recorded before per-tool latency was tracked.",
             "example": 200
           }
         },
@@ -30811,11 +32016,13 @@
           "ai_timing_ms",
           "cost",
           "error_reason",
+          "eval_prompt_id",
           "expectation",
           "id",
           "prompt",
           "query_count",
           "query_timing_ms",
+          "repeat_index",
           "score",
           "scoring_cost",
           "timing_ms",
@@ -30924,6 +32131,13 @@
                 "format": "uuid",
                 "description": "Optional branch ID to run against. Must be a branch of the prompt set's model.",
                 "example": "440e8400-e29b-41d4-a716-446655440006"
+              },
+              "repeat_count": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": "How many times to execute each prompt in the set (defaults to 1). Between 1 and 10; prompts × repeats may not exceed the per-run job limit.",
+                "example": 1
               }
             },
             "description": "Per-run configuration. Optional — omit if no overrides."
@@ -30973,13 +32187,13 @@
                 "$ref": "#/components/schemas/EvalRunDetail"
               },
               {
-                "description": "The cancelled run. `status: CANCELLED` and `is_archived: true` after this call."
+                "description": "The cancelled run. `status: CANCELLED` and `is_archived: false` after this call."
               }
             ]
           },
           "total": {
             "type": "integer",
-            "description": "Total number of per-prompt jobs in the run.",
+            "description": "Total number of jobs in the run (prompts × the repeat count).",
             "example": 12
           }
         },
@@ -31092,6 +32306,10 @@
       "FoldersCreateResponse": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "Whether breadcrumbs start at this folder"
+          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -31120,6 +32338,7 @@
           }
         },
         "required": [
+          "breadcrumbRoot",
           "id",
           "name",
           "ownerId",
@@ -31130,6 +32349,10 @@
       "FoldersCreateBody": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "When true, breadcrumbs for content in this folder start at this folder, hiding parent folders"
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -31174,6 +32397,10 @@
       "FoldersUpdateResponse": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "Whether breadcrumbs start at this folder"
+          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -31189,6 +32416,7 @@
           }
         },
         "required": [
+          "breadcrumbRoot",
           "id",
           "name",
           "path"
@@ -31197,6 +32425,10 @@
       "FoldersUpdateBody": {
         "type": "object",
         "properties": {
+          "breadcrumbRoot": {
+            "type": "boolean",
+            "description": "When true, breadcrumbs for content in this folder start at this folder, hiding parent folders"
+          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -31215,7 +32447,45 @@
             "default": false,
             "description": "When true, automatically resolves path collisions with existing folders by appending a numeric suffix (e.g., my-path-1). When false (default), returns 409 Conflict if the path is already taken. Does not apply to reserved paths, which are always rejected with 400."
           }
-        }
+        },
+        "additionalProperties": false
+      },
+      "FoldersBulkUpdateLabelsResponse": {
+        "type": "object",
+        "properties": {
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The folder's labels after the update"
+          }
+        },
+        "required": [
+          "labels"
+        ]
+      },
+      "FoldersBulkUpdateLabelsBody": {
+        "type": "object",
+        "properties": {
+          "add": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Label names to add to the folder"
+          },
+          "remove": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Label names to remove from the folder"
+          }
+        },
+        "additionalProperties": false
       },
       "FoldersGetPermissionsResponse": {
         "type": "object",
@@ -31231,7 +32501,7 @@
                 },
                 "role": {
                   "type": "string",
-                  "description": "Content role (e.g., VIEWER, EDITOR, MANAGER)",
+                  "description": "Content role (e.g., VIEWER, EDITOR, MANAGER, OWNER)",
                   "example": "VIEWER"
                 },
                 "userGroupId": {
@@ -31273,7 +32543,7 @@
           "accessBoost": {
             "type": "boolean",
             "default": false,
-            "description": "Whether to grant access boost"
+            "description": "Whether to grant access boost. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -31282,9 +32552,10 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
-            "description": "Content role to assign (VIEWER, EDITOR, or MANAGER)",
+            "description": "Content role to assign (NO_ACCESS, VIEWER, EXPLORER, EDITOR, MANAGER, or OWNER). OWNER may only be granted to users, never to groups, and never with an expiry.",
             "example": "VIEWER"
           },
           "userGroupIds": {
@@ -31327,7 +32598,7 @@
         "properties": {
           "accessBoost": {
             "type": "boolean",
-            "description": "Whether to grant access boost"
+            "description": "Whether to grant access boost. Rejected with 403 when the organization has AccessBoost turned off."
           },
           "role": {
             "type": "string",
@@ -31336,7 +32607,8 @@
               "VIEWER",
               "EXPLORER",
               "EDITOR",
-              "MANAGER"
+              "MANAGER",
+              "OWNER"
             ],
             "description": "New content role to assign"
           },
@@ -31877,6 +33149,167 @@
           "value"
         ]
       },
+      "GenerateSuggestionsResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the created generation run. Poll `GET /suggestions/runs/{runId}` for status."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued"
+            ],
+            "description": "The generation run was enqueued. Generation runs asynchronously."
+          }
+        },
+        "required": [
+          "runId",
+          "status"
+        ]
+      },
+      "SuggestionsCooldownResponse": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "lastCompletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the most recent run completed."
+          },
+          "retryAfterSeconds": {
+            "type": "integer",
+            "description": "Seconds to wait before a new run is allowed."
+          },
+          "status": {
+            "type": "integer",
+            "example": 429
+          }
+        },
+        "required": [
+          "detail",
+          "lastCompletedAt",
+          "retryAfterSeconds",
+          "status"
+        ]
+      },
+      "SuggestionRun": {
+        "type": "object",
+        "properties": {
+          "completedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the run reached a terminal state."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the run was created (queued)."
+          },
+          "error": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Failure details when `status` is `failed`; null otherwise."
+          },
+          "executionStartedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the worker started executing; null while queued."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The run id."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "executing",
+              "complete",
+              "failed"
+            ],
+            "description": "Run status. Terminal states are `complete` and `failed`."
+          },
+          "triggerSource": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "scheduled"
+            ],
+            "description": "Whether the run was triggered manually or by the schedule."
+          },
+          "triggeredBy": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "userId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "name",
+              "userId"
+            ],
+            "description": "The user who triggered a manual run; null for scheduled runs."
+          }
+        },
+        "required": [
+          "completedAt",
+          "createdAt",
+          "error",
+          "executionStartedAt",
+          "id",
+          "status",
+          "triggerSource",
+          "triggeredBy"
+        ]
+      },
+      "SuggestionRunLatestResponse": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuggestionRun"
+              },
+              {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "The most recent run for this model, or null if none exists."
+              }
+            ]
+          }
+        },
+        "required": [
+          "run"
+        ]
+      },
       "ScheduleSuggestionsResponse": {
         "type": "object",
         "properties": {
@@ -32376,8 +33809,29 @@
           },
           "filters": {
             "type": "object",
-            "additionalProperties": {},
-            "description": "Filters for the field"
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "string",
+                    "number",
+                    "date",
+                    "boolean",
+                    "null",
+                    "composite",
+                    "query",
+                    "user_attribute"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": {}
+            },
+            "description": "Filters for the field, keyed by filter id"
           },
           "format": {
             "type": "string",
@@ -32387,9 +33841,27 @@
             "type": "array",
             "items": {
               "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "string",
+                    "number",
+                    "date",
+                    "boolean",
+                    "null",
+                    "composite",
+                    "query",
+                    "user_attribute"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ],
               "additionalProperties": {}
             },
-            "description": "Group filters"
+            "description": "Group filters, one filter per entry in groupNames"
           },
           "groupLabel": {
             "type": "string",
@@ -32545,7 +34017,62 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "additionalProperties": {}
+                  "properties": {
+                    "bidirectional": {
+                      "type": "boolean"
+                    },
+                    "extension_model_id": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "ignored": {
+                      "type": "boolean"
+                    },
+                    "join_type": {
+                      "type": "string"
+                    },
+                    "left_view_alias": {
+                      "type": "string"
+                    },
+                    "left_view_label": {
+                      "type": "string"
+                    },
+                    "left_view_name": {
+                      "type": "string"
+                    },
+                    "original_on_sql": {
+                      "type": "string"
+                    },
+                    "right_view_alias": {
+                      "type": "string"
+                    },
+                    "right_view_label": {
+                      "type": "string"
+                    },
+                    "right_view_name": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "yaml_path_prefix": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "join_type",
+                    "left_view_name",
+                    "original_on_sql",
+                    "right_view_name",
+                    "sql",
+                    "type"
+                  ]
                 },
                 "description": "Relationships for the topic"
               },
@@ -32553,6 +34080,148 @@
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "properties": {
+                    "ai_context": {
+                      "type": "string"
+                    },
+                    "aliases": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "catalog": {
+                      "type": "string"
+                    },
+                    "default_drill_fields": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "dimensions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field_name": {
+                            "type": "string",
+                            "description": "Field name"
+                          }
+                        },
+                        "required": [
+                          "field_name"
+                        ],
+                        "additionalProperties": {}
+                      }
+                    },
+                    "display_order": {
+                      "type": "number"
+                    },
+                    "extension_model_id": {
+                      "type": "string"
+                    },
+                    "fields_limited": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "filter_only_fields": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field_name": {
+                            "type": "string",
+                            "description": "Field name"
+                          }
+                        },
+                        "required": [
+                          "field_name"
+                        ],
+                        "additionalProperties": {}
+                      }
+                    },
+                    "folder": {
+                      "type": "string"
+                    },
+                    "hidden": {
+                      "type": "boolean"
+                    },
+                    "ide_file_name": {
+                      "type": "string"
+                    },
+                    "ignored": {
+                      "type": "boolean"
+                    },
+                    "is_pseudo_display_view": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "measures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field_name": {
+                            "type": "string",
+                            "description": "Field name"
+                          }
+                        },
+                        "required": [
+                          "field_name"
+                        ],
+                        "additionalProperties": {}
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "schema_label": {
+                      "type": "string"
+                    },
+                    "table_name": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "topic_scope": {
+                      "type": "string"
+                    },
+                    "yaml_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "dimensions",
+                    "filter_only_fields",
+                    "ide_file_name",
+                    "measures",
+                    "name",
+                    "yaml_path"
+                  ],
                   "additionalProperties": {}
                 },
                 "description": "Views available in the topic"
@@ -32902,6 +34571,122 @@
           "dbt_environment_id"
         ]
       },
+      "ModelsBranchDbtGetResponse": {
+        "type": "object",
+        "properties": {
+          "git_branch": {
+            "type": "string",
+            "description": "The dbt git branch the environment compiles against. When none is pinned, this is the resolved default: for a non-production environment on a branch, a git branch named after the Omni branch; otherwise the dbt repo's default branch. If the named branch doesn't exist in the dbt repo, compilation falls back to the repo's default branch.",
+            "example": "feature/new-metrics"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the dbt environment the branch resolves to",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "is_default_environment": {
+            "type": "boolean",
+            "description": "True when the branch resolves to the connection's default (production) environment — typically because the branch has no dbt environment of its own."
+          },
+          "is_deferral_enabled": {
+            "type": "boolean"
+          },
+          "manifest_status": {
+            "type": "string",
+            "enum": [
+              "NOT_FOUND",
+              "OUTDATED",
+              "UP_TO_DATE"
+            ],
+            "description": "Whether the environment's compiled dbt manifest is up to date"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "Production"
+          },
+          "owner_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "User id the environment belongs to (a personal development environment), or null"
+          },
+          "target_database": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_role": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target_schema": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelsBranchDbtEnvironmentVariable"
+            }
+          }
+        },
+        "required": [
+          "git_branch",
+          "id",
+          "is_default_environment",
+          "is_deferral_enabled",
+          "manifest_status",
+          "name",
+          "owner_id",
+          "target_database",
+          "target_name",
+          "target_role",
+          "target_schema",
+          "variables"
+        ]
+      },
+      "ModelsBranchDbtEnvironmentVariable": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "is_secret": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Always null when is_secret is true."
+          }
+        },
+        "required": [
+          "id",
+          "is_secret",
+          "name",
+          "value"
+        ]
+      },
       "JobCreatedResponse": {
         "type": "object",
         "properties": {
@@ -33104,9 +34889,10 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
-            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33124,6 +34910,30 @@
             "description": "Clone URL of the git repository (SSH or HTTPS)",
             "example": "git@github.com:org/repo.git"
           },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
           "gitFollower": {
             "type": "boolean",
             "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
@@ -33133,6 +34943,14 @@
             "type": "string",
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
           },
           "modelPath": {
             "type": [
@@ -33188,8 +35006,12 @@
           "baseBranch",
           "branchPerPullRequest",
           "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
           "gitFollower",
           "gitServiceProvider",
+          "githubAppInstallationId",
           "modelPath",
           "publicKey",
           "requirePullRequest",
@@ -33205,9 +35027,10 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
-            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33225,6 +35048,30 @@
             "description": "Clone URL of the git repository (SSH or HTTPS)",
             "example": "git@github.com:org/repo.git"
           },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
           "gitFollower": {
             "type": "boolean",
             "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
@@ -33234,6 +35081,14 @@
             "type": "string",
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
           },
           "modelPath": {
             "type": [
@@ -33289,8 +35144,12 @@
           "baseBranch",
           "branchPerPullRequest",
           "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
           "gitFollower",
           "gitServiceProvider",
+          "githubAppInstallationId",
           "modelPath",
           "publicKey",
           "requirePullRequest",
@@ -33306,10 +35165,11 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
             "default": "ssh",
-            "description": "Authentication method. \"ssh\" for deploy key (default), \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key (default), \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation (github.com only).",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33327,8 +35187,28 @@
           "cloneUrl": {
             "type": "string",
             "minLength": 1,
-            "description": "Clone URL of the git repository. SSH (git@...) for deploy key auth, HTTPS (https://...) for token auth.",
+            "description": "Clone URL of the git repository. SSH (git@...) for deploy key auth, HTTPS (https://...) for token or GitHub App auth.",
             "example": "git@github.com:org/repo.git"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
           },
           "deployKeyPassphrase": {
             "type": "string",
@@ -33359,6 +35239,12 @@
             "default": "auto",
             "description": "The git provider type. Use \"auto\" for automatic detection. Defaults to \"auto\"",
             "example": "auto"
+          },
+          "githubAppInstallationId": {
+            "type": "string",
+            "pattern": "^[0-9]+$",
+            "description": "Numeric GitHub App installation ID (the value in the URL after installing the Omni GitHub App on the repo). Required when authMethod is \"github_app\".",
+            "example": "12345678"
           },
           "modelPath": {
             "type": "string",
@@ -33403,9 +35289,10 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
-            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT.",
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
             "example": "ssh"
           },
           "baseBranch": {
@@ -33423,6 +35310,30 @@
             "description": "Clone URL of the git repository (SSH or HTTPS)",
             "example": "git@github.com:org/repo.git"
           },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
           "gitFollower": {
             "type": "boolean",
             "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
@@ -33432,6 +35343,14 @@
             "type": "string",
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
           },
           "modelPath": {
             "type": [
@@ -33487,8 +35406,12 @@
           "baseBranch",
           "branchPerPullRequest",
           "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
           "gitFollower",
           "gitServiceProvider",
+          "githubAppInstallationId",
           "modelPath",
           "publicKey",
           "requirePullRequest",
@@ -33504,7 +35427,8 @@
             "type": "string",
             "enum": [
               "ssh",
-              "https_token"
+              "https_token",
+              "github_app"
             ],
             "description": "Authentication method to change to.",
             "example": "ssh"
@@ -33524,6 +35448,26 @@
             "minLength": 1,
             "description": "Clone URL of the git repository (SSH or HTTPS).",
             "example": "git@github.com:org/repo.git"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
           },
           "deployKeyPassphrase": {
             "type": "string",
@@ -33552,6 +35496,12 @@
             ],
             "description": "The git provider type",
             "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": "string",
+            "pattern": "^[0-9]+$",
+            "description": "Numeric GitHub App installation ID (the value in the URL after installing the Omni GitHub App on the repo). Required when authMethod is \"github_app\".",
+            "example": "12345678"
           },
           "modelPath": {
             "type": "string",
@@ -33646,6 +35596,181 @@
             "example": "Update model schema"
           }
         }
+      },
+      "ModelsGitRotateSigningKeyResponse": {
+        "type": "object",
+        "properties": {
+          "authMethod": {
+            "type": "string",
+            "enum": [
+              "ssh",
+              "https_token",
+              "github_app"
+            ],
+            "description": "Authentication method. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+            "example": "ssh"
+          },
+          "baseBranch": {
+            "type": "string",
+            "description": "The target branch for Omni pull requests",
+            "example": "main"
+          },
+          "branchPerPullRequest": {
+            "type": "boolean",
+            "description": "If true, all pull requests will create a branch in Omni, even those created outside of the tool",
+            "example": false
+          },
+          "cloneUrl": {
+            "type": "string",
+            "description": "Clone URL of the git repository (SSH or HTTPS)",
+            "example": "git@github.com:org/repo.git"
+          },
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer email written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Committer display name written into signed commits (github_app auth). Null when signing is not configured.",
+            "example": "Omni Bot"
+          },
+          "commitSigningPublicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSHSIG signing public key to register on the committer’s GitHub user (github_app auth). Null for other auth methods.",
+            "example": "ssh-ed25519 AAAA..."
+          },
+          "gitFollower": {
+            "type": "boolean",
+            "description": "If true, the shared model is read-only and can only be updated by merging pull requests to the base branch",
+            "example": false
+          },
+          "gitServiceProvider": {
+            "type": "string",
+            "description": "The git provider type",
+            "example": "github"
+          },
+          "githubAppInstallationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "GitHub App installation ID. Null unless github_app auth.",
+            "example": "12345678"
+          },
+          "modelPath": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to model files in the repository",
+            "example": "omni/my_model"
+          },
+          "publicKey": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SSH public key for repository access (deploy key). Null for HTTPS token auth.",
+            "example": "ssh-ed25519 AAAA..."
+          },
+          "requirePullRequest": {
+            "type": "string",
+            "enum": [
+              "always",
+              "users-only",
+              "never"
+            ],
+            "description": "When pull requests are required: \"always\" for all changes, \"users-only\" for user-initiated changes only, \"never\" for direct commits.",
+            "example": "users-only"
+          },
+          "sshUrl": {
+            "type": "string",
+            "deprecated": true,
+            "description": "Deprecated — use cloneUrl. Clone URL of the git repository."
+          },
+          "webUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Custom web URL for the git repository, or null if not set",
+            "example": "https://github.com/org/repo"
+          },
+          "webhookSecret": {
+            "type": "string",
+            "description": "Webhook secret for signature verification. Only included if requested via ?include=webhookSecret"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "description": "Webhook URL to configure in your git provider",
+            "example": "https://app.omni.co/api/webhooks/model/..."
+          }
+        },
+        "required": [
+          "authMethod",
+          "baseBranch",
+          "branchPerPullRequest",
+          "cloneUrl",
+          "commitSigningCommitterEmail",
+          "commitSigningCommitterName",
+          "commitSigningPublicKey",
+          "gitFollower",
+          "gitServiceProvider",
+          "githubAppInstallationId",
+          "modelPath",
+          "publicKey",
+          "requirePullRequest",
+          "sshUrl",
+          "webUrl",
+          "webhookUrl"
+        ]
+      },
+      "ModelsGitRotateSigningKeyBody": {
+        "type": "object",
+        "properties": {
+          "commitSigningCommitterEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 320,
+            "format": "email",
+            "description": "Verified email of the GitHub user that owns the registered signing key, written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterName.",
+            "example": "omni-bot@example.com"
+          },
+          "commitSigningCommitterName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Display name written into signed commits (github_app auth only). Send a string to set it, null to clear it (disabling signing), or omit it to leave the stored value unchanged. Must be set, cleared, or omitted together with commitSigningCommitterEmail.",
+            "example": "Omni Bot"
+          },
+          "signingKeyPassphrase": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Passphrase for signingPrivateKey when it is encrypted. Omni uses it once to decrypt the key, then stores the key under its own encryption at rest; the passphrase itself is not retained."
+          },
+          "signingPrivateKey": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 65536,
+            "description": "Bring-your-own ED25519 signing private key in PEM format (as produced by `ssh-keygen -t ed25519`), used instead of an Omni-generated keypair. Enables zero-downtime rotation: register the matching public key on the GitHub user first, then set it here. RSA keys are rejected — commit signing is SSHSIG over ED25519. Must be non-blank when provided; omit it to have Omni mint a fresh keypair."
+          }
+        },
+        "additionalProperties": false
       },
       "ModelsContentValidatorGetResponse": {
         "type": "object",
@@ -33757,7 +35882,7 @@
               "TOPIC",
               "VIEW"
             ],
-            "description": "Type of find/replace operation."
+            "description": "Type of find/replace operation. A FIELD replacement also rewrites references to the field through the join aliases of its view (with users joined as sellers, users.age → users.age2 also rewrites sellers.age → sellers.age2); an alias that names a different view in some other topic is only rewritten in content known to be in the topic that aliases it. VIEW replacements do not touch aliases."
           },
           "folder_paths": {
             "type": "array",
@@ -33814,8 +35939,10 @@
           },
           "viewNames": {
             "type": "object",
-            "additionalProperties": {},
-            "description": "View name mappings"
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Mapping of file name to view name"
           }
         },
         "required": [
@@ -33920,29 +36047,146 @@
           "prompt"
         ]
       },
-      "QueryRunResponse": {
+      "QueryRunStreamLine": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/QueryStreamJobsSubmittedLine"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamJobLine"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamFooterLine"
+          }
+        ],
+        "description": "One line of the query/run NDJSON stream: a jobs_submitted header, then one line per job, then a footer."
+      },
+      "QueryStreamJobsSubmittedLine": {
         "type": "object",
         "properties": {
-          "completedQueries": {
-            "type": "array",
-            "items": {},
-            "description": "Queries that completed synchronously with their results."
+          "jobs_submitted": {
+            "type": "object",
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            },
+            "description": "Map of submitted job ID to the client result ID for that job (null when the job has no client result ID). Job IDs are the keys to poll via /api/v1/query/wait."
+          }
+        },
+        "required": [
+          "jobs_submitted"
+        ],
+        "description": "First line of the query/run stream: the jobs accepted for execution."
+      },
+      "QueryStreamJobLine": {
+        "type": "object",
+        "properties": {
+          "cache_metadata": {
+            "description": "Cache metadata for the result (row count, byte size, freshness timestamps, requery plan key)."
           },
-          "jobIds": {
+          "client_result_id": {
+            "type": "string",
+            "description": "Client-supplied result ID echoed back for correlating jobs to queries."
+          },
+          "column_name_mapping": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "error": {
+            "description": "Structured error details, e.g. an OAuth re-authentication requirement."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Human-readable error message. Present on failed jobs.",
+            "example": "No such view \"order_items\""
+          },
+          "error_type": {
+            "type": "string",
+            "description": "Machine-readable error category (e.g. PLAN, SQL). Present on failed jobs.",
+            "example": "PLAN"
+          },
+          "job_id": {
+            "type": "string",
+            "description": "ID of the query job this line reports on."
+          },
+          "kill_reason": {
+            "type": "string",
+            "description": "Why the job was killed, when it was cancelled."
+          },
+          "query": {
+            "description": "The query that was executed."
+          },
+          "requery_fallback_sql": {
+            "type": "string"
+          },
+          "requery_sql": {
+            "type": "string",
+            "description": "SQL to re-query the cached result set, when the result supports requery."
+          },
+          "requery_table_name": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string",
+            "description": "Result rows as a base64-encoded Arrow IPC stream. Present on completed jobs. Decode with any Arrow IPC reader and use summary.fields to interpret the columns."
+          },
+          "status": {
+            "type": "string",
+            "description": "Job status. Known values include COMPLETE, ERROR, FAILED, and MISSING; new values may be added over time.",
+            "example": "COMPLETE"
+          },
+          "stream_stats": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Server-side streaming latency stats, in milliseconds."
+          },
+          "summary": {
+            "description": "Execution summary. summary.fields maps field names to their metadata and is needed to interpret the decoded Arrow table; also carries the generated SQL and cache type."
+          },
+          "used_keys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "description": "Per-job line emitted as each job reaches a terminal state. A completed job carries the result set as base64-encoded Arrow IPC in `result`; a failed job carries `error_type` and `error_message` instead."
+      },
+      "QueryStreamFooterLine": {
+        "type": "object",
+        "properties": {
+          "remaining_job_ids": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Job IDs for queries running asynchronously. Use /api/v1/query/wait to poll for results.",
-            "example": [
-              "job_abc123",
-              "job_def456"
-            ]
+            "description": "Job IDs that had not completed when the wait window elapsed. Poll /api/v1/query/wait with these IDs until the list is empty.",
+            "example": []
           },
-          "plan": {
-            "description": "Query execution plan (only present if planOnly is true)."
+          "timed_out": {
+            "type": "string",
+            "enum": [
+              "false",
+              "true"
+            ],
+            "description": "Whether the wait window elapsed before every job completed. Note: a string (\"true\"/\"false\"), not a boolean.",
+            "example": "false"
           }
-        }
+        },
+        "required": [
+          "remaining_job_ids",
+          "timed_out"
+        ],
+        "description": "Last line of the stream."
       },
       "QueryTimeoutResponse": {
         "type": "object",
@@ -34025,21 +36269,23 @@
             "format": "uuid",
             "description": "Alternate location for the `?userId=` query parameter. Prefer the query parameter — this body field exists for backwards compatibility. Supplying both forms results in a 400. Only valid for org-scoped API keys; when set, the user's attributes are applied for row-level security and connection-environment switching.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workbookUrl": {
+            "type": "boolean",
+            "description": "If true, creates an ephemeral workbook for the query and returns its URL in the `X-Omni-Workbook-Url` response header, for all resultType modes. Requires the workbooks permission on the query's model for the (target) user; the header is silently omitted otherwise. Cannot be combined with planOnly."
           }
         }
       },
-      "QueryWaitResponse": {
-        "type": "object",
-        "properties": {
-          "results": {
-            "type": "array",
-            "items": {},
-            "description": "Array of completed query results. Each result contains the query data or an error."
+      "QueryWaitStreamLine": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/QueryStreamJobLine"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamFooterLine"
           }
-        },
-        "required": [
-          "results"
-        ]
+        ],
+        "description": "One line of the query/wait NDJSON stream: one line per completed job, then a footer. Unlike query/run, there is no jobs_submitted header line."
       },
       "SchedulesListItem": {
         "type": "object",
@@ -35811,6 +38057,68 @@
           "success"
         ]
       },
+      "UploadPutResponse": {
+        "type": "object",
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "description": "File name of the replacement upload",
+            "example": "users_updated.csv"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The upload id — unchanged by the data swap"
+          },
+          "inDbAsTableName": {
+            "type": "string",
+            "description": "Database table name in the scratch schema (empty for S3-only connections)"
+          },
+          "refreshedModelIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Models whose view of this upload was re-pointed at the new data (the upload's workbook model, or the connection's shared models holding a view backed by this upload)"
+          },
+          "rowCount": {
+            "type": "integer",
+            "description": "Number of rows in the replacement file"
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "Whether the file was truncated due to row limit"
+          },
+          "viewName": {
+            "type": "string",
+            "description": "View name — unchanged by the data swap"
+          }
+        },
+        "required": [
+          "fileName",
+          "id",
+          "inDbAsTableName",
+          "refreshedModelIds",
+          "rowCount",
+          "truncated",
+          "viewName"
+        ]
+      },
+      "UploadPutBody": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "The replacement CSV file. Fully replaces the existing data. Column renames/removals may break content referencing the old columns.",
+            "format": "binary"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "additionalProperties": false
+      },
       "UsersGetModelRolesResponse": {
         "type": "object",
         "properties": {
@@ -36412,6 +38720,7 @@
                 "USE_AI",
                 "USE_IDE",
                 "USE_WORKBOOKS",
+                "CREATE_APPS",
                 "UPDATE",
                 "UPDATE_RESTRICTED"
               ]
@@ -36459,7 +38768,7 @@
   "paths": {
     "/api/v1/ai/generate-query": {
       "post": {
-        "description": "Generate an Omni semantic query from a natural language prompt. Optionally executes the generated query and returns results. The AI analyzes the prompt, selects appropriate fields and filters from the model, and constructs a query. Requires the querier role on the target model.",
+        "description": "Generate an Omni semantic query from a natural language prompt. Optionally executes the generated query and returns results. The AI analyzes the prompt, selects appropriate fields and filters from the model, and constructs a query. Requires the querier role on the target model. The effective user's per-connector AI toggles (set in the chat + menu) govern which integration tools the agent may use.",
         "operationId": "aiGenerateQuery",
         "summary": "Generate query from natural language",
         "tags": [
@@ -36684,7 +38993,7 @@
     },
     "/api/v1/ai/jobs": {
       "post": {
-        "description": "Submit a new AI job for asynchronous execution. The AI will analyze the prompt, generate and execute queries against the specified model, and produce a summarized answer. Jobs are processed by a background worker and typically complete within 15–60 seconds. Use GET /api/v1/ai/jobs/{jobId} to poll for status, or configure a webhookUrl to receive a notification when the job completes. Optionally continue an existing conversation by providing a conversationId.",
+        "description": "Submit a new AI job for asynchronous execution. The AI will analyze the prompt, generate and execute queries against the specified model, and produce a summarized answer. Jobs are processed by a background worker and typically complete within 15–60 seconds. Use GET /api/v1/ai/jobs/{jobId} to poll for status, or configure a webhookUrl to receive a notification when the job completes. Optionally continue an existing conversation by providing a conversationId. The effective user's per-connector AI toggles (set in the chat + menu) govern which integration tools the agent may use.",
         "operationId": "aiJobSubmit",
         "summary": "Submit an AI job",
         "tags": [
@@ -37289,7 +39598,7 @@
     },
     "/api/v1/ai/credit-controls": {
       "get": {
-        "description": "Get the organization's AI credit controls: the downgrade and shutoff thresholds, the default per-user credit limit, plus read-only context (the credit limit, usage so far this billing period, and the period bounds). This is the API mirror of the AI Hub credit controls page and requires the same AI-admin permission.",
+        "description": "Get the organization's AI credit controls: the downgrade and shutoff thresholds, the default per-user and per-entity-group credit limits, plus read-only context (the credit limit, usage so far this billing period, and the period bounds). This is the API mirror of the AI Hub credit controls page and requires the same AI-admin permission.",
         "operationId": "aiCreditControlsGet",
         "summary": "Get AI credit controls",
         "tags": [
@@ -37329,7 +39638,7 @@
         }
       },
       "patch": {
-        "description": "Update the organization's AI credit controls: the downgrade and shutoff thresholds and the default per-user credit limit (userDefaultCredits). All fields are optional and tri-state: omit a field to leave it unchanged, send `null` to turn that control off (for userDefaultCredits: unlimited by default), or send a non-negative number to set it. At least one field is required. The `downgradeCredits <= shutoffCredits` invariant is enforced against the merged result. Returns the full current state, the same shape as GET.",
+        "description": "Update the organization's AI credit controls: the downgrade and shutoff thresholds, the default per-user credit limit (userDefaultCredits), and the default per-entity-group credit limit (entityGroupDefaultCredits). All fields are optional and tri-state: omit a field to leave it unchanged, send `null` to turn that control off (for the defaults: unlimited by default), or send a non-negative number to set it. At least one field is required. The `downgradeCredits <= shutoffCredits` invariant is enforced against the merged result. Returns the full current state, the same shape as GET.",
         "operationId": "aiCreditControlsUpdate",
         "summary": "Update AI credit controls",
         "tags": [
@@ -37538,6 +39847,299 @@
         }
       }
     },
+    "/api/v1/ai/credit-controls/entity-groups": {
+      "patch": {
+        "description": "Set individual embed entity groups' AI credit limits in bulk. Each entry names an entity group by its embed `entity` string and either sets an individual limit (`creditLimit`: a non-negative number, or `null` for unlimited) or removes one (`useDefaultLimit: true`) so the entity group follows the org default. Each entity may appear at most once and must have an entity group in the organization. All updates are applied in one transaction, so either every entry takes effect or none do — an unknown entity fails the whole request with a 404 naming it. Requires the same add/remove-users permission as the group settings page and the embed-entity credit-limit feature flag.",
+        "operationId": "aiCreditControlsEntityGroupsUpdate",
+        "summary": "Set individual entity groups' AI credit limits",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiEntityGroupCreditLimitsUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "All entries applied. Returns each entity group's effective limit, in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiEntityGroupCreditLimitsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: an empty entityGroups array, more than 1000 entries, an entry with both creditLimit and useDefaultLimit (or neither), a negative creditLimit, or a duplicated entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, per-entity-group AI credit limits are not enabled, or credit controls editing is disabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "An entity has no entity group in the organization; the response names the first invalid entity. No limits are changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "List the organization's active individual embed entity-group AI credit limits, keyed by the embed `entity` string. Only entity groups with an individual limit appear — everyone else follows the org default. A `null` creditLimit is an explicit unlimited override, distinct from following the default. Paginated via opaque cursors: pass `pageInfo.nextCursor` from one response as the `cursor` query parameter on the next request. Requires the same add/remove-users permission as the PATCH.",
+        "operationId": "aiCreditControlsEntityGroupsList",
+        "summary": "List individual entity groups' AI credit limits",
+        "tags": [
+          "AI"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Cursor for pagination (from previous response nextCursor)",
+              "example": "eyJpZCI6IjEyMzQ1In0"
+            },
+            "required": false,
+            "description": "Cursor for pagination (from previous response nextCursor)",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Number of results per page (1-100, integer)",
+              "example": 20
+            },
+            "required": false,
+            "description": "Number of results per page (1-100, integer)",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One page of entity groups' individual AI credit limits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditControlsEntityGroupsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid cursor or pageSize.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or per-entity-group AI credit limits are not enabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/credit-usage/users": {
+      "post": {
+        "description": "Read individual users' AI credit usage for the current billing period. Names the users by userId (the user's membership id in this organization); each id must be a member of the organization. Returns each user's credits used, in request order, plus the billing-period bounds. A user with no usage yet reports 0. At most 1000 ids per request; each userId may appear at most once. An unknown userId fails the whole request with a 404 naming it. This is a read, so it works even when credit-controls editing is disabled; it requires the same manage-user-attributes permission and per-user credit-limit feature flag as the per-user limit endpoints.",
+        "operationId": "aiCreditUsageUsersRead",
+        "summary": "Read individual users' AI credit usage",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiCreditUsageUsersBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Each requested user's credit usage for the current billing period, in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditUsageUsersResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: an empty userIds array, more than 1000 ids, or a duplicated userId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or per-user AI credit limits are not enabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A userId is not a member of the organization; the response names the first invalid id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/credit-usage/entity-groups": {
+      "post": {
+        "description": "Read individual embed entity groups' AI credit usage for the current billing period. Names the entity groups by their embed `entity` string; each must have an entity group in the organization. Returns each entity group's credits used (summed across every member sharing that entity string), in request order, plus the billing-period bounds. An entity with no usage yet reports 0. At most 1000 entities per request; each entity may appear at most once. An unknown entity fails the whole request with a 404 naming it. This is a read, so it works even when credit-controls editing is disabled; it requires the same add/remove-users permission and embed-entity credit-limit feature flag as the per-entity-group limit endpoints.",
+        "operationId": "aiCreditUsageEntityGroupsRead",
+        "summary": "Read individual entity groups' AI credit usage",
+        "tags": [
+          "AI"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AiCreditUsageEntityGroupsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Each requested entity group's credit usage for the current billing period, in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiCreditUsageEntityGroupsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. Common causes: an empty entities array, more than 1000 entities, or a duplicated entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError400"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError401"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions, or per-entity-group AI credit limits are not enabled for the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError403"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "An entity has no entity group in the organization; the response names the first invalid entity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError404"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/ai/routines": {
       "get": {
         "description": "List routines for the calling user, newest first. Includes routines paused by the owner or disabled by Omni, but excludes deleted routines. Use `pageInfo.nextCursor` from one response as the `cursor` query parameter on the next request. Organization API keys can pass `?userId=<membershipId>` to list routines for a specific organization member.",
@@ -37705,11 +40307,11 @@
             }
           },
           "400": {
-            "description": "Invalid request body, recipient configuration, schedule, or timezone. Also returned when the schedule is more frequent than the organization allows.",
+            "description": "Invalid request body, recipient configuration, schedule, or timezone. Also returned when the schedule is more frequent than the organization allows, and, with code `no_condition_detected`, for `gating: \"alert\"` (no delivery condition can be honored from the prompt alone).",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError400"
+                  "$ref": "#/components/schemas/RoutineCreateApiError400"
                 }
               }
             }
@@ -37725,7 +40327,7 @@
             }
           },
           "403": {
-            "description": "AI routines or AI query generation are not enabled for the organization, or the API key cannot act on behalf of the requested user.",
+            "description": "AI routines or AI query generation are not enabled for the organization, the API key cannot act on behalf of the requested user, the request used `gating: \"alert\"` but conditional routines are not enabled for the organization, or the target user is an embed user (embed users cannot own routines).",
             "content": {
               "application/json": {
                 "schema": {
@@ -37735,7 +40337,7 @@
             }
           },
           "404": {
-            "description": "Model, branch, or topic not found, or not accessible to the requested user.",
+            "description": "Model, branch, or topic not found, or not accessible to the requested user. Also returned when the `userId` membership has not accepted its invitation to the organization yet.",
             "content": {
               "application/json": {
                 "schema": {
@@ -37899,7 +40501,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiError400"
+                  "$ref": "#/components/schemas/RoutineCreateApiError400"
                 }
               }
             }
@@ -38023,7 +40625,7 @@
     },
     "/api/v1/ai/routines/{id}/trigger": {
       "post": {
-        "description": "Run a routine immediately, in addition to its schedule. The run executes once using the routine owner's permissions and delivers the AI response to every configured recipient — it is not a private preview. Returns once the run has started; the result is delivered asynchronously. Organization API keys can pass `?userId=<membershipId>` to act on behalf of a specific organization member.",
+        "description": "Run a routine immediately, in addition to its schedule. The run executes once using the routine owner's permissions and delivers the AI response to every configured recipient — it is not a private preview. A conditional routine evaluates its delivery condition first, so the run may complete without delivering. Because runs execute as the owner, the owner's per-connector AI toggles (set in the chat + menu) govern which integration tools the agent may use. Returns once the run has started; the result is delivered asynchronously. Organization API keys can pass `?userId=<membershipId>` to act on behalf of a specific organization member.",
         "operationId": "routineTrigger",
         "summary": "Run a routine now",
         "tags": [
@@ -38055,7 +40657,7 @@
         ],
         "responses": {
           "202": {
-            "description": "The run has started.",
+            "description": "The run has started. For a conditional routine this is the condition evaluation, which delivers only if the condition holds.",
             "content": {
               "application/json": {
                 "schema": {
@@ -38467,6 +41069,14 @@
                       "items": {
                         "type": "object",
                         "properties": {
+                          "acceptsLicense": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether license terms have been accepted (Oracle)",
+                            "example": false
+                          },
                           "allowBranchConnectionEnvironments": {
                             "type": [
                               "boolean",
@@ -38474,6 +41084,38 @@
                             ],
                             "description": "Whether a branch may select its own connection environment. When user-attribute environment selection is also enabled, a branch selection overrides the user attribute.",
                             "example": false
+                          },
+                          "allowsUserSpecificTimezones": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether users may specify their own timezones",
+                            "example": false
+                          },
+                          "alwaysScopeViewNames": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether generated view names always include catalog/schema scoping",
+                            "example": false
+                          },
+                          "authenticationType": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`.",
+                            "example": "snowflake-password"
+                          },
+                          "awsRoleArn": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "AWS IAM role ARN (Athena)",
+                            "example": null
                           },
                           "baseRole": {
                             "type": [
@@ -38502,7 +41144,7 @@
                               "string",
                               "null"
                             ],
-                            "description": "Database name",
+                            "description": "Database/catalog name (project ID for BigQuery)",
                             "example": "analytics_db"
                           },
                           "defaultSchema": {
@@ -38518,30 +41160,48 @@
                               "string",
                               "null"
                             ],
-                            "description": "Timestamp when connection was deleted (ISO 8601)",
+                            "description": "Timestamp when connection was archived (ISO 8601)",
                             "example": null
                           },
                           "dialect": {
                             "type": "string",
                             "enum": [
-                              "snowflake",
                               "bigquery",
-                              "redshift",
-                              "postgres",
                               "mysql",
-                              "mariadb",
+                              "postgres",
+                              "redshift",
+                              "exasol",
+                              "snowflake",
+                              "motherduck",
+                              "mssql",
                               "databricks",
                               "databricks_lakebase",
+                              "clickhouse",
                               "trino",
                               "athena",
-                              "duckdb",
-                              "motherduck",
-                              "sqlserver",
-                              "clickhouse",
-                              "singlestore"
+                              "starrocks",
+                              "mariadb",
+                              "oracle",
+                              "sap_hana"
                             ],
-                            "description": "Database dialect type",
+                            "description": "Database dialect",
                             "example": "snowflake"
+                          },
+                          "enableDbSemanticLayerIntegration": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether the dialect-native semantic layer integration is enabled (Snowflake, Databricks)",
+                            "example": false
+                          },
+                          "enableDbSemanticLayerTopics": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether dialect-native semantic layer topics are generated (Snowflake, Databricks)",
+                            "example": false
                           },
                           "environmentConnectionSwitchesSchemaModel": {
                             "type": [
@@ -38551,21 +41211,209 @@
                             "description": "Whether environment connections switch schema model",
                             "example": false
                           },
+                          "externalOauthAudience": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "External OAuth audience claim (Snowflake)",
+                            "example": null
+                          },
+                          "externalOauthAuthorizationUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "External OAuth authorization URL (Snowflake)",
+                            "example": null
+                          },
+                          "externalOauthTokenUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "External OAuth token URL (Snowflake)",
+                            "example": null
+                          },
+                          "host": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Hostname or IP of the database server (account identifier for Snowflake)",
+                            "example": "myaccount"
+                          },
+                          "hostOverride": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Custom Snowflake host, overriding the account identifier",
+                            "example": null
+                          },
                           "id": {
                             "type": "string",
                             "format": "uuid",
                             "description": "Unique connection identifier",
                             "example": "550e8400-e29b-41d4-a716-446655440000"
                           },
+                          "includeOtherCatalogs": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Additional catalogs/databases included in schema refresh",
+                            "example": null
+                          },
+                          "includeSchemas": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Schemas included in schema refresh. Null means all schemas are included.",
+                            "example": [
+                              "public",
+                              "analytics"
+                            ]
+                          },
+                          "inferRelationshipsFromColumnNames": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether relationships are inferred from column-name conventions during schema refresh",
+                            "example": true
+                          },
+                          "inferRelationshipsFromForeignKeys": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether relationships are inferred from declared foreign keys during schema refresh",
+                            "example": false
+                          },
+                          "maxBillingBytes": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Maximum bytes billed for a query, as a string (BigQuery). Null when unset.",
+                            "example": null
+                          },
                           "name": {
                             "type": "string",
                             "description": "Connection display name",
                             "example": "Production Snowflake"
                           },
+                          "oauthClientId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "OAuth client ID for admin schema refresh (non-secret)",
+                            "example": null
+                          },
+                          "offloadedSchemas": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Schemas queried via the offloaded engine",
+                            "example": null
+                          },
+                          "port": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "description": "Port number for the database connection",
+                            "example": 5432
+                          },
+                          "queryTimeoutSeconds": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ],
+                            "description": "Query timeout in seconds",
+                            "example": 900
+                          },
+                          "queryTimezone": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Timezone used for query results",
+                            "example": null
+                          },
+                          "region": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Region (BigQuery, Athena)",
+                            "example": null
+                          },
+                          "scratchSchema": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Schema used for data input (upload) tables",
+                            "example": null
+                          },
+                          "systemTimezone": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Timezone of the database",
+                            "example": null
+                          },
+                          "trustServerCertificate": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether to trust the server certificate",
+                            "example": false
+                          },
                           "updatedAt": {
                             "type": "string",
                             "description": "Timestamp when connection was last updated (ISO 8601)",
                             "example": "2024-01-15T10:30:00Z"
+                          },
+                          "useMachineAuth": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether machine (M2M OAuth) credentials are used",
+                            "example": null
+                          },
+                          "useReadScaling": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether read scaling is enabled (MotherDuck)",
+                            "example": null
+                          },
+                          "useSessionHint": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether session hints are applied (MotherDuck)",
+                            "example": null
                           },
                           "userAttributeNameForConnectionEnvironments": {
                             "type": [
@@ -38573,7 +41421,7 @@
                               "null"
                             ],
                             "description": "User attribute name used for connection environments",
-                            "example": "region"
+                            "example": null
                           },
                           "userAttributeValuesForDefaultEnvironment": {
                             "type": [
@@ -38584,14 +41432,32 @@
                               "type": "string"
                             },
                             "description": "Default user attribute values for the base environment",
-                            "example": [
-                              "us-east",
-                              "us-west"
-                            ]
+                            "example": null
+                          },
+                          "username": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Username to authenticate with (client email for BigQuery service accounts)",
+                            "example": "analytics_user"
+                          },
+                          "warehouse": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Warehouse (Snowflake) or HTTP path (Databricks)",
+                            "example": "COMPUTE_WH"
                           }
                         },
                         "required": [
+                          "acceptsLicense",
                           "allowBranchConnectionEnvironments",
+                          "allowsUserSpecificTimezones",
+                          "alwaysScopeViewNames",
+                          "authenticationType",
+                          "awsRoleArn",
                           "baseRole",
                           "branchConnectionEnvironmentOverridesUserAttr",
                           "createdAt",
@@ -38599,12 +41465,38 @@
                           "defaultSchema",
                           "deletedAt",
                           "dialect",
+                          "enableDbSemanticLayerIntegration",
+                          "enableDbSemanticLayerTopics",
                           "environmentConnectionSwitchesSchemaModel",
+                          "externalOauthAudience",
+                          "externalOauthAuthorizationUrl",
+                          "externalOauthTokenUrl",
+                          "host",
+                          "hostOverride",
                           "id",
+                          "includeOtherCatalogs",
+                          "includeSchemas",
+                          "inferRelationshipsFromColumnNames",
+                          "inferRelationshipsFromForeignKeys",
+                          "maxBillingBytes",
                           "name",
+                          "oauthClientId",
+                          "offloadedSchemas",
+                          "port",
+                          "queryTimeoutSeconds",
+                          "queryTimezone",
+                          "region",
+                          "scratchSchema",
+                          "systemTimezone",
+                          "trustServerCertificate",
                           "updatedAt",
+                          "useMachineAuth",
+                          "useReadScaling",
+                          "useSessionHint",
                           "userAttributeNameForConnectionEnvironments",
-                          "userAttributeValuesForDefaultEnvironment"
+                          "userAttributeValuesForDefaultEnvironment",
+                          "username",
+                          "warehouse"
                         ],
                         "description": "Connection object",
                         "title": "Connection"
@@ -38660,7 +41552,7 @@
                   },
                   "authenticationType": {
                     "type": "string",
-                    "description": "Authentication type. Applicable for BigQuery, MSSQL, Snowflake, Databricks, and Athena.",
+                    "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`. Applicable for BigQuery, MSSQL, Snowflake, Databricks, and Athena.",
                     "example": "snowflake-password"
                   },
                   "awsRoleArn": {
@@ -38688,29 +41580,29 @@
                   },
                   "defaultSchema": {
                     "type": "string",
-                    "description": "The default schema to use. Required for MSSQL.",
+                    "description": "The default schema to use. Tables in it are queried without a schema prefix.",
                     "example": "public"
                   },
                   "dialect": {
                     "type": "string",
                     "enum": [
-                      "athena",
                       "bigquery",
-                      "clickhouse",
-                      "databricks",
-                      "databricks_lakebase",
-                      "exasol",
-                      "mariadb",
-                      "motherduck",
-                      "mssql",
                       "mysql",
-                      "oracle",
                       "postgres",
                       "redshift",
-                      "sap_hana",
+                      "exasol",
                       "snowflake",
+                      "motherduck",
+                      "mssql",
+                      "databricks",
+                      "databricks_lakebase",
+                      "clickhouse",
+                      "trino",
+                      "athena",
                       "starrocks",
-                      "trino"
+                      "mariadb",
+                      "oracle",
+                      "sap_hana"
                     ],
                     "description": "The database dialect",
                     "example": "snowflake"
@@ -38936,7 +41828,7 @@
     },
     "/api/v1/connections/{id}": {
       "get": {
-        "description": "Fetch a single connection by ID.",
+        "description": "Fetch a single connection by ID, including its full non-secret configuration. Credentials (password, OAuth client secret, keypairs) are never returned.",
         "operationId": "connectionsGet",
         "summary": "Get connection",
         "tags": [
@@ -38967,6 +41859,14 @@
                     "connection": {
                       "type": "object",
                       "properties": {
+                        "acceptsLicense": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether license terms have been accepted (Oracle)",
+                          "example": false
+                        },
                         "allowBranchConnectionEnvironments": {
                           "type": [
                             "boolean",
@@ -38974,6 +41874,38 @@
                           ],
                           "description": "Whether a branch may select its own connection environment. When user-attribute environment selection is also enabled, a branch selection overrides the user attribute.",
                           "example": false
+                        },
+                        "allowsUserSpecificTimezones": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether users may specify their own timezones",
+                          "example": false
+                        },
+                        "alwaysScopeViewNames": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether generated view names always include catalog/schema scoping",
+                          "example": false
+                        },
+                        "authenticationType": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`.",
+                          "example": "snowflake-password"
+                        },
+                        "awsRoleArn": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "AWS IAM role ARN (Athena)",
+                          "example": null
                         },
                         "baseRole": {
                           "type": [
@@ -39002,7 +41934,7 @@
                             "string",
                             "null"
                           ],
-                          "description": "Database name",
+                          "description": "Database/catalog name (project ID for BigQuery)",
                           "example": "analytics_db"
                         },
                         "defaultSchema": {
@@ -39018,30 +41950,48 @@
                             "string",
                             "null"
                           ],
-                          "description": "Timestamp when connection was deleted (ISO 8601)",
+                          "description": "Timestamp when connection was archived (ISO 8601)",
                           "example": null
                         },
                         "dialect": {
                           "type": "string",
                           "enum": [
-                            "snowflake",
                             "bigquery",
-                            "redshift",
-                            "postgres",
                             "mysql",
-                            "mariadb",
+                            "postgres",
+                            "redshift",
+                            "exasol",
+                            "snowflake",
+                            "motherduck",
+                            "mssql",
                             "databricks",
                             "databricks_lakebase",
+                            "clickhouse",
                             "trino",
                             "athena",
-                            "duckdb",
-                            "motherduck",
-                            "sqlserver",
-                            "clickhouse",
-                            "singlestore"
+                            "starrocks",
+                            "mariadb",
+                            "oracle",
+                            "sap_hana"
                           ],
-                          "description": "Database dialect type",
+                          "description": "Database dialect",
                           "example": "snowflake"
+                        },
+                        "enableDbSemanticLayerIntegration": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether the dialect-native semantic layer integration is enabled (Snowflake, Databricks)",
+                          "example": false
+                        },
+                        "enableDbSemanticLayerTopics": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether dialect-native semantic layer topics are generated (Snowflake, Databricks)",
+                          "example": false
                         },
                         "environmentConnectionSwitchesSchemaModel": {
                           "type": [
@@ -39051,21 +42001,209 @@
                           "description": "Whether environment connections switch schema model",
                           "example": false
                         },
+                        "externalOauthAudience": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "External OAuth audience claim (Snowflake)",
+                          "example": null
+                        },
+                        "externalOauthAuthorizationUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "External OAuth authorization URL (Snowflake)",
+                          "example": null
+                        },
+                        "externalOauthTokenUrl": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "External OAuth token URL (Snowflake)",
+                          "example": null
+                        },
+                        "host": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Hostname or IP of the database server (account identifier for Snowflake)",
+                          "example": "myaccount"
+                        },
+                        "hostOverride": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Custom Snowflake host, overriding the account identifier",
+                          "example": null
+                        },
                         "id": {
                           "type": "string",
                           "format": "uuid",
                           "description": "Unique connection identifier",
                           "example": "550e8400-e29b-41d4-a716-446655440000"
                         },
+                        "includeOtherCatalogs": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Additional catalogs/databases included in schema refresh",
+                          "example": null
+                        },
+                        "includeSchemas": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Schemas included in schema refresh. Null means all schemas are included.",
+                          "example": [
+                            "public",
+                            "analytics"
+                          ]
+                        },
+                        "inferRelationshipsFromColumnNames": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether relationships are inferred from column-name conventions during schema refresh",
+                          "example": true
+                        },
+                        "inferRelationshipsFromForeignKeys": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether relationships are inferred from declared foreign keys during schema refresh",
+                          "example": false
+                        },
+                        "maxBillingBytes": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Maximum bytes billed for a query, as a string (BigQuery). Null when unset.",
+                          "example": null
+                        },
                         "name": {
                           "type": "string",
                           "description": "Connection display name",
                           "example": "Production Snowflake"
                         },
+                        "oauthClientId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "OAuth client ID for admin schema refresh (non-secret)",
+                          "example": null
+                        },
+                        "offloadedSchemas": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Schemas queried via the offloaded engine",
+                          "example": null
+                        },
+                        "port": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Port number for the database connection",
+                          "example": 5432
+                        },
+                        "queryTimeoutSeconds": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Query timeout in seconds",
+                          "example": 900
+                        },
+                        "queryTimezone": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Timezone used for query results",
+                          "example": null
+                        },
+                        "region": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Region (BigQuery, Athena)",
+                          "example": null
+                        },
+                        "scratchSchema": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Schema used for data input (upload) tables",
+                          "example": null
+                        },
+                        "systemTimezone": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Timezone of the database",
+                          "example": null
+                        },
+                        "trustServerCertificate": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether to trust the server certificate",
+                          "example": false
+                        },
                         "updatedAt": {
                           "type": "string",
                           "description": "Timestamp when connection was last updated (ISO 8601)",
                           "example": "2024-01-15T10:30:00Z"
+                        },
+                        "useMachineAuth": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether machine (M2M OAuth) credentials are used",
+                          "example": null
+                        },
+                        "useReadScaling": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether read scaling is enabled (MotherDuck)",
+                          "example": null
+                        },
+                        "useSessionHint": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ],
+                          "description": "Whether session hints are applied (MotherDuck)",
+                          "example": null
                         },
                         "userAttributeNameForConnectionEnvironments": {
                           "type": [
@@ -39073,7 +42211,7 @@
                             "null"
                           ],
                           "description": "User attribute name used for connection environments",
-                          "example": "region"
+                          "example": null
                         },
                         "userAttributeValuesForDefaultEnvironment": {
                           "type": [
@@ -39084,14 +42222,32 @@
                             "type": "string"
                           },
                           "description": "Default user attribute values for the base environment",
-                          "example": [
-                            "us-east",
-                            "us-west"
-                          ]
+                          "example": null
+                        },
+                        "username": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Username to authenticate with (client email for BigQuery service accounts)",
+                          "example": "analytics_user"
+                        },
+                        "warehouse": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Warehouse (Snowflake) or HTTP path (Databricks)",
+                          "example": "COMPUTE_WH"
                         }
                       },
                       "required": [
+                        "acceptsLicense",
                         "allowBranchConnectionEnvironments",
+                        "allowsUserSpecificTimezones",
+                        "alwaysScopeViewNames",
+                        "authenticationType",
+                        "awsRoleArn",
                         "baseRole",
                         "branchConnectionEnvironmentOverridesUserAttr",
                         "createdAt",
@@ -39099,12 +42255,38 @@
                         "defaultSchema",
                         "deletedAt",
                         "dialect",
+                        "enableDbSemanticLayerIntegration",
+                        "enableDbSemanticLayerTopics",
                         "environmentConnectionSwitchesSchemaModel",
+                        "externalOauthAudience",
+                        "externalOauthAuthorizationUrl",
+                        "externalOauthTokenUrl",
+                        "host",
+                        "hostOverride",
                         "id",
+                        "includeOtherCatalogs",
+                        "includeSchemas",
+                        "inferRelationshipsFromColumnNames",
+                        "inferRelationshipsFromForeignKeys",
+                        "maxBillingBytes",
                         "name",
+                        "oauthClientId",
+                        "offloadedSchemas",
+                        "port",
+                        "queryTimeoutSeconds",
+                        "queryTimezone",
+                        "region",
+                        "scratchSchema",
+                        "systemTimezone",
+                        "trustServerCertificate",
                         "updatedAt",
+                        "useMachineAuth",
+                        "useReadScaling",
+                        "useSessionHint",
                         "userAttributeNameForConnectionEnvironments",
-                        "userAttributeValuesForDefaultEnvironment"
+                        "userAttributeValuesForDefaultEnvironment",
+                        "username",
+                        "warehouse"
                       ],
                       "description": "Connection object",
                       "title": "Connection"
@@ -39131,7 +42313,7 @@
         }
       },
       "patch": {
-        "description": "Update connection settings including base role, environment user attributes, and credentials.\n\nCredential fields:\n- `passwordUnencrypted`: Update password (all dialects) or service account JSON (BigQuery)\n- `privateKey`: Add/rotate RSA keypair for Snowflake keypair authentication\n\nNote: Credentials are encrypted at rest and never returned in API responses.",
+        "description": "Update connection settings, including the non-secret configuration fields returned by GET, plus base role, environment user attributes, and credentials. Round-trips with GET so a connection can be managed as code. `dialect` cannot be changed.\n\nCredential fields (write-only, never returned):\n- `passwordUnencrypted`: Update password (all dialects) or service account JSON (BigQuery)\n- `privateKey`: Add/rotate RSA keypair for Snowflake keypair authentication\n- `oauthClientSecretUnencrypted`: Update OAuth client secret (Snowflake, Databricks)\n\nChanging `host` or `port` is subject to the same SSH tunnel and PrivateLink restrictions as connection create: you may only point a connection at an SSH tunnel already provisioned for your organization, and a PrivateLink host must belong to your organization. Requests that violate this return 400.\n\nNote: Credentials are encrypted at rest and never returned in API responses.",
         "operationId": "connectionsUpdate",
         "summary": "Update connection",
         "tags": [
@@ -39157,10 +42339,56 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "acceptsLicense": {
+                    "type": "boolean",
+                    "description": "Acceptance of the license terms (Oracle)",
+                    "example": true
+                  },
+                  "allowsUserSpecificTimezones": {
+                    "type": "boolean",
+                    "description": "Whether users may specify their own timezones",
+                    "example": false
+                  },
+                  "alwaysScopeViewNames": {
+                    "type": "boolean",
+                    "description": "Whether generated view names always include catalog/schema scoping",
+                    "example": true
+                  },
+                  "authenticationType": {
+                    "type": "string",
+                    "description": "Authentication type. Dialect-specific; known values are `aws-access-key`, `aws-cross-account-role`, `databricks-oauth-m2m`, `databricks-personal-access-token`, `databricks-oauth-user`, `mssql-sql-authentication`, `mssql-active-directory-password`, `mssql-active-directory-service-principal`, `snowflake-oauth-user`, `snowflake-external-oauth-user`, `snowflake-password`, `snowflake-keypair`, `bigquery-oauth-user`, `bigquery-byo-oauth-user`, `bigquery-service-account`, `bigquery-workload-identity-federation`.",
+                    "example": "snowflake-password"
+                  },
+                  "awsRoleArn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN (Athena)",
+                    "example": "arn:aws:iam::123456789012:role/OmniAthenaRole"
+                  },
                   "baseRole": {
                     "type": "string",
                     "description": "Default role to assign to this connection",
                     "example": "QUERIER"
+                  },
+                  "database": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Database/catalog name (project ID for BigQuery)",
+                    "example": "analytics_db"
+                  },
+                  "defaultSchema": {
+                    "type": "string",
+                    "description": "Default schema for the connection",
+                    "example": "public"
+                  },
+                  "enableDbSemanticLayerIntegration": {
+                    "type": "boolean",
+                    "description": "Enable the dialect-native semantic layer integration (Snowflake, Databricks)",
+                    "example": false
+                  },
+                  "enableDbSemanticLayerTopics": {
+                    "type": "boolean",
+                    "description": "Enable dialect-native semantic layer topics (Snowflake, Databricks)",
+                    "example": false
                   },
                   "environmentUserAttribute": {
                     "type": [
@@ -39194,16 +42422,176 @@
                     ],
                     "description": "User attribute settings for connection environments"
                   },
+                  "externalOauthAudience": {
+                    "type": "string",
+                    "description": "External OAuth audience claim (Snowflake)"
+                  },
+                  "externalOauthAuthorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth authorization URL, HTTPS (Snowflake)",
+                    "example": "https://oauth.example.com/authorize"
+                  },
+                  "externalOauthTokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "External OAuth token URL, HTTPS (Snowflake)",
+                    "example": "https://oauth.example.com/token"
+                  },
+                  "host": {
+                    "type": "string",
+                    "description": "Hostname or IP of the database server (account identifier for Snowflake)",
+                    "example": "myaccount"
+                  },
+                  "hostOverride": {
+                    "type": "string",
+                    "description": "Custom Snowflake host, overriding the account identifier",
+                    "example": "myaccount.snowflakecomputing.com"
+                  },
+                  "includeOtherCatalogs": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Additional catalogs/databases to include. Comma-separated string or array.",
+                    "example": [
+                      "other_project"
+                    ]
+                  },
+                  "includeSchemas": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Schemas to include in schema refresh. Comma-separated string or array; empty means all schemas.",
+                    "example": [
+                      "public",
+                      "analytics"
+                    ]
+                  },
+                  "inferRelationshipsFromColumnNames": {
+                    "type": "boolean",
+                    "description": "Infer relationships from column-name conventions",
+                    "example": true
+                  },
+                  "inferRelationshipsFromForeignKeys": {
+                    "type": "boolean",
+                    "description": "Infer relationships from declared foreign keys",
+                    "example": false
+                  },
+                  "maxBillingBytes": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "description": "Maximum bytes billed for a query (BigQuery)",
+                    "example": "1000000000"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Connection display name",
+                    "example": "Production Snowflake"
+                  },
+                  "oauthClientId": {
+                    "type": "string",
+                    "description": "OAuth client ID for admin schema refresh (Snowflake, Databricks)"
+                  },
+                  "oauthClientSecretUnencrypted": {
+                    "type": "string",
+                    "description": "OAuth client secret for admin schema refresh (Snowflake, Databricks). Write-only; never returned."
+                  },
+                  "offloadedSchemas": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Schemas queried via the offloaded engine. Comma-separated string or array.",
+                    "example": [
+                      "analytics_archive"
+                    ]
+                  },
                   "passwordUnencrypted": {
                     "type": "string",
                     "description": "New password or service account key. For BigQuery, this must be the JSON service account key file content."
                   },
+                  "port": {
+                    "type": "integer",
+                    "description": "Port number for the database connection",
+                    "example": 5432
+                  },
                   "privateKey": {
                     "type": "string",
                     "description": "RSA private key for keypair authentication (Snowflake only). Must be PEM-encoded PKCS#8 format, minimum 2048-bit."
+                  },
+                  "queryTimeoutSeconds": {
+                    "type": "integer",
+                    "maximum": 3600,
+                    "description": "Query timeout in seconds (max 3600)",
+                    "example": 900
+                  },
+                  "queryTimezone": {
+                    "type": "string",
+                    "description": "Timezone used for query results",
+                    "example": "NONE"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Region (BigQuery, Athena)",
+                    "example": "us-east-1"
+                  },
+                  "scratchSchema": {
+                    "type": "string",
+                    "description": "Schema used for data input (upload) tables",
+                    "example": "omni_scratch"
+                  },
+                  "systemTimezone": {
+                    "type": "string",
+                    "description": "Timezone of the database",
+                    "example": "UTC"
+                  },
+                  "trustServerCertificate": {
+                    "type": "boolean",
+                    "description": "Whether to trust the server certificate",
+                    "example": false
+                  },
+                  "useMachineAuth": {
+                    "type": "boolean",
+                    "description": "Authenticate using machine (M2M OAuth) credentials",
+                    "example": false
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "Username to authenticate with (client email for BigQuery service accounts)",
+                    "example": "analytics_user"
+                  },
+                  "warehouse": {
+                    "type": "string",
+                    "description": "Warehouse (Snowflake) or HTTP path (Databricks)",
+                    "example": "COMPUTE_WH"
                   }
                 },
-                "description": "Request body for updating connection attributes and credentials. At least one field must be provided.",
+                "additionalProperties": false,
+                "description": "Request body for updating connection settings and credentials. At least one field must be provided. Secrets are write-only and never returned.",
                 "title": "ConnectionsUpdateBody"
               }
             }
@@ -39348,6 +42736,16 @@
                     {
                       "type": "object",
                       "properties": {
+                        "authMethod": {
+                          "type": "string",
+                          "enum": [
+                            "ssh",
+                            "https_token",
+                            "github_app"
+                          ],
+                          "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+                          "example": "ssh"
+                        },
                         "autogenRelationships": {
                           "type": "boolean",
                           "description": "Whether relationships are auto-generated from dbt",
@@ -39357,6 +42755,29 @@
                           "type": "string",
                           "description": "Git branch name",
                           "example": "main"
+                        },
+                        "commitSigningCommitterEmail": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+                          "example": "omni-bot@example.com"
+                        },
+                        "commitSigningCommitterName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+                          "example": "Omni Bot"
+                        },
+                        "commitSigningPublicKey": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
                         },
                         "dbtVersion": {
                           "type": "string",
@@ -39373,6 +42794,14 @@
                           "description": "Whether virtual schemas are enabled",
                           "example": false
                         },
+                        "githubAppInstallationId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "GitHub App installation ID. Null for non-github_app auth.",
+                          "example": "12345678"
+                        },
                         "projectRootPath": {
                           "type": [
                             "string",
@@ -39383,7 +42812,7 @@
                         },
                         "sshUrl": {
                           "type": "string",
-                          "description": "SSH URL for git repository",
+                          "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
                           "example": "git@github.com:org/repo.git"
                         },
                         "supportsDbt": {
@@ -39396,11 +42825,16 @@
                         }
                       },
                       "required": [
+                        "authMethod",
                         "autogenRelationships",
                         "branch",
+                        "commitSigningCommitterEmail",
+                        "commitSigningCommitterName",
+                        "commitSigningPublicKey",
                         "dbtVersion",
                         "enableSemanticLayer",
                         "enableVirtualSchemas",
+                        "githubAppInstallationId",
                         "projectRootPath",
                         "sshUrl",
                         "supportsDbt"
@@ -39473,6 +42907,16 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "authMethod": {
+                    "type": "string",
+                    "enum": [
+                      "ssh",
+                      "https_token",
+                      "github_app"
+                    ],
+                    "description": "Authentication method for the git repository: \"ssh\" (deploy key), \"https_token\" (deploy token or PAT), or \"github_app\" (GitHub App installation, github.com only). Omit to keep the connected repository's method (SSH for a first-time setup).",
+                    "example": "ssh"
+                  },
                   "autogenRelationships": {
                     "type": "boolean",
                     "description": "Automatically generate relationships from dbt",
@@ -39483,6 +42927,20 @@
                     "minLength": 1,
                     "description": "Git branch name",
                     "example": "main"
+                  },
+                  "commitSigningCommitterEmail": {
+                    "type": "string",
+                    "maxLength": 320,
+                    "format": "email",
+                    "description": "Verified email of the GitHub user that owns the registered signing key (github_app auth only). Omit to leave the stored value unchanged. Must be set together with commitSigningCommitterName.",
+                    "example": "omni-bot@example.com"
+                  },
+                  "commitSigningCommitterName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Display name written into signed commits (github_app auth only). Omit to leave the stored value unchanged. Must be set together with commitSigningCommitterEmail.",
+                    "example": "Omni Bot"
                   },
                   "dbtVersion": {
                     "type": [
@@ -39502,6 +42960,12 @@
                     "type": "boolean",
                     "description": "Enable virtual schemas from dbt",
                     "example": false
+                  },
+                  "githubAppInstallationId": {
+                    "type": "string",
+                    "pattern": "^[0-9]+$",
+                    "description": "Numeric GitHub App installation ID. Required when connecting a repository with authMethod \"github_app\"; may be omitted on updates that keep the connected repository.",
+                    "example": "12345678"
                   },
                   "projectRootPath": {
                     "anyOf": [
@@ -39535,14 +42999,20 @@
                   "rotateKeys": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Rotate SSH deploy keys",
+                    "description": "Rotate SSH deploy keys (ssh auth only)",
                     "example": false
                   },
                   "sshUrl": {
                     "type": "string",
                     "minLength": 1,
-                    "description": "SSH URL for git repository",
+                    "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
                     "example": "git@github.com:org/repo.git"
+                  },
+                  "token": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "pattern": "^[a-zA-Z0-9_\\-.]+$",
+                    "description": "HTTPS access token (deploy token value, PAT, etc.). Required when connecting a repository with authMethod \"https_token\"; omit on updates that keep the stored token."
                   }
                 },
                 "required": [
@@ -39565,23 +43035,227 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "message": {
+                    "authMethod": {
                       "type": "string",
-                      "description": "Success message",
-                      "example": "dbt configuration updated successfully"
+                      "enum": [
+                        "ssh",
+                        "https_token",
+                        "github_app"
+                      ],
+                      "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+                      "example": "ssh"
                     },
-                    "success": {
+                    "autogenRelationships": {
                       "type": "boolean",
-                      "description": "Whether the operation succeeded",
+                      "description": "Whether relationships are auto-generated from dbt",
+                      "example": true
+                    },
+                    "branch": {
+                      "type": "string",
+                      "description": "Git branch name",
+                      "example": "main"
+                    },
+                    "commitSigningCommitterEmail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "omni-bot@example.com"
+                    },
+                    "commitSigningCommitterName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "Omni Bot"
+                    },
+                    "commitSigningPublicKey": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
+                    },
+                    "dbtVersion": {
+                      "type": "string",
+                      "description": "dbt version being used",
+                      "example": "Auto"
+                    },
+                    "enableSemanticLayer": {
+                      "type": "boolean",
+                      "description": "Whether the dbt semantic layer integration is enabled",
+                      "example": false
+                    },
+                    "enableVirtualSchemas": {
+                      "type": "boolean",
+                      "description": "Whether virtual schemas are enabled",
+                      "example": false
+                    },
+                    "githubAppInstallationId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "GitHub App installation ID. Null for non-github_app auth.",
+                      "example": "12345678"
+                    },
+                    "projectRootPath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Path to dbt project root",
+                      "example": "dbt_project"
+                    },
+                    "sshUrl": {
+                      "type": "string",
+                      "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
+                      "example": "git@github.com:org/repo.git"
+                    },
+                    "supportsDbt": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ],
+                      "description": "Indicates dbt is supported and configured",
                       "example": true
                     }
                   },
                   "required": [
-                    "message",
-                    "success"
+                    "authMethod",
+                    "autogenRelationships",
+                    "branch",
+                    "commitSigningCommitterEmail",
+                    "commitSigningCommitterName",
+                    "commitSigningPublicKey",
+                    "dbtVersion",
+                    "enableSemanticLayer",
+                    "enableVirtualSchemas",
+                    "githubAppInstallationId",
+                    "projectRootPath",
+                    "sshUrl",
+                    "supportsDbt"
                   ],
-                  "description": "dbt update response",
-                  "title": "ConnectionsDbtUpdateResponse"
+                  "description": "dbt repository configuration response",
+                  "title": "DbtConfiguredResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "dbt configuration created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "authMethod": {
+                      "type": "string",
+                      "enum": [
+                        "ssh",
+                        "https_token",
+                        "github_app"
+                      ],
+                      "description": "Authentication method for the git repository. \"ssh\" for deploy key, \"https_token\" for deploy token/PAT, \"github_app\" for a GitHub App installation.",
+                      "example": "ssh"
+                    },
+                    "autogenRelationships": {
+                      "type": "boolean",
+                      "description": "Whether relationships are auto-generated from dbt",
+                      "example": true
+                    },
+                    "branch": {
+                      "type": "string",
+                      "description": "Git branch name",
+                      "example": "main"
+                    },
+                    "commitSigningCommitterEmail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Verified email of the GitHub user that owns the registered signing key. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "omni-bot@example.com"
+                    },
+                    "commitSigningCommitterName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Display name written into signed commits. Null unless a commit signer is configured (github_app auth only).",
+                      "example": "Omni Bot"
+                    },
+                    "commitSigningPublicKey": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "SSH public key to register as a signing key on the GitHub user that owns commitSigningCommitterEmail, so commits show as Verified. Null for non-github_app auth."
+                    },
+                    "dbtVersion": {
+                      "type": "string",
+                      "description": "dbt version being used",
+                      "example": "Auto"
+                    },
+                    "enableSemanticLayer": {
+                      "type": "boolean",
+                      "description": "Whether the dbt semantic layer integration is enabled",
+                      "example": false
+                    },
+                    "enableVirtualSchemas": {
+                      "type": "boolean",
+                      "description": "Whether virtual schemas are enabled",
+                      "example": false
+                    },
+                    "githubAppInstallationId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "GitHub App installation ID. Null for non-github_app auth.",
+                      "example": "12345678"
+                    },
+                    "projectRootPath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Path to dbt project root",
+                      "example": "dbt_project"
+                    },
+                    "sshUrl": {
+                      "type": "string",
+                      "description": "Clone URL for the git repository — SSH (git@...) for ssh auth, https:// for https_token or github_app auth",
+                      "example": "git@github.com:org/repo.git"
+                    },
+                    "supportsDbt": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ],
+                      "description": "Indicates dbt is supported and configured",
+                      "example": true
+                    }
+                  },
+                  "required": [
+                    "authMethod",
+                    "autogenRelationships",
+                    "branch",
+                    "commitSigningCommitterEmail",
+                    "commitSigningCommitterName",
+                    "commitSigningPublicKey",
+                    "dbtVersion",
+                    "enableSemanticLayer",
+                    "enableVirtualSchemas",
+                    "githubAppInstallationId",
+                    "projectRootPath",
+                    "sshUrl",
+                    "supportsDbt"
+                  ],
+                  "description": "dbt repository configuration response",
+                  "title": "DbtConfiguredResponse"
                 }
               }
             }
@@ -39657,6 +43331,66 @@
           },
           "404": {
             "description": "Connection not found or dbt not configured"
+          }
+        }
+      }
+    },
+    "/api/v1/connections/{connectionId}/dbt/rotate-signing-key": {
+      "post": {
+        "description": "Rotate the commit signing keypair for a GitHub App dbt connection and return the dbt configuration with the new commitSigningPublicKey to register on the committer’s GitHub user. Omni mints a fresh Ed25519 keypair unless signingPrivateKey supplies your own (with signingKeyPassphrase when encrypted), enabling zero-downtime rotation: register the matching public key on GitHub first, then set it here. The committer identity can be changed in the same call, so signing can be moved to a different GitHub user in one step. Commits already signed with the old key stay Verified only while the old public key remains registered on GitHub. Only valid for github_app auth.",
+        "operationId": "connectionsDbtRotateSigningKey",
+        "summary": "Rotate dbt commit signing key",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Connection ID",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Connection ID",
+            "name": "connectionId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectionsDbtRotateSigningKeyBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signing key rotated; response includes the new public key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionsDbtRotateSigningKeyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid signing key, passphrase, or committer fields"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied - connection admin role required"
+          },
+          "404": {
+            "description": "Connection not found or dbt not configured"
+          },
+          "422": {
+            "description": "Connection is not a GitHub App dbt repository"
           }
         }
       }
@@ -40973,6 +44707,61 @@
         }
       }
     },
+    "/api/v1/content/search": {
+      "get": {
+        "operationId": "contentSearch",
+        "summary": "Search dashboards",
+        "tags": [
+          "Content"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 25,
+              "default": 10,
+              "description": "Max results to return (1-25).",
+              "example": 10
+            },
+            "required": false,
+            "description": "Max results to return (1-25).",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Free-text keywords matched against dashboard names, descriptions, query names, folder names, labels, and creator names.",
+              "example": "revenue by region"
+            },
+            "required": true,
+            "description": "Free-text keywords matched against dashboard names, descriptions, query names, folder names, labels, and creator names.",
+            "name": "q",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching dashboards",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          }
+        }
+      }
+    },
     "/api/v1/dashboards/{identifier}/download": {
       "post": {
         "operationId": "dashboardsDownload",
@@ -41508,7 +45297,7 @@
       },
       "put": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removed on July 31, 2026: this endpoint now returns `410` unless your organization has been granted a migration extension. Contact support if you need one.\n\nUpdates a document with the specified identifier. This endpoint performs a full resource replacement — all required fields must be provided and existing query presentations are replaced entirely. Only dashboard documents are supported; analysis documents and documents without an associated dashboard return 400. For published documents, the update goes through a draft/publish workflow automatically; if a draft already exists, the request returns 409 unless `clearExistingDraft` is set to `true`.",
         "operationId": "documentsPut",
         "summary": "Replace document (full replacement)",
         "tags": [
@@ -41592,12 +45381,46 @@
           },
           "409": {
             "description": "Draft already exists - set clearExistingDraft to true to discard it and proceed"
+          },
+          "410": {
+            "description": "Endpoint has been removed; the organization does not hold a migration extension",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            }
           }
         }
       },
       "patch": {
         "deprecated": true,
-        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Scheduled for removal on July 31, 2026 (see the `Sunset` response header).\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
+        "description": "**Deprecated** — use `PATCH /api/v2/documents/{identifier}/draft` (and the related `/draft` routes). Removed on July 31, 2026: this endpoint now returns `410` unless your organization has been granted a migration extension. Contact support if you need one.\n\nUpdates a document's name, description, and/or identifier. This is a partial update — only provided fields are modified, and at least one of `name`, `description`, or `identifier` must be supplied. When `identifier` is changed, the previous identifier is retained in the document identifier history and continues to redirect. For published documents, the update goes through a draft/publish workflow automatically.",
         "operationId": "documentsUpdate",
         "summary": "Rename document",
         "tags": [
@@ -41681,6 +45504,40 @@
           },
           "409": {
             "description": "Draft already exists - set clearExistingDraft to true to discard it and proceed"
+          },
+          "410": {
+            "description": "Endpoint has been removed; the organization does not hold a migration extension",
+            "headers": {
+              "Deprecation": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "true"
+                  ],
+                  "description": "Marks the endpoint as deprecated."
+                },
+                "required": true,
+                "description": "Marks the endpoint as deprecated."
+              },
+              "Link": {
+                "schema": {
+                  "type": "string",
+                  "description": "Points to the v2 successor resource.",
+                  "example": "</api/v2/documents/{identifier}>; rel=\"successor-version\""
+                },
+                "required": true,
+                "description": "Points to the v2 successor resource."
+              },
+              "Sunset": {
+                "schema": {
+                  "type": "string",
+                  "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594).",
+                  "example": "Fri, 31 Jul 2026 00:00:00 GMT"
+                },
+                "required": true,
+                "description": "Date the endpoint will be removed, in RFC 1123 form (RFC 8594)."
+              }
+            }
           }
         }
       },
@@ -41748,7 +45605,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of queries in the document",
+            "description": "Every query in the document — the dashboard's query presentation collection, which mirrors the workbook's tabs. The dashboard layout decides which of these render, so a query here may not appear on the dashboard.",
             "content": {
               "application/json": {
                 "schema": {
@@ -41764,7 +45621,7 @@
             "description": "Permission denied"
           },
           "404": {
-            "description": "Document not found"
+            "description": "Document not found, or the document has no dashboard (required today; see the endpoint README)"
           }
         }
       }
@@ -41826,6 +45683,7 @@
     },
     "/api/v1/documents/{identifier}/permissions": {
       "get": {
+        "description": "Returns the document-level ability values (the Share dialog \"Abilities\" toggles), plus the resolved permits for a specific user when `userId` is provided.",
         "operationId": "documentsGetPermissions",
         "summary": "Get document permissions",
         "tags": [
@@ -41847,17 +45705,17 @@
             "schema": {
               "type": "string",
               "format": "uuid",
-              "description": "User membership ID to check permissions for"
+              "description": "User membership ID to check permissions for. When omitted, only the document-level abilities are returned."
             },
-            "required": true,
-            "description": "User membership ID to check permissions for",
+            "required": false,
+            "description": "User membership ID to check permissions for. When omitted, only the document-level abilities are returned.",
             "name": "userId",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "User permissions for the document",
+            "description": "Document abilities, plus user permits when userId is provided",
             "content": {
               "application/json": {
                 "schema": {
@@ -41923,7 +45781,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Document not found"
@@ -41976,7 +45834,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Document not found"
@@ -42029,7 +45887,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Document not found"
@@ -42522,7 +46380,7 @@
             }
           },
           "400": {
-            "description": "Invalid request - at least one label must be specified"
+            "description": "Invalid request - at least one label must be specified, or an unrecognized field was sent"
           },
           "401": {
             "description": "Authentication required"
@@ -42652,6 +46510,8 @@
     },
     "/api/v1/documents/{identifier}/transfer-ownership": {
       "put": {
+        "deprecated": true,
+        "description": "Deprecated. Ownership is a content role: grant a user the OWNER role via the permissions endpoint instead. This endpoint grants OWNER to the named user and demotes every other user holding OWNER on the document itself to MANAGER. Ownership inherited from an ancestor folder is untouched.",
         "operationId": "documentsTransferOwnership",
         "summary": "Transfer document ownership",
         "tags": [
@@ -43102,11 +46962,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
               "example": "def456"
             },
             "required": true,
-            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
             "name": "draftIdentifier",
             "in": "path"
           },
@@ -43174,11 +47034,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
               "example": "def456"
             },
             "required": true,
-            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
             "name": "draftIdentifier",
             "in": "path"
           },
@@ -43250,11 +47110,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
               "example": "def456"
             },
             "required": true,
-            "description": "Draft workbook identifier (see `POST /api/v1/documents/{identifier}/draft`).",
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
             "name": "draftIdentifier",
             "in": "path"
           },
@@ -43298,6 +47158,166 @@
           },
           "422": {
             "description": "The document is an app, not a dashboard."
+          }
+        }
+      }
+    },
+    "/api/v2/documents/{identifier}/draft/{draftIdentifier}/queries/{queryKey}/query-model": {
+      "put": {
+        "description": "Bind a query-presentation tile to a query model on a draft.\n\nThe query-model binding (`query.model_extension_id`) is server-owned on the whole-document PATCH surface — a supplied value there is ignored and the tile keeps its stored binding. This draft-scoped route is the way to change it, addressing one tile by its stable record key. The binding shifts on every draft (each draft re-clones its query models), so work against a draft you have already read.\n\nThe `queryModelId` must be a live query model layered on this draft’s workbook model, and not already bound to another tile — a query model is dedicated to a single query. A LINKED tile inherits its query model from its source and can’t be bound directly.",
+        "operationId": "documentsV2BindQueryModel",
+        "summary": "Bind a tile to a query model",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$",
+              "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+              "example": "1"
+            },
+            "required": true,
+            "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+            "name": "queryKey",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentsV2BindQueryModelBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tile bound to the query model; the response carries the `draftIdentifier`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `queryKey` or body, the tile’s query is degraded (not an object) or the tile is LINKED, or the `queryModelId` is not a query model available on this draft."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the document."
+          },
+          "404": {
+            "description": "Document, draft, or tile not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document, or the query model is already bound to another tile."
+          }
+        }
+      },
+      "delete": {
+        "description": "Unbind a query-presentation tile from its query model on a draft, keeping the tile’s query. No request body.\n\nThe query-model binding (`query.model_extension_id`) is server-owned on the whole-document PATCH surface — a supplied value there is ignored and the tile keeps its stored binding. This draft-scoped route is the way to change it, addressing one tile by its stable record key. The binding shifts on every draft (each draft re-clones its query models), so work against a draft you have already read.",
+        "operationId": "documentsV2UnbindQueryModel",
+        "summary": "Unbind a tile from its query model",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+              "example": "def456"
+            },
+            "required": true,
+            "description": "Draft workbook identifier (see `PATCH /api/v2/documents/{identifier}/draft`).",
+            "name": "draftIdentifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Published document identifier.",
+              "example": "abc123"
+            },
+            "required": true,
+            "description": "Published document identifier.",
+            "name": "identifier",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$",
+              "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+              "example": "1"
+            },
+            "required": true,
+            "description": "Record key of the tile, as it appears in `queryPresentations.data`.",
+            "name": "queryKey",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tile unbound from its query model; the response carries the `draftIdentifier`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentsV2PatchDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `queryKey`, or the tile is LINKED."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Insufficient permissions to update the document."
+          },
+          "404": {
+            "description": "Document, draft, or tile not found."
+          },
+          "405": {
+            "description": "Method not allowed."
+          },
+          "409": {
+            "description": "The target is not a published document."
           }
         }
       }
@@ -44041,7 +48061,7 @@
         }
       },
       "post": {
-        "description": "Create and start a new run against an existing prompt set. The run enqueues one agentic job per prompt and begins executing immediately. Returns the newly created run with its initial per-prompt result rows.",
+        "description": "Create and start a new run against an existing prompt set. The run enqueues `run_config.repeat_count` agentic jobs per prompt (default 1) and begins executing immediately. Returns the newly created run with its initial per-execution result rows.",
         "operationId": "aiEvalRunsCreate",
         "summary": "Start an eval run",
         "tags": [
@@ -44109,7 +48129,7 @@
             }
           },
           "422": {
-            "description": "`run_config.branch_id` does not belong to the prompt set's model.",
+            "description": "`run_config.branch_id` does not belong to the prompt set's model, or prompts × `run_config.repeat_count` exceeds the per-run job limit.",
             "content": {
               "application/json": {
                 "schema": {
@@ -44724,7 +48744,7 @@
             }
           },
           "400": {
-            "description": "Invalid request body (empty name, invalid path characters, reserved path, or neither field provided)"
+            "description": "Invalid request body (empty name, invalid path characters, reserved path, an unrecognized field, or neither field provided)"
           },
           "401": {
             "description": "Authentication required"
@@ -44737,6 +48757,74 @@
           },
           "409": {
             "description": "Path conflicts with an existing folder (when resolvePathConflict is false)"
+          }
+        }
+      }
+    },
+    "/api/v1/folders/{folderId}/labels": {
+      "patch": {
+        "description": "Add and remove labels on a folder in a single atomic operation. Labels must already exist in the organization - create them with POST /api/v1/labels.",
+        "operationId": "foldersBulkUpdateLabels",
+        "summary": "Bulk update folder labels",
+        "tags": [
+          "Folders"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique identifier for the folder",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": true,
+            "description": "Unique identifier for the folder",
+            "name": "folderId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Target user membership ID (for org-scoped API keys)"
+            },
+            "required": false,
+            "description": "Target user membership ID (for org-scoped API keys)",
+            "name": "userId",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoldersBulkUpdateLabelsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Labels updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoldersBulkUpdateLabelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - no labels specified, the same label in both add and remove, or an unrecognized field"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied - label management, or verified/homepage label permissions"
+          },
+          "404": {
+            "description": "Folder not found, label not found in the organization, or label not applied to the folder"
           }
         }
       }
@@ -44842,7 +48930,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Folder not found"
@@ -44896,7 +48984,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - MANAGER role required"
+            "description": "Permission denied - MANAGER role required, or AccessBoost is turned off for the organization"
           },
           "404": {
             "description": "Folder not found"
@@ -45280,6 +49368,181 @@
         }
       }
     },
+    "/api/v1/models/{modelId}/suggestions/generate": {
+      "post": {
+        "description": "Triggers an AI suggestion generation run for the shared model and enqueues the async job. Poll `GET /suggestions/runs/{runId}` for status. Requires organization admin permissions. At most one active run per model; a cooldown applies after a completed run.",
+        "operationId": "modelSuggestionsGenerate",
+        "summary": "Generate model suggestions",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Generation run enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateSuggestionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "409": {
+            "description": "A generation run is already active for this model"
+          },
+          "429": {
+            "description": "A run completed recently; retry after the cooldown (see the `Retry-After` header)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionsCooldownResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to enqueue the generation job"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/runs/{runId}": {
+      "get": {
+        "description": "Returns the status of a specific generation run. Poll until `status` is terminal (`complete` or `failed`), then re-fetch the suggestions list. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsRunGet",
+        "summary": "Get a generation run",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the run belongs to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the run belongs to",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the generation run",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            },
+            "required": true,
+            "description": "UUID of the generation run",
+            "name": "runId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generation run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionRun"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed id"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Run not found in this organization/model"
+          }
+        }
+      }
+    },
+    "/api/v1/models/{modelId}/suggestions/runs/latest": {
+      "get": {
+        "description": "Returns the most recent generation run for the shared model (the active run if one is in flight, otherwise the last terminal run), or null if none exists. Requires organization admin permissions.",
+        "operationId": "modelSuggestionsRunLatest",
+        "summary": "Get the latest generation run",
+        "tags": [
+          "AI Model Suggestions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the shared model the suggestions belong to",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "description": "UUID of the shared model the suggestions belong to",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The latest generation run, or null",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionRunLatestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed `modelId`"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Feature not enabled, AI disabled, model is not a shared model, or caller lacks organization admin permissions"
+          },
+          "404": {
+            "description": "Model not found in this organization"
+          }
+        }
+      }
+    },
     "/api/v1/models/{modelId}/suggestions/schedule": {
       "put": {
         "description": "Enables the daily schedule that generates suggestions for the shared model. Idempotent — re-enabling leaves an existing schedule untouched. Requires organization admin permissions.",
@@ -45627,6 +49890,22 @@
             "required": false,
             "description": "Cursor for pagination",
             "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1",
+                "true",
+                "false"
+              ],
+              "description": "When true, returns only models that can be explored directly: shared models, and shared extension models the org allows as a workbook base. Combining with a modelKind other than SHARED or SHARED_EXTENSION is a 400."
+            },
+            "required": false,
+            "description": "When true, returns only models that can be explored directly: shared models, and shared extension models the org allows as a workbook base. Combining with a modelKind other than SHARED or SHARED_EXTENSION is a 400.",
+            "name": "explorable",
             "in": "query"
           },
           {
@@ -46824,7 +51103,7 @@
             "description": "Authentication required"
           },
           "403": {
-            "description": "Permission denied - connection admin role required"
+            "description": "Permission denied - a branch refresh requires permission to update the branch; a direct refresh requires connection admin, or modeler on a connection with exactly one shared model"
           },
           "404": {
             "description": "Model not found"
@@ -47185,6 +51464,66 @@
           },
           "404": {
             "description": "Model or branch not found"
+          }
+        }
+      },
+      "get": {
+        "description": "Read the dbt environment a branch resolves to, including the dbt git branch it compiles against. A branch with no environment of its own resolves to the connection's default (production) environment, reported with is_default_environment: true.",
+        "operationId": "modelsBranchDbtGet",
+        "summary": "Read branch dbt environment",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Branch name",
+              "example": "feature/new-metrics"
+            },
+            "required": true,
+            "description": "Branch name",
+            "name": "branchName",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The dbt environment the branch resolves to",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsBranchDbtGetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "Model, branch, or dbt environment not found, or model deleted"
+          },
+          "422": {
+            "description": "The model is not a shared model"
           }
         }
       }
@@ -47710,6 +52049,66 @@
         }
       }
     },
+    "/api/v1/models/{modelId}/git/rotate-signing-key": {
+      "post": {
+        "description": "Rotate the commit signing keypair for a GitHub App connection and return the git configuration with the new commitSigningPublicKey to register on the committer’s GitHub user. Omni mints a fresh Ed25519 keypair unless signingPrivateKey supplies your own (with signingKeyPassphrase when encrypted), enabling zero-downtime rotation: register the matching public key on GitHub first, then set it here. The committer identity can be changed in the same call, so signing can be moved to a different GitHub user in one step. Commits already signed with the old key stay Verified only while the old public key remains registered on GitHub. Only valid for github_app auth.",
+        "operationId": "modelsGitRotateSigningKey",
+        "summary": "Rotate commit signing key",
+        "tags": [
+          "Models"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Model UUID",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            },
+            "required": true,
+            "description": "Model UUID",
+            "name": "modelId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelsGitRotateSigningKeyBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signing key rotated; response includes the new public key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsGitRotateSigningKeyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid signing key, passphrase, or committer fields"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "Model not found or git not configured"
+          },
+          "422": {
+            "description": "Model is not a GitHub App connection"
+          }
+        }
+      }
+    },
     "/api/v1/models/{modelId}/content-validator": {
       "get": {
         "operationId": "modelsContentValidatorGet",
@@ -47780,10 +52179,10 @@
                 "TOPIC",
                 "VIEW"
               ],
-              "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name)."
+              "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name), and also match the field through the join aliases of its view (with users joined as sellers, users.age also matches sellers.age)."
             },
             "required": false,
-            "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name).",
+            "description": "Optional type of find operation (VIEW, FIELD, TOPIC). Requires find to be provided. FIELD values must be scoped by view name (e.g. view_name.field_name), and also match the field through the join aliases of its view (with users joined as sellers, users.age also matches sellers.age).",
             "name": "find_type",
             "in": "query"
           },
@@ -48141,12 +52540,15 @@
                 },
                 {
                   "type": "string"
+                },
+                {
+                  "type": "string"
                 }
               ],
-              "description": "File name to delete (must end with '.topic' or '.view')"
+              "description": "File name to delete (must end with '.topic', '.composite_topic', or '.view')"
             },
             "required": true,
-            "description": "File name to delete (must end with '.topic' or '.view')",
+            "description": "File name to delete (must end with '.topic', '.composite_topic', or '.view')",
             "name": "fileName",
             "in": "query"
           },
@@ -48245,6 +52647,7 @@
     },
     "/api/v1/query/run": {
       "post": {
+        "description": "Runs a semantic query. By default (no `resultType`) the response is a stream of newline-delimited JSON (`Content-Type: text/ndjson`), one JSON object per line: a `jobs_submitted` header, then one line per job as it reaches a terminal state (a completed job carries the result set as base64-encoded Arrow IPC in `result`; use `summary.fields` to interpret the decoded columns), then a footer. A footer with non-empty `remaining_job_ids` means the wait window elapsed before every job finished — poll GET /api/v1/query/wait with those IDs until the list is empty. When `resultType` is set, the response is instead a single CSV, XLSX, or JSON document, and a timeout is reported as a 408.",
         "operationId": "queryRun",
         "summary": "Execute a semantic query",
         "tags": [
@@ -48274,11 +52677,45 @@
         },
         "responses": {
           "200": {
-            "description": "Query executed or started successfully",
+            "description": "Query executed or started successfully. The default response (no resultType) is a text/ndjson stream — one JSON object per line, each matching QueryRunStreamLine; it cannot be parsed as a single JSON document. When resultType is set, the body is a single CSV, XLSX, or JSON document instead.",
+            "headers": {
+              "X-Omni-Workbook-Url": {
+                "schema": {
+                  "type": "string",
+                  "description": "URL of an ephemeral workbook running this query. Present only when the request sets `workbookUrl: true` and the (target) user has the workbooks permission on the model.",
+                  "example": "https://myorg.omniapp.co/e/1:abc123DEF456/1"
+                },
+                "required": false,
+                "description": "URL of an ephemeral workbook running this query. Present only when the request sets `workbookUrl: true` and the (target) user has the workbooks permission on the model."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/QueryRunResponse"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "description": "Array of result-row objects keyed by field name. Returned only when resultType is \"json\"."
+                }
+              },
+              "application/vnd.ms-excel": {
+                "schema": {
+                  "description": "XLSX document. Returned only when resultType is \"xlsx\".",
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "description": "CSV document. Returned only when resultType is \"csv\".",
+                  "type": "string"
+                }
+              },
+              "text/ndjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryRunStreamLine"
                 }
               }
             }
@@ -48296,7 +52733,7 @@
             "description": "Model, topic, view, or branch not found"
           },
           "408": {
-            "description": "Query timed out. The response includes remaining_job_ids that can be polled via the query/wait endpoint.",
+            "description": "Query timed out. Only returned when resultType is set — the default text/ndjson response reports timeouts in-band via the footer line's remaining_job_ids instead. The response includes remaining_job_ids that can be polled via the query/wait endpoint.",
             "content": {
               "application/json": {
                 "schema": {
@@ -48313,6 +52750,7 @@
     },
     "/api/v1/query/wait": {
       "get": {
+        "description": "Waits for previously submitted query jobs and streams results as they complete. The response is a stream of newline-delimited JSON (`Content-Type: text/ndjson`): one line per job (same shape as the job lines from query/run, including the base64-encoded Arrow IPC `result`), then a footer. Unlike query/run, there is no `jobs_submitted` header line. If the footer's `remaining_job_ids` is non-empty, call this endpoint again with those IDs until it is empty.",
         "operationId": "queryWait",
         "summary": "Wait for query jobs to complete",
         "tags": [
@@ -48333,11 +52771,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Query results for completed jobs",
+            "description": "Query results for completed jobs, as a text/ndjson stream — one JSON object per line, each matching QueryWaitStreamLine; it cannot be parsed as a single JSON document.",
             "content": {
-              "application/json": {
+              "text/ndjson": {
                 "schema": {
-                  "$ref": "#/components/schemas/QueryWaitResponse"
+                  "$ref": "#/components/schemas/QueryWaitStreamLine"
                 }
               }
             }
@@ -48631,6 +53069,11 @@
                     ],
                     "description": "The delivery destination type",
                     "example": "email"
+                  },
+                  "enableConditionalFormatting": {
+                    "type": "boolean",
+                    "description": "Defaults to true. When true, conditional formatting rules are included in xlsx output — provided the organization has the 'excel-conditional-formatting' feature enabled.",
+                    "example": true
                   },
                   "enableFormatting": {
                     "type": "boolean",
@@ -49258,7 +53701,7 @@
             "description": "Schedule not found"
           },
           "409": {
-            "description": "Schedule cannot be triggered (paused, system-disabled, or another execution is in progress)"
+            "description": "Schedule cannot be triggered (paused, system-disabled, delivering to a destination type the organization has disabled, or another execution is in progress)"
           }
         }
       }
@@ -50359,6 +54802,61 @@
           },
           "400": {
             "description": "Invalid upload ID format"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "Upload not found or already deleted"
+          }
+        }
+      },
+      "put": {
+        "description": "Replace the data behind an existing CSV upload while keeping its id stable. The new file lands as fresh storage and (when the connection stages uploads) a fresh warehouse table, and the upload's pointers move to them — views and document tabs reference the upload by id, so they serve the new data with no model or document changes. Column renames/removals may break content referencing the old columns.",
+        "operationId": "uploadsReplaceData",
+        "summary": "Replace an upload's data",
+        "tags": [
+          "Uploads"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the upload to delete"
+            },
+            "required": true,
+            "description": "ID of the upload to delete",
+            "name": "uploadId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadPutBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upload data replaced successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadPutResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (missing file, invalid file type, CSV parsing failed, or a non-CSV upload)"
           },
           "401": {
             "description": "Authentication required"


### PR DESCRIPTION
## Summary

Syncs the embedded OpenAPI spec from `exploreomni/omni@main`. Headline additions:

- **Model suggestions** — `omni ai-model-suggestions model-suggestions-generate / run-get / run-latest` join the existing suggestion commands.
- **Content search** — `omni content search --q --limit` free-text search over dashboards.
- **AI credits** — per-entity-group credit controls (`ai credit-controls-entity-groups-list/update`) and credit usage reads for users and entity groups (`ai credit-usage-users-read`, `ai credit-usage-entity-groups-read`).
- **Documents** — `documents v2-bind-query-model` / `v2-unbind-query-model` to bind a tile to a query model.
- **Folders** — `folders bulk-update-labels` for atomic label add/remove.
- **Key rotation** — `connections dbt-rotate-signing-key`, `models git-rotate-signing-key`.
- **dbt** — `models branch-dbt-get` to read a branch's dbt environment.
- **Uploads** — `uploads replace-data` to swap the data behind a CSV upload while keeping its id.

Side effects: several existing operations (`routinesList`, `routineCreate`, `connectionsDbtDelete`, `documentsUpdate`, `modelsDbtExposures`, `modelsBranchDbt`) moved position in the spec with no behavior change. New request-body fields on POST/PATCH endpoints don't surface as flags — those endpoints take `--body` (see `--schema`).

## Test plan

- [x] `make build`
- [x] `make test` (all packages pass)
- [x] `--help` verified for each new command (`ai-model-suggestions`, `content search`, `ai credit-*`, `folders bulk-update-labels`, `uploads replace-data`, `documents v2-bind/unbind-query-model`, key-rotation commands)
- [x] Live read-only verification against ernesto.playground: `content search`, `ai credit-controls-get`, `ai credit-controls-entity-groups-list`, `ai credit-usage-users-read`, `ai-model-suggestions model-suggestions-run-latest/list`, `models branch-dbt-get` (note: credit-usage takes membership ids, not user ids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
