### PR TITLE
Support OpenAPI multipart form requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ After installing, restart your shell and try: `omni <TAB>`, `omni ai <TAB>`, `om
 
 The CLI embeds the OpenAPI spec (`api/openapi.json`) into the binary. At startup it parses the spec and generates cobra subcommands for every operation. Each API tag becomes a command group, path params become positional args, query params become flags, and request bodies are passed via `--body` or stdin.
 
+A request body can be given three ways: inline JSON (`--body '{"name":"x"}'`), a file
+(`--body @path/to/body.json`), or stdin (`--body - < path/to/body.json`). The body is
+checked as JSON before the request is sent, so a typo fails locally instead of coming
+back as a generic API 400.
+
 Adding a new API endpoint requires no code changes — update `api/openapi.json` (or run `make sync-spec`) and rebuild.
 
 ## Auth

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ omni documents list
 omni --help
 ```
 
+### Upload a CSV
+
+Multipart request fields are generated as normal CLI flags. Binary OpenAPI
+fields accept a local file path:
+
+```bash
+omni uploads create \
+  --file ./people.csv \
+  --model-id 00000000-0000-0000-0000-000000000000 \
+  --view-name people
+```
+
+Multipart commands also accept `--body` JSON for compatibility. Values for
+binary fields are interpreted as file paths:
+
+```bash
+omni uploads create --body '{"file":"./people.csv","modelId":"00000000-0000-0000-0000-000000000000"}'
+```
+
 ## Shell completions
 
 `omni` supports tab completion for bash, zsh, fish, and PowerShell. Pick your shell below and run the snippet once — tab completion works on every new shell thereafter.
@@ -120,7 +139,7 @@ After installing, restart your shell and try: `omni <TAB>`, `omni ai <TAB>`, `om
 
 ## How it works
 
-The CLI embeds the OpenAPI spec (`api/openapi.json`) into the binary. At startup it parses the spec and generates cobra subcommands for every operation. Each API tag becomes a command group, path params become positional args, query params become flags, and request bodies are passed via `--body` or stdin.
+The CLI embeds the OpenAPI spec (`api/openapi.json`) into the binary. At startup it parses the spec and generates cobra subcommands for every operation. Each API tag becomes a command group, path params become positional args, query params become flags, and JSON request bodies are passed via `--body` or stdin. For `multipart/form-data` bodies, top-level schema properties become flags and binary properties are read from file paths.
 
 A request body can be given three ways: inline JSON (`--body '{"name":"x"}'`), a file
 (`--body @path/to/body.json`), or stdin (`--body - < path/to/body.json`). The body is

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -58,6 +58,10 @@ Set OMNI_API_TOKEN env var, or run: omni config init
 ### Search Omni documentation
   omni ai search-omni-docs --body '{"query":"how do I..."}'
 
+### Upload a CSV
+Multipart body fields are generated as flags; binary fields take file paths.
+  omni uploads create --file ./people.csv --model-id MODEL_ID --view-name people
+
 ## Command Groups
   ai            AI-powered query generation, jobs, doc search
   ai-eval       AI eval prompt set management
@@ -94,6 +98,10 @@ name a leaf without knowing the container shape:
   omni documents v2-create --schema --field queryPresentations.data # just the tiles map
   omni documents v2-create --schema --field queryPresentations.data.query
 
+For multipart/form-data commands, top-level schema properties are also exposed
+as flags. Binary properties are labeled "file path" in --help. --body remains
+available; binary values in its JSON object are interpreted as file paths.
+
 ## Common Flags
   --compact       Non-indented JSON output
   --token TOKEN   API token (overrides env/config)
@@ -109,7 +117,7 @@ name a leaf without knowing the container shape:
 - Use "omni ai generate-query" to answer data questions — it picks fields and filters for you.
 - Set a user's attribute values: omni users set-attributes <user-id> --attr region=us-east
 - Path parameters are positional args: omni dashboards download <dashboard-id>
-- Query parameters are flags: omni models list --pagesize 10
+- Query parameters are flags: omni models list --page-size 10
 - Run "omni <group> --help" to see all commands in a group.
 - Run "omni <group> <command> --help" to see flags for a specific command.
 `

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -99,7 +99,8 @@ name a leaf without knowing the container shape:
   --token TOKEN   API token (overrides env/config)
   --base-url URL  API base URL (overrides config)
   --profile NAME  Config profile to use
-  --body JSON     Request body (JSON string or "-" for stdin)
+  --body JSON     Request body: JSON string, @path/to/file.json, or "-" for stdin
+                  (a bare path is rejected client-side — prefix it with @)
   --schema        Print the request body's schema + example, then exit
   --field PATH    With --schema: drill into a dotted field path
   --depth N       With --schema: cap nesting depth (lower = smaller)

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -54,7 +54,6 @@ func main() {
 	root.PersistentFlags().Bool("compact", false, "compact JSON output (no indentation)")
 	root.PersistentFlags().StringP("format", "o", "", "output format: json, human, auto (default auto: human on TTY, json when piped)")
 
-
 	// Hand-written commands (not from spec)
 	addConfigCommands(root)
 	addAgentHelpCommand(root)
@@ -101,7 +100,7 @@ func executeAPICall(req openapi.APIRequest) error {
 	// scripts piping JSON shouldn't get decorative noise on stderr.
 	sp := maybeStartSpinner(format)
 
-	resp, err := auth.Do(cfg, req.Method, req.Path, req.Body)
+	resp, err := auth.DoWithContentType(cfg, req.Method, req.Path, req.Body, req.ContentType)
 	sp.Stop()
 	if err != nil {
 		return err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -12,6 +12,13 @@ import (
 
 // Do executes an authenticated HTTP request against the Omni API.
 func Do(cfg *config.ResolvedConfig, method, path string, body []byte) (*http.Response, error) {
+	return DoWithContentType(cfg, method, path, body, "application/json")
+}
+
+// DoWithContentType executes an authenticated request using the caller's
+// declared request media type. Multipart callers must include the boundary in
+// contentType (for example, multipart/form-data; boundary=...).
+func DoWithContentType(cfg *config.ResolvedConfig, method, path string, body []byte, contentType string) (*http.Response, error) {
 	baseURL := strings.TrimRight(cfg.BaseURL, "/")
 	url := baseURL + path
 
@@ -32,7 +39,10 @@ func Do(cfg *config.ResolvedConfig, method, path string, body []byte) (*http.Res
 	}
 
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	req.Header.Set("Content-Type", "application/json")
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -46,6 +46,26 @@ func TestDo_SetsHeaders(t *testing.T) {
 	}
 }
 
+func TestDoWithContentType_PreservesMultipartBoundary(t *testing.T) {
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &config.ResolvedConfig{Token: "tok", BaseURL: srv.URL}
+	want := "multipart/form-data; boundary=test-boundary"
+	resp, err := DoWithContentType(cfg, "POST", "/uploads", []byte("body"), want)
+	if err != nil {
+		t.Fatalf("DoWithContentType: %v", err)
+	}
+	resp.Body.Close()
+	if gotContentType != want {
+		t.Errorf("Content-Type = %q, want %q", gotContentType, want)
+	}
+}
+
 // Verify that the HTTP method (GET, POST, etc.) and URL path are forwarded
 // correctly to the server.
 func TestDo_MethodAndPath(t *testing.T) {

--- a/internal/openapi/body_input.go
+++ b/internal/openapi/body_input.go
@@ -1,0 +1,173 @@
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveBody turns a raw --body/--json-body flag value into the bytes to send.
+//
+//	"-"        read from stdin
+//	"@path"    read from a file ("@-" is stdin too, curl-style)
+//	anything else is the literal body
+//
+// When validateJSON is set the result is checked with json.Valid before any
+// network call, because the API answers a non-JSON body with a generic
+// "Invalid JSON" 400 that reads like a body-shape problem. flagName is the flag
+// the value came from, so the error text names the flag the caller typed.
+//
+// The bytes are never re-serialized — what the caller supplied is what gets
+// sent.
+func resolveBody(raw, flagName string, validateJSON bool) ([]byte, error) {
+	switch {
+	case raw == "-":
+		data, err := readStdin()
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		return checkBody(data, raw, flagName, "stdin", validateJSON)
+
+	case strings.HasPrefix(raw, "@"):
+		path := strings.TrimPrefix(raw, "@")
+		if path == "-" {
+			data, err := readStdin()
+			if err != nil {
+				return nil, fmt.Errorf("reading stdin: %w", err)
+			}
+			return checkBody(data, raw, flagName, "stdin", validateJSON)
+		}
+		if strings.TrimSpace(path) == "" {
+			return nil, fmt.Errorf("--%s: no file path after \"@\"; use --%s @path/to/body.json", flagName, flagName)
+		}
+		path = expandHome(path)
+		data, err := readBodyFile(path)
+		if err != nil {
+			return nil, err
+		}
+		return checkBody(data, raw, flagName, fmt.Sprintf("file %s", path), validateJSON)
+
+	default:
+		return checkBody([]byte(raw), raw, flagName, "", validateJSON)
+	}
+}
+
+// readBodyFile reads a body file, enforcing the same size cap as stdin.
+func readBodyFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("body file not found: %s", path)
+		}
+		return nil, fmt.Errorf("reading body file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxStdinSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading body file %s: %w", path, err)
+	}
+	if len(data) > maxStdinSize {
+		return nil, fmt.Errorf("body file %s exceeds maximum size of 10 MB", path)
+	}
+	return data, nil
+}
+
+// checkBody validates data and returns it unchanged. source describes where
+// the bytes came from ("stdin", "file X") or is empty when they came straight
+// from the flag value — only in that case can the raw value itself be a
+// mistyped file path. Operations whose request body isn't JSON (e.g. the
+// multipart upload endpoints) pass validateJSON=false and get the bytes back
+// untouched.
+func checkBody(data []byte, raw, flagName, source string, validateJSON bool) ([]byte, error) {
+	if !validateJSON {
+		return data, nil
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		if source != "" {
+			return nil, fmt.Errorf("no request body read from %s", source)
+		}
+		return nil, fmt.Errorf("--%s is empty; omit the flag to send no body", flagName)
+	}
+
+	if json.Valid(data) {
+		return data, nil
+	}
+
+	if source == "" && looksLikePath(raw) {
+		return nil, fmt.Errorf("--%s looks like a file path, not JSON: %s\nread the file instead: --%s @%s   (or --%s - < %s)",
+			flagName, raw, flagName, raw, flagName, raw)
+	}
+
+	where := "--" + flagName
+	if source != "" {
+		where = source
+	}
+	return nil, fmt.Errorf("request body from %s is not valid JSON: %s", where, jsonProblem(data))
+}
+
+// looksLikePath reports whether a flag value is more plausibly a file path than
+// a JSON document — an absolute/relative path prefix, or the name of a file
+// that actually exists.
+func looksLikePath(raw string) bool {
+	if raw == "" || strings.ContainsAny(raw, " \t\r\n") {
+		return false
+	}
+	for _, prefix := range []string{"/", "./", "../", "~/"} {
+		if strings.HasPrefix(raw, prefix) {
+			return true
+		}
+	}
+	if info, err := os.Stat(expandHome(raw)); err == nil && !info.IsDir() {
+		return true
+	}
+	return false
+}
+
+// jsonProblem renders a short parse diagnostic: the syntax error plus the few
+// bytes around the offset it points at.
+func jsonProblem(data []byte) string {
+	var v json.RawMessage
+	err := json.Unmarshal(data, &v)
+	if err == nil {
+		return "unexpected trailing data"
+	}
+
+	syn, ok := err.(*json.SyntaxError)
+	if !ok {
+		return err.Error()
+	}
+
+	offset := int(syn.Offset)
+	if offset < 0 || offset > len(data) {
+		return syn.Error()
+	}
+	start := offset - 20
+	if start < 0 {
+		start = 0
+	}
+	end := offset + 20
+	if end > len(data) {
+		end = len(data)
+	}
+	return fmt.Sprintf("%s (at byte %d, near %q)", syn.Error(), offset, string(data[start:end]))
+}
+
+// expandHome expands a leading "~/" — shells don't expand it after "@".
+func expandHome(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+}

--- a/internal/openapi/body_input_test.go
+++ b/internal/openapi/body_input_test.go
@@ -1,0 +1,377 @@
+package openapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// ---------------------------------------------------------------------------
+// --body transport
+//
+// The API answers any non-JSON body with a generic 400 "Invalid JSON", which
+// reads like a body-SHAPE problem. These tests pin the client-side handling
+// that keeps callers out of that dead end: @file input, and rejecting a body
+// that isn't JSON before any network call.
+// ---------------------------------------------------------------------------
+
+// writeTempBody writes content to a temp file and returns its path.
+func writeTempBody(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing temp body: %v", err)
+	}
+	return path
+}
+
+// "--body @file.json" reads the body from disk, byte for byte.
+func TestResolveBody_AtFile(t *testing.T) {
+	content := `{"modelId":"abc","prompt":"hi"}`
+	path := writeTempBody(t, "body.json", content)
+
+	got, err := resolveBody("@"+path, "body", true)
+	if err != nil {
+		t.Fatalf("resolveBody: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("body = %q, want %q", string(got), content)
+	}
+}
+
+// A missing @file is a client-side error that names the path.
+func TestResolveBody_AtFileMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.json")
+
+	_, err := resolveBody("@"+missing, "body", true)
+	if err == nil {
+		t.Fatal("expected an error for a missing body file, got nil")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error = %q, want it to name the path %q", err.Error(), missing)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to say the file was not found", err.Error())
+	}
+}
+
+// The 10 MB stdin cap applies to @file input too.
+func TestResolveBody_AtFileTooLarge(t *testing.T) {
+	path := writeTempBody(t, "big.json", strings.Repeat("x", maxStdinSize+1))
+
+	_, err := resolveBody("@"+path, "body", true)
+	if err == nil {
+		t.Fatal("expected an error for an oversized body file, got nil")
+	}
+	if !strings.Contains(err.Error(), "10 MB") {
+		t.Errorf("error = %q, want it to mention 10 MB", err.Error())
+	}
+}
+
+// "@" with no path is a usage error, not a stat of the empty string.
+func TestResolveBody_AtWithoutPath(t *testing.T) {
+	if _, err := resolveBody("@", "body", true); err == nil {
+		t.Fatal("expected an error for a bare @, got nil")
+	}
+}
+
+// A file whose contents aren't JSON is rejected before the request is made.
+func TestResolveBody_AtFileInvalidJSON(t *testing.T) {
+	path := writeTempBody(t, "body.json", "modelId: abc\n")
+
+	_, err := resolveBody("@"+path, "body", true)
+	if err == nil {
+		t.Fatal("expected an error for a non-JSON body file, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("error = %q, want it to say the body is not valid JSON", err.Error())
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error = %q, want it to name the file %q", err.Error(), path)
+	}
+}
+
+// The curl-style mistake: passing a bare file path as the body. The error must
+// point at the @file / stdin forms rather than leave the caller re-reading the
+// body schema.
+func TestResolveBody_BareFilePathHint(t *testing.T) {
+	path := writeTempBody(t, "body.json", `{"a":1}`)
+
+	for _, raw := range []string{path, "/tmp/does-not-exist.json", "./body.json", "~/body.json"} {
+		_, err := resolveBody(raw, "body", true)
+		if err == nil {
+			t.Fatalf("resolveBody(%q): expected an error, got nil", raw)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "looks like a file path") {
+			t.Errorf("resolveBody(%q) error = %q, want the file-path hint", raw, msg)
+		}
+		if !strings.Contains(msg, "--body @"+raw) {
+			t.Errorf("resolveBody(%q) error = %q, want it to suggest --body @%s", raw, msg, raw)
+		}
+		if !strings.Contains(msg, "--body - < "+raw) {
+			t.Errorf("resolveBody(%q) error = %q, want it to suggest the stdin form", raw, msg)
+		}
+	}
+}
+
+// Non-JSON that isn't path-shaped gets a plain parse error with a position.
+func TestResolveBody_InvalidJSONDiagnostic(t *testing.T) {
+	_, err := resolveBody(`{"a":1,}`, "body", true)
+	if err == nil {
+		t.Fatal("expected an error for malformed JSON, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not valid JSON") {
+		t.Errorf("error = %q, want it to say the body is not valid JSON", msg)
+	}
+	if !strings.Contains(msg, "byte ") {
+		t.Errorf("error = %q, want it to include the parse position", msg)
+	}
+	if strings.Contains(msg, "looks like a file path") {
+		t.Errorf("error = %q, should not offer the file-path hint here", msg)
+	}
+}
+
+// The error names whichever flag the caller actually used.
+func TestResolveBody_NamesTheFlagUsed(t *testing.T) {
+	_, err := resolveBody("not json", "json-body", true)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--json-body") {
+		t.Errorf("error = %q, want it to name --json-body", err.Error())
+	}
+}
+
+// Valid JSON passes through byte-identical: no reformatting, no re-ordering.
+func TestResolveBody_ValidJSONPassthrough(t *testing.T) {
+	cases := []string{
+		`{"b":1,   "a":  [1,2,3]}`,
+		`  {"padded": true}  `,
+		`[1,2,3]`,
+		`"a bare string"`,
+		`null`,
+	}
+	for _, raw := range cases {
+		got, err := resolveBody(raw, "body", true)
+		if err != nil {
+			t.Fatalf("resolveBody(%q): %v", raw, err)
+		}
+		if string(got) != raw {
+			t.Errorf("resolveBody(%q) = %q, want the bytes unchanged", raw, string(got))
+		}
+	}
+}
+
+// Non-JSON media types (the multipart upload endpoints) skip validation.
+func TestResolveBody_SkipsValidationForNonJSON(t *testing.T) {
+	raw := "--boundary\r\nnot json\r\n"
+	got, err := resolveBody(raw, "body", false)
+	if err != nil {
+		t.Fatalf("resolveBody: %v", err)
+	}
+	if string(got) != raw {
+		t.Errorf("body = %q, want it unchanged", string(got))
+	}
+}
+
+// "-" still reads stdin, and stdin is validated the same way.
+func TestResolveBody_Stdin(t *testing.T) {
+	withStdin(t, `{"from":"stdin"}`, func() {
+		got, err := resolveBody("-", "body", true)
+		if err != nil {
+			t.Fatalf("resolveBody: %v", err)
+		}
+		if string(got) != `{"from":"stdin"}` {
+			t.Errorf("body = %q, want the stdin bytes", string(got))
+		}
+	})
+
+	withStdin(t, "not json", func() {
+		_, err := resolveBody("-", "body", true)
+		if err == nil {
+			t.Fatal("expected an error for non-JSON stdin, got nil")
+		}
+		if !strings.Contains(err.Error(), "stdin") {
+			t.Errorf("error = %q, want it to name stdin as the source", err.Error())
+		}
+	})
+}
+
+// "@-" is the curl spelling of stdin.
+func TestResolveBody_AtDashIsStdin(t *testing.T) {
+	withStdin(t, `{"from":"stdin"}`, func() {
+		got, err := resolveBody("@-", "body", true)
+		if err != nil {
+			t.Fatalf("resolveBody: %v", err)
+		}
+		if string(got) != `{"from":"stdin"}` {
+			t.Errorf("body = %q, want the stdin bytes", string(got))
+		}
+	})
+}
+
+// An empty source is reported as empty rather than as a JSON syntax error.
+func TestResolveBody_EmptySources(t *testing.T) {
+	path := writeTempBody(t, "empty.json", "")
+	if _, err := resolveBody("@"+path, "body", true); err == nil {
+		t.Fatal("expected an error for an empty body file, got nil")
+	} else if !strings.Contains(err.Error(), "no request body") {
+		t.Errorf("error = %q, want it to report an empty body", err.Error())
+	}
+
+	if _, err := resolveBody("   ", "body", true); err == nil {
+		t.Fatal("expected an error for a whitespace-only --body, got nil")
+	}
+}
+
+// withStdin swaps os.Stdin for a pipe carrying content for the duration of fn.
+func withStdin(t *testing.T, content string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig; r.Close() }()
+
+	go func() {
+		w.Write([]byte(content))
+		w.Close()
+	}()
+	fn()
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end through a generated command
+// ---------------------------------------------------------------------------
+
+func bodyCmd(t *testing.T, exec Executor) *cobra.Command {
+	t.Helper()
+	cmd := buildCommand(&operationInfo{
+		Tag:         "test",
+		OperationID: "testCreateWidget",
+		Method:      "POST",
+		Path:        "/api/v1/widgets",
+		HasBody:     true,
+	}, exec)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	return cmd
+}
+
+// "omni ... --body @file.json" sends the file's bytes.
+func TestBuildCommand_BodyAtFile(t *testing.T) {
+	content := `{"key":"val"}`
+	path := writeTempBody(t, "body.json", content)
+
+	var captured APIRequest
+	cmd := bodyCmd(t, func(req APIRequest) error { captured = req; return nil })
+	cmd.SetArgs([]string{"--body", "@" + path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if string(captured.Body) != content {
+		t.Errorf("body = %q, want %q", string(captured.Body), content)
+	}
+}
+
+// The hidden --json-body alias gets identical treatment.
+func TestBuildCommand_JSONBodyAtFile(t *testing.T) {
+	content := `{"key":"val"}`
+	path := writeTempBody(t, "body.json", content)
+
+	var captured APIRequest
+	cmd := bodyCmd(t, func(req APIRequest) error { captured = req; return nil })
+	cmd.SetArgs([]string{"--json-body", "@" + path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if string(captured.Body) != content {
+		t.Errorf("body = %q, want %q", string(captured.Body), content)
+	}
+}
+
+// An invalid body must fail before the executor runs — no request is made.
+func TestBuildCommand_InvalidBodyMakesNoRequest(t *testing.T) {
+	called := false
+	cmd := bodyCmd(t, func(req APIRequest) error { called = true; return nil })
+	cmd.SetArgs([]string{"--body", "/tmp/some-body.json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error for a bare file path, got nil")
+	}
+	if called {
+		t.Error("executor ran despite an invalid body")
+	}
+	if !strings.Contains(err.Error(), "looks like a file path") {
+		t.Errorf("error = %q, want the file-path hint", err.Error())
+	}
+}
+
+// Body shorthand assembles its own JSON and must not trip the new validation.
+func TestBodyShorthand_SurvivesBodyValidation(t *testing.T) {
+	var captured APIRequest
+	op := &operationInfo{
+		Tag:         "ai",
+		OperationID: "aiSearchOmniDocs",
+		Method:      "POST",
+		Path:        "/api/v1/ai/search-omni-docs",
+		HasBody:     true,
+	}
+	cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"How do I add a format to a dimension?"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if string(captured.Body) != `{"question":"How do I add a format to a dimension?"}` {
+		t.Errorf("body = %q, want the assembled shorthand JSON", string(captured.Body))
+	}
+}
+
+// Shorthand commands accept --body @file for the full JSON form.
+func TestBodyShorthand_AtFileBody(t *testing.T) {
+	content := `{"question":"why?"}`
+	path := writeTempBody(t, "body.json", content)
+
+	var captured APIRequest
+	op := &operationInfo{
+		Tag:         "ai",
+		OperationID: "aiSearchOmniDocs",
+		Method:      "POST",
+		Path:        "/api/v1/ai/search-omni-docs",
+		HasBody:     true,
+	}
+	cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--body", "@" + path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if string(captured.Body) != content {
+		t.Errorf("body = %q, want %q", string(captured.Body), content)
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	if got := expandHome("~/x.json"); got != filepath.Join(home, "x.json") {
+		t.Errorf("expandHome(~/x.json) = %q, want %q", got, filepath.Join(home, "x.json"))
+	}
+	// "~" only expands as a path prefix, never mid-string.
+	if got := expandHome("/tmp/~/x.json"); got != "/tmp/~/x.json" {
+		t.Errorf("expandHome = %q, want it unchanged", got)
+	}
+}

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -19,10 +19,11 @@ import (
 
 // APIRequest is passed to the executor callback when a generated command runs.
 type APIRequest struct {
-	Cmd    *cobra.Command
-	Method string
-	Path   string // fully resolved path with query string
-	Body   []byte // nil for GET/DELETE
+	Cmd         *cobra.Command
+	Method      string
+	Path        string // fully resolved path with query string
+	Body        []byte // nil for GET/DELETE
+	ContentType string // request body media type; defaults to application/json when empty
 }
 
 // Executor is the callback that actually makes the HTTP request.
@@ -82,18 +83,19 @@ type paramInfo struct {
 }
 
 type operationInfo struct {
-	Tag         string
-	OperationID string
-	Summary     string
-	Description string
-	Method      string
-	Path        string
-	PathParams  []paramInfo
-	QueryParams []paramInfo
-	HasBody     bool
-	BodySchema  *base.SchemaProxy // request body schema, when HasBody
-	BodyNonJSON bool              // request body uses a non-JSON media type (e.g. multipart)
-	Deprecated  bool
+	Tag           string
+	OperationID   string
+	Summary       string
+	Description   string
+	Method        string
+	Path          string
+	PathParams    []paramInfo
+	QueryParams   []paramInfo
+	HasBody       bool
+	BodySchema    *base.SchemaProxy // request body schema, when HasBody
+	BodyMediaType string
+	BodyFields    []multipartFieldInfo
+	Deprecated    bool
 }
 
 func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*operationInfo) {
@@ -159,8 +161,14 @@ func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*o
 		// Check for request body
 		if op.RequestBody != nil {
 			info.HasBody = true
-			info.BodySchema = requestBodySchema(op.RequestBody)
-			info.BodyNonJSON = !requestBodyIsJSON(op.RequestBody)
+			mediaType, media := requestBodyMediaType(op.RequestBody)
+			info.BodyMediaType = mediaType
+			if media != nil {
+				info.BodySchema = media.Schema
+				if mediaType == "multipart/form-data" {
+					info.BodyFields = multipartFields(media.Schema, media.Encoding)
+				}
+			}
 		}
 
 		groups[tag] = append(groups[tag], info)
@@ -172,7 +180,7 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	name := commandName(op)
 	use := name
 	for _, p := range op.PathParams {
-		use += " <" + slugify(p.Name) + ">"
+		use += " <" + cliFlagName(p.Name) + ">"
 	}
 
 	short := op.Summary
@@ -201,10 +209,9 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 			// Build query string from flags
 			query := url.Values{}
 			for _, q := range op.QueryParams {
-				flagName := slugify(q.Name)
-				val, err := cmd.Flags().GetString(flagName)
+				val, err := queryFlagValue(cmd, q.Name)
 				if err != nil {
-					continue
+					return err
 				}
 				if val != "" {
 					query.Set(q.Name, val)
@@ -214,8 +221,9 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 				path += "?" + query.Encode()
 			}
 
-			// Read body from stdin, a file, or the flag value itself
+			// Read body from stdin, a file, or the flag value itself.
 			var body []byte
+			contentType := op.BodyMediaType
 			if op.HasBody {
 				bodyFlag, _ := cmd.Flags().GetString("body")
 				jsonBodyFlag, _ := cmd.Flags().GetString("json-body")
@@ -225,13 +233,15 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 				}
 
 				effectiveBody, flagName := bodyFlag, "body"
+				bodyProvided := cmd.Flags().Changed("body")
 				if jsonBodyFlag != "" {
 					effectiveBody, flagName = jsonBodyFlag, "json-body"
+					bodyProvided = true
 				}
 
 				if effectiveBody != "" {
 					var err error
-					body, err = resolveBody(effectiveBody, flagName, !op.BodyNonJSON)
+					body, err = resolveBody(effectiveBody, flagName, op.bodyFlagIsJSON())
 					if err != nil {
 						// A body input error is self-explanatory; the usage
 						// block would bury the hint.
@@ -239,32 +249,59 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 						return err
 					}
 				}
+
+				if op.BodyMediaType == "multipart/form-data" {
+					var err error
+					body, contentType, err = buildMultipartBody(cmd, body, bodyProvided, op.BodyFields)
+					if err != nil {
+						return err
+					}
+				}
 			}
 
 			return exec(APIRequest{
-				Cmd:    cmd,
-				Method: op.Method,
-				Path:   path,
-				Body:   body,
+				Cmd:         cmd,
+				Method:      op.Method,
+				Path:        path,
+				Body:        body,
+				ContentType: contentType,
 			})
 		},
 	}
 
 	// Register query params as flags
 	for _, q := range op.QueryParams {
-		flagName := slugify(q.Name)
+		flagName := cliFlagName(q.Name)
 		desc := q.Description
 		if len(q.Enum) > 0 {
 			desc += fmt.Sprintf(" [%s]", strings.Join(q.Enum, ", "))
 		}
 		cmd.Flags().String(flagName, "", desc)
+
+		// Before camelCase names were normalized, flags such as modelId were
+		// exposed as --modelid. Keep a hidden deprecated alias so existing
+		// scripts continue to work while help and new usage use --model-id.
+		legacyName := slugify(q.Name)
+		if legacyName != flagName {
+			cmd.Flags().String(legacyName, "", "deprecated alias for --"+flagName)
+			_ = cmd.Flags().MarkDeprecated(legacyName, "use --"+flagName+" instead")
+			_ = cmd.Flags().MarkHidden(legacyName)
+		}
 	}
 
-	// If the operation accepts a body, add --body and --json-body flags
+	// If the operation accepts a body, add --body and --json-body flags.
 	if op.HasBody {
-		cmd.Flags().String("body", "", `request body as JSON string, "@path/to/file.json" to read a file, or "-" for stdin (run with --schema to see its shape)`)
+		bodyHelp := `request body as JSON string, "@path/to/file.json" to read a file, or "-" for stdin (run with --schema to see its shape)`
+		if op.BodyMediaType == "multipart/form-data" {
+			bodyHelp = `multipart fields as JSON string, "@path/to/file.json", or "-" for stdin; binary field values are file paths`
+		}
+		cmd.Flags().String("body", "", bodyHelp)
 		cmd.Flags().String("json-body", "", `request body as JSON string, "@path/to/file.json", or "-" for stdin (alias for --body)`)
 		cmd.Flags().MarkHidden("json-body")
+
+		if op.BodyMediaType == "multipart/form-data" {
+			registerMultipartFlags(cmd, op.BodyFields)
+		}
 	}
 
 	// Apply body shorthand if one exists for this operation
@@ -316,43 +353,44 @@ func schemaRequested(cmd *cobra.Command) bool {
 	return err == nil && v
 }
 
-// requestBodySchema returns the schema for a request body, preferring the
-// application/json media type and falling back to the first declared one.
-func requestBodySchema(rb *v3.RequestBody) *base.SchemaProxy {
+// requestBodyMediaType returns the media type and definition the CLI will use,
+// preferring application/json for backward compatibility and otherwise using
+// the first declared media type.
+func requestBodyMediaType(rb *v3.RequestBody) (string, *v3.MediaType) {
 	if rb == nil || rb.Content == nil {
-		return nil
+		return "", nil
 	}
-	var first *base.SchemaProxy
+	var firstType string
+	var first *v3.MediaType
 	for pair := rb.Content.First(); pair != nil; pair = pair.Next() {
 		mt := pair.Value()
-		if mt == nil || mt.Schema == nil {
+		if mt == nil {
 			continue
 		}
 		if pair.Key() == "application/json" {
-			return mt.Schema
+			return pair.Key(), mt
 		}
 		if first == nil {
-			first = mt.Schema
+			firstType = pair.Key()
+			first = mt
 		}
 	}
-	return first
+	return firstType, first
 }
 
-// requestBodyIsJSON reports whether a request body is sent as JSON. Bodies with
-// no declared content default to JSON — that's what the CLI sends. Only the
-// media types the spec actually declares (today: multipart/form-data uploads)
-// opt out of client-side JSON validation.
-func requestBodyIsJSON(rb *v3.RequestBody) bool {
-	if rb == nil || rb.Content == nil || rb.Content.Len() == 0 {
+// bodyFlagIsJSON reports whether the --body flag value is JSON, and so worth
+// validating client-side. A JSON body is sent verbatim; a multipart body takes
+// a JSON object of field values that buildMultipartBody turns into form parts.
+// A body with no declared content defaults to JSON — that's what the CLI sends.
+// Any other media type passes --body through as raw bytes, unvalidated.
+func (op *operationInfo) bodyFlagIsJSON() bool {
+	switch {
+	case op.BodyMediaType == "", op.BodyMediaType == "application/json":
+		return true
+	case op.BodyMediaType == "multipart/form-data":
 		return true
 	}
-	for pair := rb.Content.First(); pair != nil; pair = pair.Next() {
-		mt := pair.Key()
-		if mt == "application/json" || strings.HasSuffix(mt, "+json") {
-			return true
-		}
-	}
-	return false
+	return strings.HasSuffix(op.BodyMediaType, "+json")
 }
 
 // commandName derives a CLI subcommand name from the operationId or method+path.
@@ -382,6 +420,24 @@ func slugify(s string) string {
 	s = strings.ReplaceAll(s, " ", "-")
 	s = strings.ReplaceAll(s, "_", "-")
 	return s
+}
+
+func cliFlagName(s string) string {
+	return slugify(camelToKebab(s))
+}
+
+func queryFlagValue(cmd *cobra.Command, parameterName string) (string, error) {
+	canonicalName := cliFlagName(parameterName)
+	legacyName := slugify(parameterName)
+	canonicalChanged := cmd.Flags().Changed(canonicalName)
+	legacyChanged := legacyName != canonicalName && cmd.Flags().Changed(legacyName)
+	if canonicalChanged && legacyChanged {
+		return "", fmt.Errorf("cannot use both --%s and deprecated --%s", canonicalName, legacyName)
+	}
+	if legacyChanged {
+		return cmd.Flags().GetString(legacyName)
+	}
+	return cmd.Flags().GetString(canonicalName)
 }
 
 func camelToKebab(s string) string {

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -92,6 +92,7 @@ type operationInfo struct {
 	QueryParams []paramInfo
 	HasBody     bool
 	BodySchema  *base.SchemaProxy // request body schema, when HasBody
+	BodyNonJSON bool              // request body uses a non-JSON media type (e.g. multipart)
 	Deprecated  bool
 }
 
@@ -159,6 +160,7 @@ func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*o
 		if op.RequestBody != nil {
 			info.HasBody = true
 			info.BodySchema = requestBodySchema(op.RequestBody)
+			info.BodyNonJSON = !requestBodyIsJSON(op.RequestBody)
 		}
 
 		groups[tag] = append(groups[tag], info)
@@ -212,7 +214,7 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 				path += "?" + query.Encode()
 			}
 
-			// Read body from stdin or flags
+			// Read body from stdin, a file, or the flag value itself
 			var body []byte
 			if op.HasBody {
 				bodyFlag, _ := cmd.Flags().GetString("body")
@@ -222,21 +224,20 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 					return fmt.Errorf("cannot use both --body and --json-body; use one or the other")
 				}
 
-				effectiveBody := bodyFlag
+				effectiveBody, flagName := bodyFlag, "body"
 				if jsonBodyFlag != "" {
-					effectiveBody = jsonBodyFlag
+					effectiveBody, flagName = jsonBodyFlag, "json-body"
 				}
 
-				if effectiveBody == "-" || effectiveBody == "" {
-					if effectiveBody == "-" {
-						var err error
-						body, err = readStdin()
-						if err != nil {
-							return fmt.Errorf("reading stdin: %w", err)
-						}
+				if effectiveBody != "" {
+					var err error
+					body, err = resolveBody(effectiveBody, flagName, !op.BodyNonJSON)
+					if err != nil {
+						// A body input error is self-explanatory; the usage
+						// block would bury the hint.
+						cmd.SilenceUsage = true
+						return err
 					}
-				} else if effectiveBody != "" {
-					body = []byte(effectiveBody)
 				}
 			}
 
@@ -261,8 +262,8 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 
 	// If the operation accepts a body, add --body and --json-body flags
 	if op.HasBody {
-		cmd.Flags().String("body", "", `request body as JSON string, or "-" for stdin (run with --schema to see its shape)`)
-		cmd.Flags().String("json-body", "", `request body as JSON string, or "-" for stdin (alias for --body)`)
+		cmd.Flags().String("body", "", `request body as JSON string, "@path/to/file.json" to read a file, or "-" for stdin (run with --schema to see its shape)`)
+		cmd.Flags().String("json-body", "", `request body as JSON string, "@path/to/file.json", or "-" for stdin (alias for --body)`)
 		cmd.Flags().MarkHidden("json-body")
 	}
 
@@ -335,6 +336,23 @@ func requestBodySchema(rb *v3.RequestBody) *base.SchemaProxy {
 		}
 	}
 	return first
+}
+
+// requestBodyIsJSON reports whether a request body is sent as JSON. Bodies with
+// no declared content default to JSON — that's what the CLI sends. Only the
+// media types the spec actually declares (today: multipart/form-data uploads)
+// opt out of client-side JSON validation.
+func requestBodyIsJSON(rb *v3.RequestBody) bool {
+	if rb == nil || rb.Content == nil || rb.Content.Len() == 0 {
+		return true
+	}
+	for pair := rb.Content.First(); pair != nil; pair = pair.Next() {
+		mt := pair.Key()
+		if mt == "application/json" || strings.HasSuffix(mt, "+json") {
+			return true
+		}
+	}
+	return false
 }
 
 // commandName derives a CLI subcommand name from the operationId or method+path.

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -263,8 +263,8 @@ func TestGenerateCommands_PathParamsFollowPathOrder(t *testing.T) {
 	}
 
 	sub := cmds[0].Commands()[0]
-	if sub.Use != "get-item <outerid> <innerid>" {
-		t.Errorf("Use = %q, want %q", sub.Use, "get-item <outerid> <innerid>")
+	if sub.Use != "get-item <outer-id> <inner-id>" {
+		t.Errorf("Use = %q, want %q", sub.Use, "get-item <outer-id> <inner-id>")
 	}
 
 	// Positional args in path order must substitute into the matching slots.
@@ -352,6 +352,61 @@ func TestBuildCommand_QueryFlags(t *testing.T) {
 	if !strings.Contains(captured.Path, "cursor=abc") {
 		t.Errorf("path %q missing cursor=abc", captured.Path)
 	}
+}
+
+func TestBuildCommand_CamelCaseQueryFlags(t *testing.T) {
+	op := &operationInfo{
+		Tag:         "test",
+		OperationID: "testListItems",
+		Method:      "GET",
+		Path:        "/api/v1/items",
+		QueryParams: []paramInfo{
+			{Name: "modelId", In: "query"},
+			{Name: "searchTerm", In: "query"},
+		},
+	}
+
+	t.Run("canonical kebab-case flags", func(t *testing.T) {
+		var captured APIRequest
+		cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+		if cmd.Flags().Lookup("model-id") == nil || cmd.Flags().Lookup("search-term") == nil {
+			t.Fatal("missing canonical camelCase query flags")
+		}
+		legacy := cmd.Flags().Lookup("modelid")
+		if legacy == nil || legacy.Deprecated == "" || !legacy.Hidden {
+			t.Fatalf("legacy --modelid flag = %#v, want hidden and deprecated", legacy)
+		}
+		cmd.SetArgs([]string{"--model-id", "model-123", "--search-term", "people"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !strings.Contains(captured.Path, "modelId=model-123") || !strings.Contains(captured.Path, "searchTerm=people") {
+			t.Errorf("path = %q, want original OpenAPI parameter names", captured.Path)
+		}
+	})
+
+	t.Run("legacy aliases remain compatible", func(t *testing.T) {
+		var captured APIRequest
+		cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+		cmd.SetArgs([]string{"--modelid", "model-123", "--searchterm", "people"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !strings.Contains(captured.Path, "modelId=model-123") || !strings.Contains(captured.Path, "searchTerm=people") {
+			t.Errorf("path = %q, want legacy aliases to preserve parameter names", captured.Path)
+		}
+	})
+
+	t.Run("canonical and legacy conflict", func(t *testing.T) {
+		cmd := buildCommand(op, func(req APIRequest) error { return nil })
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.SetArgs([]string{"--model-id", "new", "--modelid", "old"})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "cannot use both --model-id and deprecated --modelid") {
+			t.Fatalf("error = %v, want conflicting alias error", err)
+		}
+	})
 }
 
 // Verify that operations with a request body (POST/PUT/PATCH) get a --body

--- a/internal/openapi/multipart.go
+++ b/internal/openapi/multipart.go
@@ -1,0 +1,326 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/spf13/cobra"
+)
+
+// multipartFieldInfo is the CLI-facing subset of a multipart schema property.
+// A binary field consumes a file path; other fields are serialized as form
+// values according to their JSON type.
+type multipartFieldInfo struct {
+	Name        string
+	FlagName    string
+	Description string
+	Type        string
+	Required    bool
+	Binary      bool
+	ContentType string
+	Explode     bool
+}
+
+func multipartFields(schemaProxy *base.SchemaProxy, encodings *orderedmap.Map[string, *v3.Encoding]) []multipartFieldInfo {
+	fields := make([]multipartFieldInfo, 0)
+	indexes := map[string]int{}
+	required := map[string]bool{}
+	seen := map[*base.Schema]bool{}
+
+	var collect func(*base.SchemaProxy)
+	collect = func(proxy *base.SchemaProxy) {
+		if proxy == nil || proxy.Schema() == nil {
+			return
+		}
+		schema := proxy.Schema()
+		if seen[schema] {
+			return
+		}
+		seen[schema] = true
+
+		for _, name := range schema.Required {
+			required[name] = true
+		}
+		for _, parent := range schema.AllOf {
+			collect(parent)
+		}
+		if schema.Properties == nil {
+			return
+		}
+		for pair := schema.Properties.First(); pair != nil; pair = pair.Next() {
+			name := pair.Key()
+			property := pair.Value()
+			propertySchema := property.Schema()
+			field := multipartFieldInfo{Name: name, FlagName: cliFlagName(name), Type: "string", Explode: true}
+			if propertySchema != nil {
+				field.Description = propertySchema.Description
+				field.Type = schemaType(property)
+				field.Binary = strings.EqualFold(propertySchema.Format, "binary") || strings.EqualFold(propertySchema.ContentEncoding, "binary")
+				field.ContentType = propertySchema.ContentMediaType
+			}
+			if encodings != nil {
+				if encoding, ok := encodings.Get(name); ok && encoding != nil {
+					if encoding.ContentType != "" {
+						field.ContentType = encoding.ContentType
+					}
+					if encoding.Explode != nil {
+						field.Explode = *encoding.Explode
+					}
+					if encoding.ContentType == "application/octet-stream" {
+						field.Binary = true
+					}
+				}
+			}
+
+			if index, ok := indexes[name]; ok {
+				fields[index] = field
+			} else {
+				indexes[name] = len(fields)
+				fields = append(fields, field)
+			}
+		}
+	}
+
+	collect(schemaProxy)
+	for i := range fields {
+		fields[i].Required = required[fields[i].Name]
+	}
+	return fields
+}
+
+func registerMultipartFlags(cmd *cobra.Command, fields []multipartFieldInfo) {
+	reserved := map[string]bool{
+		"body": true, "json-body": true, "schema": true, "field": true, "depth": true,
+		"profile": true, "token": true, "base-url": true, "compact": true, "format": true, "help": true,
+	}
+	for i := range fields {
+		field := &fields[i]
+		flagName := field.FlagName
+		if reserved[flagName] || cmd.Flags().Lookup(flagName) != nil {
+			flagName = "form-" + flagName
+		}
+		field.FlagName = flagName
+
+		description := field.Description
+		if description == "" {
+			description = "multipart field " + field.Name
+		}
+		if field.Binary {
+			description += " (file path)"
+		}
+		if field.Required {
+			description += " [required unless supplied via --body]"
+		}
+		cmd.Flags().String(flagName, "", description)
+	}
+}
+
+func buildMultipartBody(cmd *cobra.Command, rawBody []byte, bodyProvided bool, fields []multipartFieldInfo) ([]byte, string, error) {
+	values := map[string]interface{}{}
+	if bodyProvided {
+		decoder := json.NewDecoder(bytes.NewReader(rawBody))
+		decoder.UseNumber()
+		if err := decoder.Decode(&values); err != nil {
+			return nil, "", fmt.Errorf("invalid multipart --body JSON: %w", err)
+		}
+	}
+
+	for _, field := range fields {
+		if !cmd.Flags().Changed(field.FlagName) {
+			continue
+		}
+		value, err := cmd.Flags().GetString(field.FlagName)
+		if err != nil {
+			return nil, "", fmt.Errorf("reading --%s: %w", field.FlagName, err)
+		}
+		parsed, err := parseMultipartFlagValue(field, value)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid --%s: %w", field.FlagName, err)
+		}
+		values[field.Name] = parsed
+	}
+
+	// Flag-based invocation gets local required-field validation. Raw --body is
+	// deliberately passed through more loosely, matching JSON request behavior.
+	if !bodyProvided {
+		for _, field := range fields {
+			if field.Required {
+				if _, ok := values[field.Name]; !ok {
+					return nil, "", fmt.Errorf("required multipart field %q is missing (use --%s or --body)", field.Name, field.FlagName)
+				}
+			}
+		}
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	known := map[string]bool{}
+	for _, field := range fields {
+		known[field.Name] = true
+		value, ok := values[field.Name]
+		if !ok {
+			continue
+		}
+		if err := writeMultipartValue(writer, field, value); err != nil {
+			return nil, "", err
+		}
+	}
+
+	// Preserve extra properties supplied through --body even when the schema
+	// permits them without naming them explicitly.
+	var extras []string
+	for name := range values {
+		if !known[name] {
+			extras = append(extras, name)
+		}
+	}
+	sort.Strings(extras)
+	for _, name := range extras {
+		field := multipartFieldInfo{Name: name, Type: inferMultipartType(values[name]), Explode: true}
+		if err := writeMultipartValue(writer, field, values[name]); err != nil {
+			return nil, "", err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, "", fmt.Errorf("finalizing multipart body: %w", err)
+	}
+	return body.Bytes(), writer.FormDataContentType(), nil
+}
+
+func parseMultipartFlagValue(field multipartFieldInfo, value string) (interface{}, error) {
+	if field.Binary || field.Type == "string" || field.Type == "" {
+		return value, nil
+	}
+	switch field.Type {
+	case "boolean":
+		return strconv.ParseBool(value)
+	case "integer":
+		return strconv.ParseInt(value, 10, 64)
+	case "number":
+		return strconv.ParseFloat(value, 64)
+	case "array", "object":
+		var parsed interface{}
+		decoder := json.NewDecoder(strings.NewReader(value))
+		decoder.UseNumber()
+		if err := decoder.Decode(&parsed); err != nil {
+			return nil, fmt.Errorf("expected JSON %s: %w", field.Type, err)
+		}
+		return parsed, nil
+	default:
+		return value, nil
+	}
+}
+
+func writeMultipartValue(writer *multipart.Writer, field multipartFieldInfo, value interface{}) error {
+	if values, ok := value.([]interface{}); ok && field.Explode {
+		for _, item := range values {
+			if err := writeMultipartSingleValue(writer, field, item); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return writeMultipartSingleValue(writer, field, value)
+}
+
+func writeMultipartSingleValue(writer *multipart.Writer, field multipartFieldInfo, value interface{}) error {
+	if field.Binary {
+		path, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("multipart file field %q must be a file path", field.Name)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("opening multipart file %q for field %q: %w", path, field.Name, err)
+		}
+		defer file.Close()
+
+		contentType := field.ContentType
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", mime.FormatMediaType("form-data", map[string]string{
+			"name": field.Name, "filename": filepath.Base(path),
+		}))
+		header.Set("Content-Type", contentType)
+		part, err := writer.CreatePart(header)
+		if err != nil {
+			return fmt.Errorf("creating multipart file field %q: %w", field.Name, err)
+		}
+		if _, err := io.Copy(part, file); err != nil {
+			return fmt.Errorf("reading multipart file %q for field %q: %w", path, field.Name, err)
+		}
+		return nil
+	}
+
+	contentType := field.ContentType
+	var encoded string
+	switch typed := value.(type) {
+	case string:
+		encoded = typed
+	case nil:
+		encoded = "null"
+	case json.Number:
+		encoded = typed.String()
+	case bool, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		encoded = fmt.Sprint(typed)
+	default:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("encoding multipart field %q: %w", field.Name, err)
+		}
+		encoded = string(data)
+		if contentType == "" {
+			contentType = "application/json"
+		}
+	}
+
+	if contentType == "" {
+		part, err := writer.CreateFormField(field.Name)
+		if err != nil {
+			return fmt.Errorf("creating multipart field %q: %w", field.Name, err)
+		}
+		_, err = io.WriteString(part, encoded)
+		return err
+	}
+
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", mime.FormatMediaType("form-data", map[string]string{"name": field.Name}))
+	header.Set("Content-Type", contentType)
+	part, err := writer.CreatePart(header)
+	if err != nil {
+		return fmt.Errorf("creating multipart field %q: %w", field.Name, err)
+	}
+	_, err = io.WriteString(part, encoded)
+	return err
+}
+
+func inferMultipartType(value interface{}) string {
+	switch value.(type) {
+	case []interface{}:
+		return "array"
+	case map[string]interface{}:
+		return "object"
+	case bool:
+		return "boolean"
+	case json.Number, float64:
+		return "number"
+	default:
+		return "string"
+	}
+}

--- a/internal/openapi/multipart_test.go
+++ b/internal/openapi/multipart_test.go
@@ -1,0 +1,291 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const multipartTestSpec = `{
+  "openapi": "3.1.0",
+  "info": {"title": "multipart test", "version": "1.0"},
+  "paths": {
+    "/uploads": {
+      "post": {
+        "operationId": "uploadsCreate",
+        "tags": ["Uploads"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["file", "modelId"],
+                "properties": {
+                  "file": {"type": "string", "format": "binary", "description": "CSV to upload"},
+                  "modelId": {"type": "string", "description": "target model"},
+                  "viewName": {"type": "string"},
+                  "publish": {"type": "boolean"},
+                  "labels": {"type": "array", "items": {"type": "string"}}
+                }
+              },
+              "encoding": {
+                "file": {"contentType": "text/csv"}
+              }
+            }
+          }
+        },
+        "responses": {"201": {"description": "created"}}
+      }
+    }
+  }
+}`
+
+type capturedPart struct {
+	fileName    string
+	contentType string
+	values      []string
+}
+
+func parseCapturedMultipart(t *testing.T, request APIRequest) map[string]capturedPart {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(request.ContentType)
+	if err != nil {
+		t.Fatalf("ParseMediaType(%q): %v", request.ContentType, err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("media type = %q, want multipart/form-data", mediaType)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		t.Fatal("multipart content type has no boundary")
+	}
+
+	parts := map[string]capturedPart{}
+	reader := multipart.NewReader(bytes.NewReader(request.Body), boundary)
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart: %v", err)
+		}
+		data, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("ReadAll(%s): %v", part.FormName(), err)
+		}
+		got := parts[part.FormName()]
+		got.fileName = part.FileName()
+		got.contentType = part.Header.Get("Content-Type")
+		got.values = append(got.values, string(data))
+		parts[part.FormName()] = got
+	}
+	return parts
+}
+
+func TestGenerateCommands_MultipartFlagsAndBody(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "people.csv")
+	if err := os.WriteFile(filePath, []byte("name\nAda\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured APIRequest
+	commands, err := GenerateCommands([]byte(multipartTestSpec), func(request APIRequest) error {
+		captured = request
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	command := commands[0].Commands()[0]
+	for _, flag := range []string{"file", "model-id", "view-name", "publish", "labels"} {
+		if command.Flags().Lookup(flag) == nil {
+			t.Errorf("missing generated --%s flag", flag)
+		}
+	}
+
+	for flag, value := range map[string]string{
+		"file": filePath, "model-id": "model-123", "view-name": "people", "publish": "true", "labels": `["one","two"]`,
+	} {
+		if err := command.Flags().Set(flag, value); err != nil {
+			t.Fatalf("set --%s: %v", flag, err)
+		}
+	}
+	if err := command.RunE(command, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	parts := parseCapturedMultipart(t, captured)
+	if got := parts["file"]; got.fileName != "people.csv" || got.contentType != "text/csv" || len(got.values) != 1 || got.values[0] != "name\nAda\n" {
+		t.Errorf("file part = %#v", got)
+	}
+	if got := parts["modelId"].values; len(got) != 1 || got[0] != "model-123" {
+		t.Errorf("modelId = %#v", got)
+	}
+	if got := parts["publish"].values; len(got) != 1 || got[0] != "true" {
+		t.Errorf("publish = %#v", got)
+	}
+	if got := parts["labels"].values; len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Errorf("labels = %#v", got)
+	}
+}
+
+func TestGenerateCommands_MultipartJSONBody(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "data.csv")
+	if err := os.WriteFile(filePath, []byte("id\n1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured APIRequest
+	commands, err := GenerateCommands([]byte(multipartTestSpec), func(request APIRequest) error {
+		captured = request
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	command := commands[0].Commands()[0]
+	body, err := json.Marshal(map[string]interface{}{
+		"file": filePath, "modelId": "from-body", "extra": map[string]bool{"ok": true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Flags().Set("body", string(body)); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.RunE(command, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	parts := parseCapturedMultipart(t, captured)
+	if got := parts["modelId"].values; len(got) != 1 || got[0] != "from-body" {
+		t.Errorf("modelId = %#v", got)
+	}
+	if got := parts["extra"]; got.contentType != "application/json" || len(got.values) != 1 || got.values[0] != `{"ok":true}` {
+		t.Errorf("extra = %#v", got)
+	}
+}
+
+func TestGenerateCommands_MultipartValidatesFlagInvocation(t *testing.T) {
+	called := false
+	commands, err := GenerateCommands([]byte(multipartTestSpec), func(request APIRequest) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := commands[0].Commands()[0]
+	if err := command.Flags().Set("model-id", "model-123"); err != nil {
+		t.Fatal(err)
+	}
+	err = command.RunE(command, nil)
+	if err == nil || !strings.Contains(err.Error(), `required multipart field "file"`) {
+		t.Fatalf("error = %v, want missing file", err)
+	}
+	if called {
+		t.Fatal("executor called for invalid multipart invocation")
+	}
+}
+
+func TestRealSpec_UploadCommandsExposeFileFlags(t *testing.T) {
+	commands, err := GenerateCommands(loadSpec(t), func(request APIRequest) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var uploadsFound int
+	for _, group := range commands {
+		if group.Name() != "uploads" {
+			continue
+		}
+		for _, command := range group.Commands() {
+			if command.Name() != "create" && command.Name() != "replace-data" {
+				continue
+			}
+			uploadsFound++
+			if command.Flags().Lookup("file") == nil {
+				t.Errorf("uploads %s has no generated --file flag", command.Name())
+			}
+		}
+	}
+	if uploadsFound != 2 {
+		t.Fatalf("found %d multipart upload commands, want 2", uploadsFound)
+	}
+}
+
+// Multipart bodies are JSON too, so they get the same --body handling as JSON
+// operations: @file reading and a client-side validity check.
+func TestGenerateCommands_MultipartBodyFromFile(t *testing.T) {
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(csvPath, []byte("id\n1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bodyPath := filepath.Join(dir, "body.json")
+	body, err := json.Marshal(map[string]string{"file": csvPath, "modelId": "from-file"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bodyPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured APIRequest
+	commands, err := GenerateCommands([]byte(multipartTestSpec), func(request APIRequest) error {
+		captured = request
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	command := commands[0].Commands()[0]
+	if err := command.Flags().Set("body", "@"+bodyPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.RunE(command, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	parts := parseCapturedMultipart(t, captured)
+	if got := parts["modelId"].values; len(got) != 1 || got[0] != "from-file" {
+		t.Errorf("modelId = %#v", got)
+	}
+	if got := parts["file"]; got.fileName != "data.csv" {
+		t.Errorf("file = %#v", got)
+	}
+}
+
+func TestGenerateCommands_MultipartBodyPathHint(t *testing.T) {
+	bodyPath := filepath.Join(t.TempDir(), "body.json")
+	if err := os.WriteFile(bodyPath, []byte(`{"modelId":"m"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	commands, err := GenerateCommands([]byte(multipartTestSpec), func(request APIRequest) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := commands[0].Commands()[0]
+	if err := command.Flags().Set("body", bodyPath); err != nil {
+		t.Fatal(err)
+	}
+	err = command.RunE(command, nil)
+	if err == nil || !strings.Contains(err.Error(), "looks like a file path") {
+		t.Fatalf("error = %v, want file-path hint", err)
+	}
+	if called {
+		t.Fatal("executor called for a path-shaped --body")
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #75** — this PR targets `feat/body-file-input`, not `main`. Merge #75 first; this base retargets to `main` automatically once it lands. The diff shown here is multipart-only.

## Summary

- preserve the selected OpenAPI request media type through command generation and HTTP transport
- generate schema-driven multipart flags, including file-path handling for binary fields
- retain `--body` JSON compatibility and honor required fields, arrays, and per-part content types
- normalize camelCase query flags and path placeholders to kebab-case, with hidden deprecated aliases for released query flags
- document CSV uploads and cover both upload operations with regression tests

## How it composes with #75

#75 added `--body @file` reading and client-side JSON validation, gated on a
`BodyNonJSON` flag it computed per operation. Rebased on top of it:

- `BodyNonJSON` is replaced by `operationInfo.bodyFlagIsJSON()`, derived from the
  media type this PR already resolves — one source of truth instead of two scans
  of the same request body.
- Multipart counts as JSON for that purpose: `--body` on an upload command is a
  JSON object of field values, so it gets #75's `@file` reading, validity check,
  and file-path hint before `buildMultipartBody` parses it.
- Multipart body-flag help mentions `@path/to/file.json` alongside the file-path
  semantics for binary fields.

Two tests cover the seam: `--body @file` on an upload command, and a bare path
`--body` producing #75's hint without calling the executor.

## Verification

- `go test ./...`
- `go vet ./...`
- built the CLI and verified generated help for `uploads create`, `uploads list`, and `uploads replace-data`
- uploaded `omni.csv` end to end: 559 rows ingested and the upload was read back successfully

## Example

```bash
omni uploads create \
  --file ./people.csv \
  --model-id MODEL_ID \
  --view-name people
```

Fixes #70
