### PR TITLE
docs(help): stop the help surface from lying about --body, args, and v2 round-trips

### DIFF
--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -129,8 +129,11 @@ name a leaf without knowing the container shape:
 - Use "omni ai generate-query" to answer data questions — it picks fields and filters for you.
 - Set a user's attribute values: omni users set-attributes <user-id> --attr region=us-east
 - Path parameters are positional args: omni dashboards download <dashboard-id>
-  Each command's --help has an "Arguments:" section saying what every positional
-  means — some take a NAME, not a UUID (e.g. models merge-branch <branch-name>).
+  Generated API commands describe every positional in an "Arguments:" section in
+  their --help. Read it — some positionals take a NAME, not a UUID:
+    omni models merge-branch <model-id> <branch-name>   # 2nd arg is the NAME
+  The few hand-written commands (config *, agent-help, models create-branch,
+  users set-attributes) have no Arguments section — read their Usage line.
 - Query parameters are flags: omni models list --pagesize 10
 - Promoted field flags (e.g. --name, --summary) are mutually exclusive with
   --body: using both is an error, not a merge. Pick one and put every field there.

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -39,21 +39,42 @@ Set OMNI_API_TOKEN env var, or run: omni config init
   omni dashboards download <dashboard-id>
 
 ### Read or edit a document (v2)
-  # Read live state. The response is a valid draft PATCH body (round-trip design).
+  # Read live state.
   omni documents v2-get <identifier> --compact
 
   # Edit metadata with flags (no JSON needed), then publish the draft:
   omni documents v2-patch-draft <identifier> --name "Q3 Revenue" --summary "rename"
   omni documents v2-publish-draft <identifier>
 
-  # Edit content by round-tripping the full state through a file:
+  # Edit content. A v2-get response is a STARTING POINT for a PATCH body, not a
+  # guaranteed round-trip — read the caveats below before doing this:
   omni documents v2-get <identifier> > doc.json
   # ...edit doc.json (containers, controls, queryPresentations, settings)...
   omni documents v2-patch-draft <identifier> --body - < doc.json
+  omni documents v2-get <identifier> --compact   # verify BEFORE publishing
   omni documents v2-publish-draft <identifier>
 
   # Create a brand-new document (published immediately):
   omni documents v2-create <model-id> "My Dashboard"
+
+#### v2 PATCH caveats (do not skip — these cost real debugging time)
+- A v2-get response is NOT accepted verbatim as a PATCH body. It carries
+  read-only/derived keys the validator rejects, so expect to strip fields and
+  retry: "hidden" on filter configs, and per-tile keys such as calculations,
+  column_totals, fill_fields, pivots, row_totals, userEditedSQL, chartType,
+  visType, fields, config. Read the error, drop the named key, retry.
+- Send only the sections you are changing. Patch the smallest subtree that
+  expresses the edit rather than replaying the whole document.
+- Tiles (queryPresentations.data.<n>) and controls (controls.data.<id>) are
+  REPLACE-WHOLE. Send the complete object for the entry you touch; a partial
+  entry is rejected or silently loses the omitted fields.
+- queryPresentations.order must enumerate EVERY presentation key, not just
+  the ones you moved or added.
+- A 200 does not mean the content survived. A successful patch can null out
+  visConfig on tiles you did not intend to touch. Always re-read with v2-get
+  and check the tiles you care about before v2-publish-draft.
+- Use "omni documents v2-patch-draft --schema --field <path>" to learn the
+  accepted shape of a subtree instead of guessing from the v2-get output.
 
 ### Search Omni documentation
   omni ai search-omni-docs --body '{"query":"how do I..."}'
@@ -108,7 +129,11 @@ name a leaf without knowing the container shape:
 - Use "omni ai generate-query" to answer data questions — it picks fields and filters for you.
 - Set a user's attribute values: omni users set-attributes <user-id> --attr region=us-east
 - Path parameters are positional args: omni dashboards download <dashboard-id>
+  Each command's --help has an "Arguments:" section saying what every positional
+  means — some take a NAME, not a UUID (e.g. models merge-branch <branch-name>).
 - Query parameters are flags: omni models list --pagesize 10
+- Promoted field flags (e.g. --name, --summary) are mutually exclusive with
+  --body: using both is an error, not a merge. Pick one and put every field there.
 - Run "omni <group> --help" to see all commands in a group.
 - Run "omni <group> <command> --help" to see flags for a specific command.
 `

--- a/internal/openapi/body_shorthand.go
+++ b/internal/openapi/body_shorthand.go
@@ -233,9 +233,18 @@ var bodyShorthands = map[string]*BodyShorthand{
 
 	// v2 documents. Metadata fields are promoted to flags; the heavy nested
 	// content (containers / controls / queryPresentations / settings) stays
-	// on --body/stdin. Because a v2-get response is a valid draft PATCH body,
-	// content round-trips cleanly: v2-get <id> > doc.json, edit, then
-	// v2-patch-draft <id> --body - < doc.json and v2-publish-draft <id>.
+	// on --body/stdin.
+	//
+	// A v2-get response is a starting point for a draft PATCH body, NOT a
+	// guaranteed clean round-trip: the response carries read-only/derived keys
+	// the PATCH validator rejects (e.g. `hidden` on filter configs, and
+	// per-tile keys such as calculations / column_totals / fill_fields /
+	// pivots / row_totals / userEditedSQL / chartType / visType / fields /
+	// config), so expect to strip fields until the PATCH is accepted. Tiles
+	// (queryPresentations.data.<n>) and controls (controls.data.<id>) are
+	// replace-whole — send the complete object, never a partial — and
+	// queryPresentations.order must enumerate every presentation key. A 200 is
+	// not proof the content survived; re-read with v2-get and check visConfig.
 	"documentsV2Create": {
 		Args: []ArgMapping{
 			{Name: "model-id", FieldPath: "modelId", Description: "UUID of the model the document is built on", Transform: "string"},
@@ -270,6 +279,11 @@ var bodyShorthands = map[string]*BodyShorthand{
 	},
 }
 
+// bodyExclusiveSuffix is appended to every promoted flag's help text. Promoted
+// flags assemble a JSON body, so they are rejected at runtime when --body /
+// --json-body is also supplied (see applyBodyShorthand).
+const bodyExclusiveSuffix = " (cannot be combined with --body)"
+
 // GetBodyShorthand returns the shorthand for an operation, or nil if none exists.
 func GetBodyShorthand(operationID string) *BodyShorthand {
 	return bodyShorthands[operationID]
@@ -287,13 +301,24 @@ func applyBodyShorthand(cmd *cobra.Command, op *operationInfo, sh *BodyShorthand
 
 	// Keep promoted flags value-taking so callers can use an explicit value such
 	// as `--run-query false`, but show their schema type in help. assembleBody
-	// uses the same request schema to encode the JSON value.
+	// uses the same request schema to encode the JSON value. The --body
+	// exclusivity note is appended here, for every flag regardless of type,
+	// rather than baked into each Description literal so the help text can't
+	// drift from the runtime check below.
 	for _, f := range sh.Flags {
 		fieldType, err := shorthandFieldType(op.BodySchema, f.FieldPath)
 		if err != nil {
 			fieldType = "string"
 		}
-		cmd.Flags().Var(&shorthandFlagValue{value: f.Default, typeName: fieldType}, f.FlagName, f.Description)
+		cmd.Flags().Var(&shorthandFlagValue{value: f.Default, typeName: fieldType}, f.FlagName, f.Description+bodyExclusiveSuffix)
+	}
+
+	// Say the same thing from the other side: --body's own description on a
+	// shorthand-bearing command warns that promoted flags can't be mixed in.
+	if len(sh.Flags) > 0 {
+		if bodyFlag := cmd.Flags().Lookup("body"); bodyFlag != nil {
+			bodyFlag.Usage += "; cannot be combined with this command's promoted field flags — put those fields in the JSON instead"
+		}
 	}
 
 	// Replace the Args validator with a flexible one

--- a/internal/openapi/body_shorthand_test.go
+++ b/internal/openapi/body_shorthand_test.go
@@ -900,6 +900,77 @@ func TestShorthand_HelpContainsExamples(t *testing.T) {
 	}
 }
 
+// Promoted flags are rejected at runtime when --body is also given (see
+// TestShorthand_BodyWithShorthandFlagErrors). The help text has to say so, from
+// both sides: on every promoted flag, and on --body itself.
+func TestShorthand_PromotedFlagsDeclareBodyExclusivity(t *testing.T) {
+	exec := func(req APIRequest) error { return nil }
+
+	op := &operationInfo{
+		Tag:         "Documents",
+		OperationID: "documentsV2PatchDraft",
+		Method:      "PATCH",
+		Path:        "/api/v2/documents/{identifier}/draft",
+		PathParams:  []paramInfo{{Name: "identifier", In: "path"}},
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, exec)
+	sh := GetBodyShorthand(op.OperationID)
+
+	for _, f := range sh.Flags {
+		flag := cmd.Flags().Lookup(f.FlagName)
+		if flag == nil {
+			t.Fatalf("missing promoted flag --%s", f.FlagName)
+		}
+		if !strings.HasSuffix(flag.Usage, "(cannot be combined with --body)") {
+			t.Errorf("--%s usage = %q, want the --body exclusivity note", f.FlagName, flag.Usage)
+		}
+		if !strings.Contains(flag.Usage, f.Description) {
+			t.Errorf("--%s usage = %q, want it to keep its description", f.FlagName, flag.Usage)
+		}
+	}
+
+	bodyFlag := cmd.Flags().Lookup("body")
+	if bodyFlag == nil {
+		t.Fatal("missing --body flag")
+	}
+	if !strings.Contains(bodyFlag.Usage, "cannot be combined") {
+		t.Errorf("--body usage = %q, want it to mention the promoted-flag conflict", bodyFlag.Usage)
+	}
+}
+
+// Every promoted flag on every registered shorthand carries the note, and
+// commands with no promoted flags leave --body's description alone.
+func TestShorthand_BodyExclusivityNoteEverywhere(t *testing.T) {
+	for opID, sh := range bodyShorthands {
+		op := &operationInfo{
+			Tag:         "test",
+			OperationID: opID,
+			Method:      "POST",
+			Path:        "/test",
+			HasBody:     true,
+		}
+		cmd := buildCommand(op, func(req APIRequest) error { return nil })
+
+		for _, f := range sh.Flags {
+			flag := cmd.Flags().Lookup(f.FlagName)
+			if flag == nil {
+				t.Errorf("%s: missing promoted flag --%s", opID, f.FlagName)
+				continue
+			}
+			if !strings.HasSuffix(flag.Usage, bodyExclusiveSuffix) {
+				t.Errorf("%s: --%s usage = %q, want suffix %q", opID, f.FlagName, flag.Usage, bodyExclusiveSuffix)
+			}
+		}
+
+		bodyUsage := cmd.Flags().Lookup("body").Usage
+		if len(sh.Flags) == 0 && strings.Contains(bodyUsage, "cannot be combined") {
+			t.Errorf("%s: --body usage = %q, want no conflict note (no promoted flags)", opID, bodyUsage)
+		}
+	}
+}
+
 func TestShorthand_UseStringContainsArgs(t *testing.T) {
 	exec := func(req APIRequest) error { return nil }
 

--- a/internal/openapi/body_shorthand_test.go
+++ b/internal/openapi/body_shorthand_test.go
@@ -906,14 +906,9 @@ func TestShorthand_HelpContainsExamples(t *testing.T) {
 func TestShorthand_PromotedFlagsDeclareBodyExclusivity(t *testing.T) {
 	exec := func(req APIRequest) error { return nil }
 
-	op := &operationInfo{
-		Tag:         "Documents",
-		OperationID: "documentsV2PatchDraft",
-		Method:      "PATCH",
-		Path:        "/api/v2/documents/{identifier}/draft",
-		PathParams:  []paramInfo{{Name: "identifier", In: "path"}},
-		HasBody:     true,
-	}
+	// Built from the real spec so promoted flags get their schema-derived
+	// types, matching what a user actually sees in --help.
+	op := operationFromRealSpec(t, "documentsV2PatchDraft")
 
 	cmd := buildCommand(op, exec)
 	sh := GetBodyShorthand(op.OperationID)
@@ -942,14 +937,20 @@ func TestShorthand_PromotedFlagsDeclareBodyExclusivity(t *testing.T) {
 
 // Every promoted flag on every registered shorthand carries the note, and
 // commands with no promoted flags leave --body's description alone.
+//
+// Flag types come from the request schema, so this walks the real spec and
+// asserts the note lands regardless of the type Cobra ends up printing —
+// including the boolean-typed flags, which are registered through the same
+// custom flag.Value as the string ones.
 func TestShorthand_BodyExclusivityNoteEverywhere(t *testing.T) {
+	ops := operationsFromRealSpec(t)
+	sawBooleanFlag := false
+
 	for opID, sh := range bodyShorthands {
-		op := &operationInfo{
-			Tag:         "test",
-			OperationID: opID,
-			Method:      "POST",
-			Path:        "/test",
-			HasBody:     true,
+		op, ok := ops[opID]
+		if !ok {
+			t.Errorf("%s: operation is not present in the OpenAPI spec", opID)
+			continue
 		}
 		cmd := buildCommand(op, func(req APIRequest) error { return nil })
 
@@ -959,8 +960,15 @@ func TestShorthand_BodyExclusivityNoteEverywhere(t *testing.T) {
 				t.Errorf("%s: missing promoted flag --%s", opID, f.FlagName)
 				continue
 			}
+			if flag.Value.Type() == "boolean" {
+				sawBooleanFlag = true
+			}
 			if !strings.HasSuffix(flag.Usage, bodyExclusiveSuffix) {
-				t.Errorf("%s: --%s usage = %q, want suffix %q", opID, f.FlagName, flag.Usage, bodyExclusiveSuffix)
+				t.Errorf("%s: --%s (type %s) usage = %q, want suffix %q",
+					opID, f.FlagName, flag.Value.Type(), flag.Usage, bodyExclusiveSuffix)
+			}
+			if !strings.Contains(flag.Usage, f.Description) {
+				t.Errorf("%s: --%s usage = %q, want it to keep its description", opID, f.FlagName, flag.Usage)
 			}
 		}
 
@@ -968,6 +976,12 @@ func TestShorthand_BodyExclusivityNoteEverywhere(t *testing.T) {
 		if len(sh.Flags) == 0 && strings.Contains(bodyUsage, "cannot be combined") {
 			t.Errorf("%s: --body usage = %q, want no conflict note (no promoted flags)", opID, bodyUsage)
 		}
+	}
+
+	// Guard against this test silently degenerating into a string-only check
+	// if schema-derived typing ever stops resolving.
+	if !sawBooleanFlag {
+		t.Error("expected at least one boolean-typed promoted flag (e.g. --run-query); schema typing may have regressed")
 	}
 }
 

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -267,8 +267,19 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	}
 
 	// Apply body shorthand if one exists for this operation
-	if sh := GetBodyShorthand(op.OperationID); sh != nil {
+	sh := GetBodyShorthand(op.OperationID)
+	if sh != nil {
 		applyBodyShorthand(cmd, op, sh)
+	}
+
+	// Describe the positional args in the long help. Cobra's usage line only
+	// shows the placeholders, so without this the spec's param descriptions
+	// (e.g. "branch name", not "branch UUID") never reach the reader.
+	if args := argumentsHelp(op, sh); args != "" {
+		if cmd.Long == "" {
+			cmd.Long = short
+		}
+		cmd.Long = strings.TrimRight(cmd.Long, "\n") + "\n\n" + args
 	}
 
 	// Add the --schema discovery flag last, wrapping arg validation and RunE so
@@ -307,6 +318,53 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	}
 
 	return cmd
+}
+
+// argumentsHelp renders an "Arguments:" block listing every positional the
+// command accepts — path params first (in URL order), then any body-shorthand
+// args — with the description the spec gives for each. Returns "" when the
+// command takes no positionals.
+func argumentsHelp(op *operationInfo, sh *BodyShorthand) string {
+	type argLine struct{ name, desc string }
+	var lines []argLine
+
+	for _, p := range op.PathParams {
+		lines = append(lines, argLine{"<" + slugify(p.Name) + ">", firstLine(p.Description)})
+	}
+	if sh != nil {
+		for _, a := range sh.Args {
+			lines = append(lines, argLine{"<" + a.Name + ">", firstLine(a.Description)})
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	width := 0
+	for _, l := range lines {
+		if len(l.name) > width {
+			width = len(l.name)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("Arguments:")
+	for _, l := range lines {
+		b.WriteString("\n  " + l.name)
+		if l.desc != "" {
+			b.WriteString(strings.Repeat(" ", width-len(l.name)) + "  " + l.desc)
+		}
+	}
+	return b.String()
+}
+
+// firstLine keeps the Arguments block to one line per arg.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
 }
 
 // schemaRequested reports whether the --schema discovery flag is set.

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/spf13/cobra"
 )
 
 // ---------------------------------------------------------------------------
@@ -636,5 +637,125 @@ func TestSpecCoverage(t *testing.T) {
 
 	if len(uncovered) > 0 {
 		t.Errorf("%d/%d operations uncovered", len(uncovered), totalOps)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Arguments help section tests
+//
+// Cobra's usage line only shows placeholders like "<branchname>", which is how
+// an agent ends up passing a branch UUID to a command that wants a branch NAME.
+// buildCommand therefore renders the spec's param descriptions into an
+// "Arguments:" block in the command's long help.
+// ---------------------------------------------------------------------------
+
+func TestBuildCommand_ArgumentsSection(t *testing.T) {
+	op := &operationInfo{
+		Tag:         "Models",
+		OperationID: "modelsMergeBranch",
+		Summary:     "Merge branch",
+		Method:      "POST",
+		Path:        "/api/v1/models/{modelId}/branch/{branchName}/merge",
+		PathParams: []paramInfo{
+			{Name: "modelId", In: "path", Description: "Model UUID"},
+			{Name: "branchName", In: "path", Description: "Branch name"},
+		},
+	}
+
+	cmd := buildCommand(op, func(req APIRequest) error { return nil })
+	if !strings.Contains(cmd.Long, "Arguments:") {
+		t.Fatalf("Long = %q, expected an Arguments section", cmd.Long)
+	}
+	for _, want := range []string{"<modelid>", "Model UUID", "<branchname>", "Branch name"} {
+		if !strings.Contains(cmd.Long, want) {
+			t.Errorf("Long = %q, expected it to contain %q", cmd.Long, want)
+		}
+	}
+	// With no Description on the operation, the Short still has to survive.
+	if !strings.Contains(cmd.Long, "Merge branch") {
+		t.Errorf("Long = %q, expected the summary to be preserved", cmd.Long)
+	}
+}
+
+// Shorthand positional args are part of the same positional list, so they
+// belong in the same block as the path params.
+func TestBuildCommand_ArgumentsSectionIncludesShorthandArgs(t *testing.T) {
+	op := &operationInfo{
+		Tag:         "AI",
+		OperationID: "aiGenerateQuery",
+		Method:      "POST",
+		Path:        "/api/v1/ai/generate-query",
+		HasBody:     true,
+	}
+
+	cmd := buildCommand(op, func(req APIRequest) error { return nil })
+	for _, want := range []string{"Arguments:", "<model-id>", "UUID of the shared model", "<prompt>", "natural language query prompt"} {
+		if !strings.Contains(cmd.Long, want) {
+			t.Errorf("Long = %q, expected it to contain %q", cmd.Long, want)
+		}
+	}
+}
+
+// Commands with no positionals must not grow an empty Arguments block.
+func TestBuildCommand_NoArgumentsSectionWithoutPositionals(t *testing.T) {
+	op := &operationInfo{
+		Tag:         "Models",
+		OperationID: "modelsList",
+		Summary:     "List models",
+		Method:      "GET",
+		Path:        "/api/v1/models",
+	}
+
+	cmd := buildCommand(op, func(req APIRequest) error { return nil })
+	if strings.Contains(cmd.Long, "Arguments:") {
+		t.Errorf("Long = %q, expected no Arguments section", cmd.Long)
+	}
+}
+
+// End-to-end against the real spec: the description the spec gives for a path
+// param has to reach the generated command's help.
+func TestGenerateCommands_ArgumentsSectionFromSpec(t *testing.T) {
+	specData := loadSpec(t)
+	cmds, err := GenerateCommands(specData, func(req APIRequest) error { return nil })
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+
+	var merge *cobra.Command
+	for _, tagCmd := range cmds {
+		if tagCmd.Use != "models" {
+			continue
+		}
+		for _, sub := range tagCmd.Commands() {
+			if sub.Name() == "merge-branch" {
+				merge = sub
+			}
+		}
+	}
+	if merge == nil {
+		t.Fatal("models merge-branch not found in generated commands")
+	}
+
+	// The second positional is a branch NAME, not a branch UUID — that
+	// distinction is exactly what the Arguments section exists to convey.
+	if !strings.Contains(merge.Long, "Arguments:") {
+		t.Fatalf("Long = %q, expected an Arguments section", merge.Long)
+	}
+	if !strings.Contains(merge.Long, "Branch name") {
+		t.Errorf("Long = %q, expected the spec's branchName description", merge.Long)
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Model UUID", "Model UUID"},
+		{"  padded  ", "padded"},
+		{"first line\nsecond line", "first line"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := firstLine(c.in); got != c.want {
+			t.Errorf("firstLine(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
Help/docs text only — no runtime changes. Fixes three help-surface defects from the agent-session cost audit, each of which made callers guess:

- **Promoted flags now say they can't combine with `--body`** — the note is stamped programmatically next to the runtime check, so help and enforcement can't drift.
- **Positional args now have descriptions** — generated commands render an `Arguments:` block from the spec (e.g. `models merge-branch` now says its 2nd arg is the branch *name*, not a UUID).
- **`agent-help` no longer claims v2 responses round-trip cleanly as PATCH bodies** — it documents the real contract instead (strip-and-retry, replace-whole tiles/controls, full `order`, verify after 200).

<details>
<summary>Details: examples, incident background, and verification</summary>

## 1. Shorthand flags vs `--body` (6 incidents)

`applyBodyShorthand` rejects `--summary` + `--body` at runtime ("cannot be combined with --body; include the field(s) in the JSON body instead"), but neither the promoted flags nor `--body` said so in `--help`. The note is now appended programmatically in `applyBodyShorthand` — one `bodyExclusiveSuffix` constant next to the check that enforces it — plus a mirror note on `--body`'s own usage for shorthand-bearing commands.

```
      --body string        request body as JSON string, or "-" for stdin (run with --schema to see its shape); cannot be combined with this command's promoted field flags — put those fields in the JSON instead
      --branch-id string   branch the new draft is created on (omit for the main workspace) (cannot be combined with --body)
      --name string        document name (cannot be combined with --body)
      --summary string     what this patch changes; written to the history audit trail (cannot be combined with --body)
```

## 2. Positional args had no descriptions

The spec describes every path param and the parser already captured it in `paramInfo.Description` — then dropped it. Consequences observed: `models merge-branch <modelid> <branchname>` takes the branch NAME as its second positional while sibling subcommands address branches by UUID, so an agent passed the UUID and got a bare 404; `models get-topic <modelid> <topicname>` was guessed as `--name`.

Generated commands now render an `Arguments:` block into their long help (path params in URL order, then body-shorthand positionals; skipped entirely when there are none):

```
$ omni models merge-branch --help
Merge branch

Arguments:
  <modelid>     Model UUID
  <branchname>  Branch name

Usage:
  omni models merge-branch <modelid> <branchname> [flags]
```

## 3. `agent-help` overstated the v2 round-trip

It said: "Read live state. The response is a valid draft PATCH body (round-trip design)." A confirmed 49-turn, 43,944-token incident disproved it. PATCHing a `v2-get` response back was rejected for `hidden` on a filter config, then for `calculations` / `column_totals` / `fill_fields` / `pivots` / `row_totals` / `userEditedSQL`, then for `chartType` / `visType` / `fields` / `config` — and one request that returned 200 silently wiped both tiles' `visConfig` to nulls.

The guide now documents the real contract: a `v2-get` response is a starting point, expect strip-and-retry; tiles (`queryPresentations.data.<n>`) and controls (`controls.data.<id>`) are replace-whole (send the complete object, never a partial); `queryPresentations.order` must enumerate every presentation key; and a 200 is not proof the content survived — re-read before publishing. The same over-claim in the `body_shorthand.go` comment block is fixed too.

## Verification

- `make build && make test` — all packages pass.
- New tests: promoted-flag exclusivity suffix (per-command and across all registered shorthands, built from the real spec so boolean-typed flags are actually exercised, including the negative case that flag-less shorthands leave `--body` alone), `Arguments:` section from a hand-built op, from a shorthand's positionals, absent when there are no positionals, and end-to-end against the real `api/openapi.json` asserting the spec's "Branch name" description reaches `models merge-branch --help`.
- Eyeballed `./omni models merge-branch --help`, `./omni documents v2-patch-draft --help`, `./omni models branch-dbt --help`, `./omni models list --help` (no stray empty block), and `./omni agent-help`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TwwKSAsAGPBToNb4iUe5s
