### PR TITLE
fix(openapi): derive shorthand flag types from schema

### DIFF
--- a/internal/openapi/body_shorthand.go
+++ b/internal/openapi/body_shorthand.go
@@ -3,8 +3,10 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/pb33f/libopenapi/datamodel/high/base"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +24,33 @@ type FlagMapping struct {
 	FieldPath   string // JSON field name
 	Description string
 	Default     string
-	IsBool      bool
+}
+
+// shorthandFlagValue keeps promoted body flags value-taking (so both
+// `--flag true` and `--flag false` work) while exposing the OpenAPI type in
+// Cobra's help output. The raw token is converted when the JSON body is built.
+type shorthandFlagValue struct {
+	value    string
+	typeName string
+}
+
+func (v *shorthandFlagValue) Set(value string) error {
+	v.value = value
+	return nil
+}
+
+func (v *shorthandFlagValue) String() string {
+	if v == nil {
+		return ""
+	}
+	return v.value
+}
+
+func (v *shorthandFlagValue) Type() string {
+	if v.typeName == "" {
+		return "string"
+	}
+	return v.typeName
 }
 
 // BodyShorthand defines how a single operation's body can be simplified.
@@ -50,9 +78,9 @@ var bodyShorthands = map[string]*BodyShorthand{
 			{Name: "prompt", FieldPath: "prompt", Description: "natural language query prompt", Transform: "string"},
 		},
 		Flags: []FlagMapping{
-			{FlagName: "run-query", FieldPath: "runQuery", Description: "execute the generated query (server default: true)", IsBool: true},
+			{FlagName: "run-query", FieldPath: "runQuery", Description: "execute the generated query (server default: true)"},
 			{FlagName: "user-id", FieldPath: "userId", Description: "user ID to execute as"},
-			{FlagName: "workbook-url", FieldPath: "workbookUrl", Description: "workbook URL for context"},
+			{FlagName: "workbook-url", FieldPath: "workbookUrl", Description: "create a workbook with the generated query and return its URL"},
 			{FlagName: "current-topic-name", FieldPath: "currentTopicName", Description: "topic name to scope query generation"},
 			{FlagName: "branch-id", FieldPath: "branchId", Description: "branch ID for the model"},
 		},
@@ -82,7 +110,7 @@ var bodyShorthands = map[string]*BodyShorthand{
 			{FlagName: "conversation-id", FieldPath: "conversationId", Description: "conversation ID to continue"},
 			{FlagName: "webhook-url", FieldPath: "webhookUrl", Description: "webhook URL for job completion"},
 			{FlagName: "webhook-signing-secret", FieldPath: "webhookSigningSecret", Description: "webhook signing secret"},
-			{FlagName: "progress-webhook-enabled", FieldPath: "progressWebhookEnabled", Description: "enable progress webhooks", IsBool: true},
+			{FlagName: "progress-webhook-enabled", FieldPath: "progressWebhookEnabled", Description: "enable progress webhooks"},
 		},
 		ExampleShort: `omni ai job-submit 770e8400-e29b-41d4-a716-446655440002 "Top 5 products by revenue"`,
 		ExampleJSON:  `omni ai job-submit --body '{"modelId":"770e8400-...","prompt":"Top 5 products by revenue"}'`,
@@ -190,7 +218,7 @@ var bodyShorthands = map[string]*BodyShorthand{
 		Flags: []FlagMapping{
 			{FlagName: "name", FieldPath: "name", Description: "new document name"},
 			{FlagName: "description", FieldPath: "description", Description: "document description"},
-			{FlagName: "clear-existing-draft", FieldPath: "clearExistingDraft", Description: "clear existing draft before updating", IsBool: true},
+			{FlagName: "clear-existing-draft", FieldPath: "clearExistingDraft", Description: "clear existing draft before updating"},
 		},
 		ExampleShort: `omni documents update <identifier> --name "New Name"`,
 		ExampleJSON:  `omni documents update <identifier> --body '{"name":"New Name"}'`,
@@ -257,10 +285,15 @@ func applyBodyShorthand(cmd *cobra.Command, op *operationInfo, sh *BodyShorthand
 		cmd.Use += " <" + a.Name + ">"
 	}
 
-	// Register promoted flags (all as strings; bool flags are parsed from
-	// their string value in assembleBody)
+	// Keep promoted flags value-taking so callers can use an explicit value such
+	// as `--run-query false`, but show their schema type in help. assembleBody
+	// uses the same request schema to encode the JSON value.
 	for _, f := range sh.Flags {
-		cmd.Flags().String(f.FlagName, f.Default, f.Description)
+		fieldType, err := shorthandFieldType(op.BodySchema, f.FieldPath)
+		if err != nil {
+			fieldType = "string"
+		}
+		cmd.Flags().Var(&shorthandFlagValue{value: f.Default, typeName: fieldType}, f.FlagName, f.Description)
 	}
 
 	// Replace the Args validator with a flexible one
@@ -294,7 +327,7 @@ func applyBodyShorthand(cmd *cobra.Command, op *operationInfo, sh *BodyShorthand
 		}
 
 		// Assemble body from shorthand args and promoted flags
-		body, err := assembleBody(sh, args, numPathParams, cmd)
+		body, err := assembleBody(sh, args, numPathParams, cmd, op.BodySchema)
 		if err != nil {
 			return err
 		}
@@ -344,7 +377,7 @@ func flexibleArgs(numPathParams, numShorthandArgs int) cobra.PositionalArgs {
 }
 
 // assembleBody builds a JSON body from shorthand positional args and promoted flags.
-func assembleBody(sh *BodyShorthand, args []string, pathParamCount int, cmd *cobra.Command) ([]byte, error) {
+func assembleBody(sh *BodyShorthand, args []string, pathParamCount int, cmd *cobra.Command, bodySchema *base.SchemaProxy) ([]byte, error) {
 	body := map[string]interface{}{}
 
 	shorthandArgs := args[pathParamCount:]
@@ -372,16 +405,42 @@ func assembleBody(sh *BodyShorthand, args []string, pathParamCount int, cmd *cob
 	}
 
 	for _, fm := range sh.Flags {
-		val, _ := cmd.Flags().GetString(fm.FlagName)
+		flag := cmd.Flags().Lookup(fm.FlagName)
+		if flag == nil {
+			continue
+		}
+		val := flag.Value.String()
 		if val == "" {
 			continue
 		}
-		if fm.IsBool {
-			body[fm.FieldPath] = (val == "true")
+		fieldType, err := shorthandFieldType(bodySchema, fm.FieldPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid shorthand --%s: %w", fm.FlagName, err)
+		}
+		if fieldType == "boolean" {
+			parsed, err := strconv.ParseBool(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --%s value %q: expected a boolean", fm.FlagName, val)
+			}
+			body[fm.FieldPath] = parsed
 		} else {
 			body[fm.FieldPath] = val
 		}
 	}
 
 	return json.Marshal(body)
+}
+
+// shorthandFieldType resolves a promoted flag against the operation's request
+// body schema. The shorthand registry chooses which fields get a convenient
+// CLI flag; the OpenAPI document remains authoritative for their JSON types.
+func shorthandFieldType(bodySchema *base.SchemaProxy, fieldPath string) (string, error) {
+	if bodySchema == nil {
+		return "string", nil
+	}
+	fieldSchema, err := resolveField(bodySchema, fieldPath)
+	if err != nil {
+		return "", fmt.Errorf("field %q is not present in the request schema: %w", fieldPath, err)
+	}
+	return schemaType(fieldSchema), nil
 }

--- a/internal/openapi/body_shorthand_test.go
+++ b/internal/openapi/body_shorthand_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pb33f/libopenapi"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +27,40 @@ func newMockCmd(flags map[string]string) *cobra.Command {
 	return cmd
 }
 
+func operationFromRealSpec(t *testing.T, operationID string) *operationInfo {
+	t.Helper()
+	ops := operationsFromRealSpec(t)
+	if op, ok := ops[operationID]; ok {
+		return op
+	}
+	t.Fatalf("operation %q not found in spec", operationID)
+	return nil
+}
+
+func operationsFromRealSpec(t *testing.T) map[string]*operationInfo {
+	t.Helper()
+	doc, err := libopenapi.NewDocument(loadSpec(t))
+	if err != nil {
+		t.Fatalf("parsing spec: %v", err)
+	}
+	model, err := doc.BuildV3Model()
+	if err != nil {
+		t.Fatalf("building spec model: %v", err)
+	}
+
+	groups := map[string][]*operationInfo{}
+	for pair := model.Model.Paths.PathItems.First(); pair != nil; pair = pair.Next() {
+		extractOperations(pair.Key(), pair.Value(), groups)
+	}
+	opsByID := map[string]*operationInfo{}
+	for _, ops := range groups {
+		for _, op := range ops {
+			opsByID[op.OperationID] = op
+		}
+	}
+	return opsByID
+}
+
 func TestAssembleBody_StringTransform(t *testing.T) {
 	sh := &BodyShorthand{
 		Args: []ArgMapping{
@@ -33,7 +68,7 @@ func TestAssembleBody_StringTransform(t *testing.T) {
 		},
 	}
 	cmd := newMockCmd(nil)
-	body, err := assembleBody(sh, []string{"How do I add a format?"}, 0, cmd)
+	body, err := assembleBody(sh, []string{"How do I add a format?"}, 0, cmd, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -52,7 +87,7 @@ func TestAssembleBody_EmailListTransform(t *testing.T) {
 		},
 	}
 	cmd := newMockCmd(nil)
-	body, err := assembleBody(sh, []string{"a@co.com,b@co.com,c@co.com"}, 0, cmd)
+	body, err := assembleBody(sh, []string{"a@co.com,b@co.com,c@co.com"}, 0, cmd, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,7 +118,7 @@ func TestAssembleBody_EmailListTrimsWhitespace(t *testing.T) {
 		},
 	}
 	cmd := newMockCmd(nil)
-	body, err := assembleBody(sh, []string{"a@co.com, b@co.com , c@co.com"}, 0, cmd)
+	body, err := assembleBody(sh, []string{"a@co.com, b@co.com , c@co.com"}, 0, cmd, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -108,7 +143,7 @@ func TestAssembleBody_WithPathParams(t *testing.T) {
 	}
 	cmd := newMockCmd(nil)
 	// args[0] is a path param, args[1] is the shorthand arg
-	body, err := assembleBody(sh, []string{"doc-123", "user-456"}, 1, cmd)
+	body, err := assembleBody(sh, []string{"doc-123", "user-456"}, 1, cmd, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +169,7 @@ func TestAssembleBody_WithPromotedFlags(t *testing.T) {
 		},
 	}
 	cmd := newMockCmd(map[string]string{"color": "#ff0000", "description": ""})
-	body, err := assembleBody(sh, []string{"my-label"}, 0, cmd)
+	body, err := assembleBody(sh, []string{"my-label"}, 0, cmd, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -155,11 +190,12 @@ func TestAssembleBody_WithPromotedFlags(t *testing.T) {
 func TestAssembleBody_BoolFlag(t *testing.T) {
 	sh := &BodyShorthand{
 		Flags: []FlagMapping{
-			{FlagName: "run-query", FieldPath: "runQuery", IsBool: true},
+			{FlagName: "run-query", FieldPath: "runQuery"},
 		},
 	}
 	cmd := newMockCmd(map[string]string{"run-query": "true"})
-	body, err := assembleBody(sh, nil, 0, cmd)
+	op := operationFromRealSpec(t, "aiGenerateQuery")
+	body, err := assembleBody(sh, nil, 0, cmd, op.BodySchema)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -168,6 +204,48 @@ func TestAssembleBody_BoolFlag(t *testing.T) {
 	json.Unmarshal(body, &parsed)
 	if parsed["runQuery"] != true {
 		t.Errorf("runQuery = %v, want true", parsed["runQuery"])
+	}
+}
+
+func TestAssembleBody_InvalidBoolFlag(t *testing.T) {
+	sh := &BodyShorthand{
+		Flags: []FlagMapping{
+			{FlagName: "workbook-url", FieldPath: "workbookUrl"},
+		},
+	}
+	cmd := newMockCmd(map[string]string{"workbook-url": "not-a-bool"})
+	op := operationFromRealSpec(t, "aiGenerateQuery")
+	_, err := assembleBody(sh, nil, 0, cmd, op.BodySchema)
+	if err == nil {
+		t.Fatal("expected invalid boolean error")
+	}
+	if !strings.Contains(err.Error(), `invalid --workbook-url value "not-a-bool": expected a boolean`) {
+		t.Fatalf("error = %q, want invalid --workbook-url boolean error", err)
+	}
+}
+
+func TestShorthand_BooleanFlagTypesComeFromSpec(t *testing.T) {
+	tests := []struct {
+		operationID string
+		fieldPath   string
+	}{
+		{operationID: "aiGenerateQuery", fieldPath: "runQuery"},
+		{operationID: "aiGenerateQuery", fieldPath: "workbookUrl"},
+		{operationID: "aiJobSubmit", fieldPath: "progressWebhookEnabled"},
+		{operationID: "documentsUpdate", fieldPath: "clearExistingDraft"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operationID+"/"+tt.fieldPath, func(t *testing.T) {
+			op := operationFromRealSpec(t, tt.operationID)
+			got, err := shorthandFieldType(op.BodySchema, tt.fieldPath)
+			if err != nil {
+				t.Fatalf("resolving field type: %v", err)
+			}
+			if got != "boolean" {
+				t.Fatalf("field type = %q, want boolean", got)
+			}
+		})
 	}
 }
 
@@ -314,16 +392,18 @@ func TestShorthand_AiGenerateQuery_WithFlags(t *testing.T) {
 	var captured APIRequest
 	exec := func(req APIRequest) error { captured = req; return nil }
 
-	op := &operationInfo{
-		Tag:         "AI",
-		OperationID: "aiGenerateQuery",
-		Method:      "POST",
-		Path:        "/api/v1/ai/generate-query",
-		HasBody:     true,
-	}
+	op := operationFromRealSpec(t, "aiGenerateQuery")
 
 	cmd := buildCommand(op, exec)
-	cmd.SetArgs([]string{"model-uuid", "Revenue query", "--run-query", "false", "--current-topic-name", "orders"})
+	if got := cmd.Flags().Lookup("workbook-url").Value.Type(); got != "boolean" {
+		t.Fatalf("--workbook-url help type = %q, want boolean", got)
+	}
+	cmd.SetArgs([]string{
+		"model-uuid", "Revenue query",
+		"--run-query", "false",
+		"--workbook-url", "true",
+		"--current-topic-name", "orders",
+	})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -332,6 +412,9 @@ func TestShorthand_AiGenerateQuery_WithFlags(t *testing.T) {
 	json.Unmarshal(captured.Body, &body)
 	if body["runQuery"] != false {
 		t.Errorf("runQuery = %v, want false", body["runQuery"])
+	}
+	if body["workbookUrl"] != true {
+		t.Errorf("workbookUrl = %v, want true", body["workbookUrl"])
 	}
 	if body["currentTopicName"] != "orders" {
 		t.Errorf("currentTopicName = %v, want orders", body["currentTopicName"])
@@ -483,14 +566,7 @@ func TestShorthand_DocumentsUpdate_FlagsOnly(t *testing.T) {
 	var captured APIRequest
 	exec := func(req APIRequest) error { captured = req; return nil }
 
-	op := &operationInfo{
-		Tag:         "Documents",
-		OperationID: "documentsUpdate",
-		Method:      "PATCH",
-		Path:        "/api/v1/documents/{identifier}",
-		PathParams:  []paramInfo{{Name: "identifier", In: "path"}},
-		HasBody:     true,
-	}
+	op := operationFromRealSpec(t, "documentsUpdate")
 
 	cmd := buildCommand(op, exec)
 	cmd.SetArgs([]string{"doc-123", "--name", "New Name", "--clear-existing-draft", "true"})
@@ -904,6 +980,27 @@ func TestShorthand_AllEntriesBuildSuccessfully(t *testing.T) {
 		for _, f := range sh.Flags {
 			if cmd.Flags().Lookup(f.FlagName) == nil {
 				t.Errorf("%s: missing promoted flag --%s", opID, f.FlagName)
+			}
+		}
+	}
+}
+
+func TestShorthand_AllMappedFieldsExistInSpec(t *testing.T) {
+	ops := operationsFromRealSpec(t)
+	for opID, sh := range bodyShorthands {
+		op, ok := ops[opID]
+		if !ok {
+			t.Errorf("%s: operation is not present in the OpenAPI spec", opID)
+			continue
+		}
+		for _, arg := range sh.Args {
+			if _, err := resolveField(op.BodySchema, arg.FieldPath); err != nil {
+				t.Errorf("%s: positional field %q is not present in the request schema: %v", opID, arg.FieldPath, err)
+			}
+		}
+		for _, flag := range sh.Flags {
+			if _, err := shorthandFieldType(op.BodySchema, flag.FieldPath); err != nil {
+				t.Errorf("%s: flag --%s: %v", opID, flag.FlagName, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- derive promoted shorthand flag types from each operation request schema
- serialize `workbookUrl` and other boolean shorthand fields as JSON booleans while preserving explicit `--flag true|false` syntax
- show schema types in command help and reject invalid boolean values locally
- verify every shorthand mapping against the checked-in OpenAPI spec to prevent drift

## Testing

- `go test ./...`
- `go vet ./...`

Fixes #58