### PR TITLE
fix(flags): normalize flag names so spec naming drift stops breaking commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ After installing, restart your shell and try: `omni <TAB>`, `omni ai <TAB>`, `om
 
 The CLI embeds the OpenAPI spec (`api/openapi.json`) into the binary. At startup it parses the spec and generates cobra subcommands for every operation. Each API tag becomes a command group, path params become positional args, query params become flags, and request bodies are passed via `--body` or stdin.
 
+Flag names are always kebab-case, whatever the spec calls the parameter (`branchId` and `branch_id` both become `--branch-id`). Spelling is forgiving: case, dashes and underscores are ignored when matching, so `--branch-id`, `--branchId`, `--branch_id` and `--branchid` all set the same flag. `--help` shows the canonical form.
+
 Adding a new API endpoint requires no code changes — update `api/openapi.json` (or run `make sync-spec`) and rebuild.
 
 ## Auth

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ The CLI embeds the OpenAPI spec (`api/openapi.json`) into the binary. At startup
 
 Flag names are always kebab-case, whatever the spec calls the parameter (`branchId` and `branch_id` both become `--branch-id`). Spelling is forgiving: case, dashes and underscores are ignored when matching, so `--branch-id`, `--branchId`, `--branch_id` and `--branchid` all set the same flag. `--help` shows the canonical form.
 
+A query parameter whose name would collide with a global or built-in flag (`--token`, `--base-url`, `--body`, `--schema`, ...) is registered with a `param-` prefix instead — a spec parameter named `baseUrl` becomes `--param-base-url`, so `--base-url` keeps meaning the API endpoint. `--help` notes the rename, and the value is still sent under the spec's own parameter name.
+
 Adding a new API endpoint requires no code changes — update `api/openapi.json` (or run `make sync-spec`) and rebuild.
 
 ## Auth

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -108,7 +108,10 @@ name a leaf without knowing the container shape:
 - Use "omni ai generate-query" to answer data questions — it picks fields and filters for you.
 - Set a user's attribute values: omni users set-attributes <user-id> --attr region=us-east
 - Path parameters are positional args: omni dashboards download <dashboard-id>
-- Query parameters are flags: omni models list --pagesize 10
+- Query parameters are flags: omni models list --page-size 10
+- Flag names are kebab-case, and spelling is forgiving: case, dashes and
+  underscores are ignored, so --branch-id, --branchId, --branch_id and
+  --branchid all mean the same flag. --help always shows the canonical form.
 - Run "omni <group> --help" to see all commands in a group.
 - Run "omni <group> <command> --help" to see flags for a specific command.
 `

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -54,6 +54,12 @@ func main() {
 	root.PersistentFlags().Bool("compact", false, "compact JSON output (no indentation)")
 	root.PersistentFlags().StringP("format", "o", "", "output format: json, human, auto (default auto: human on TTY, json when piped)")
 
+	// Flag names are matched ignoring case and dash/underscore placement, so
+	// --base-url, --baseurl and --base_url are the same flag on every command.
+	// Set before the subcommands are added: cobra propagates the function to
+	// children as they're attached, which covers the hand-written commands and
+	// the root's persistent flags as well as the generated ones.
+	root.SetGlobalNormalizationFunc(openapi.NormalizeFlagName)
 
 	// Hand-written commands (not from spec)
 	addConfigCommands(root)

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -47,12 +47,7 @@ func main() {
 		},
 	}
 
-	// Global flags
-	root.PersistentFlags().StringP("profile", "p", "", "config profile to use")
-	root.PersistentFlags().String("token", "", "API token (overrides profile/env)")
-	root.PersistentFlags().String("base-url", "", "API base URL (overrides profile)")
-	root.PersistentFlags().Bool("compact", false, "compact JSON output (no indentation)")
-	root.PersistentFlags().StringP("format", "o", "", "output format: json, human, auto (default auto: human on TTY, json when piped)")
+	addGlobalFlags(root)
 
 	// Flag names are matched ignoring case and dash/underscore placement, so
 	// --base-url, --baseurl and --base_url are the same flag on every command.
@@ -89,6 +84,21 @@ func main() {
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// addGlobalFlags registers the flags every command inherits.
+//
+// These names are reserved: openapi.IsReservedFlagName knows them, so a spec
+// query param that would otherwise shadow one (say a param named "baseUrl"
+// taking over --base-url) is registered under a --param- prefix instead.
+// TestGlobalFlagsAreReserved fails if a flag is added here without being
+// added there too.
+func addGlobalFlags(root *cobra.Command) {
+	root.PersistentFlags().StringP("profile", "p", "", "config profile to use")
+	root.PersistentFlags().String("token", "", "API token (overrides profile/env)")
+	root.PersistentFlags().String("base-url", "", "API base URL (overrides profile)")
+	root.PersistentFlags().Bool("compact", false, "compact JSON output (no indentation)")
+	root.PersistentFlags().StringP("format", "o", "", "output format: json, human, auto (default auto: human on TTY, json when piped)")
 }
 
 // executeAPICall is the callback invoked by generated commands to make the actual HTTP request.

--- a/cmd/omni/main_test.go
+++ b/cmd/omni/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/exploreomni/omni-cli/internal/openapi"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Every persistent flag on the root is inherited by every generated command,
+// so the command generator has to know not to hand its name to a spec query
+// param — otherwise the param's flag wins the slot (pflag's AddFlagSet skips a
+// persistent flag whose name is already taken) and, for --base-url or --token,
+// a query value would end up steering the request itself.
+//
+// This test is the drift guard: add a global flag without adding it to
+// reservedFlagKeys in internal/openapi/generate.go and it fails here.
+func TestGlobalFlagsAreReserved(t *testing.T) {
+	root := &cobra.Command{Use: "omni"}
+	addGlobalFlags(root)
+
+	seen := 0
+	root.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		seen++
+		if !openapi.IsReservedFlagName(f.Name) {
+			t.Errorf("global flag --%s is not in openapi's reserved flag names; a spec query param could shadow it", f.Name)
+		}
+	})
+	if seen == 0 {
+		t.Fatal("addGlobalFlags registered no flags")
+	}
+}
+
+// Cobra adds --help to every command, and it must stay a bool: a spec param
+// that took the name would leave cobra reading a string flag as a bool.
+func TestHelpFlagIsReserved(t *testing.T) {
+	if !openapi.IsReservedFlagName("help") {
+		t.Error("--help must be reserved")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/pb33f/libopenapi v0.34.4
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.41.0
@@ -30,7 +31,6 @@ require (
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/internal/openapi/body_shorthand.go
+++ b/internal/openapi/body_shorthand.go
@@ -288,6 +288,11 @@ func applyBodyShorthand(cmd *cobra.Command, op *operationInfo, sh *BodyShorthand
 	// Keep promoted flags value-taking so callers can use an explicit value such
 	// as `--run-query false`, but show their schema type in help. assembleBody
 	// uses the same request schema to encode the JSON value.
+	//
+	// FlagName is the canonical kebab-case spelling. Registration goes through
+	// the flag set's normalization function (installed in buildCommand), so
+	// --branchid / --branchId / --branch_id reach the same flag, as do the
+	// Lookup and Changed calls below.
 	for _, f := range sh.Flags {
 		fieldType, err := shorthandFieldType(op.BodySchema, f.FieldPath)
 		if err != nil {

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -173,9 +173,10 @@ func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*o
 func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	// Build the use string: operation-name <path-param1> <path-param2> ...
 	name := commandName(op)
+	queryFlags := resolveQueryFlags(op)
 	use := name
 	for _, p := range op.PathParams {
-		use += " <" + canonicalFlagName(p.Name) + ">"
+		use += " <" + canonicalName(p.Name) + ">"
 	}
 
 	short := op.Summary
@@ -205,19 +206,18 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 			//
 			// The flag name is the canonical kebab-case rendering of the param
 			// (branchId → --branch-id), but the query string must use the
-			// param's ORIGINAL spec spelling — query.Set takes q.Name, never
-			// the flag name. The server rejects "branch-id" where it expects
-			// "branchId", so these two must not be conflated. That holds for
-			// params queryFlagName had to rename too: --param-base-url still
-			// goes out as baseUrl=.
+			// param's ORIGINAL spec spelling — the server rejects "branch-id"
+			// where it expects "branchId", so the two must not be conflated.
+			// That holds for renamed params too: --param-base-url still goes
+			// out as baseUrl=.
 			query := url.Values{}
-			for _, q := range op.QueryParams {
-				val, err := cmd.Flags().GetString(queryFlagName(q.Name))
+			for _, qf := range queryFlags {
+				val, err := cmd.Flags().GetString(qf.Name)
 				if err != nil {
 					continue
 				}
 				if val != "" {
-					query.Set(q.Name, val)
+					query.Set(qf.Param.Name, val)
 				}
 			}
 			if len(query) > 0 {
@@ -267,22 +267,21 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	cmd.Flags().SetNormalizeFunc(NormalizeFlagName)
 
 	// Register query params as flags
-	for _, q := range op.QueryParams {
-		flagName := queryFlagName(q.Name)
-		desc := q.Description
-		if len(q.Enum) > 0 {
-			desc += fmt.Sprintf(" [%s]", strings.Join(q.Enum, ", "))
+	for _, qf := range queryFlags {
+		desc := qf.Param.Description
+		if len(qf.Param.Enum) > 0 {
+			desc += fmt.Sprintf(" [%s]", strings.Join(qf.Param.Enum, ", "))
 		}
-		if canonical := canonicalFlagName(q.Name); flagName != canonical {
+		if qf.Note != "" {
 			// Say so in --help, otherwise the flag looks like a typo next to
 			// the spec's parameter name.
 			desc = strings.TrimSpace(desc)
 			if desc != "" {
 				desc += " "
 			}
-			desc += fmt.Sprintf("(query param %q; renamed because --%s is a global CLI flag)", q.Name, canonical)
+			desc += qf.Note
 		}
-		cmd.Flags().String(flagName, "", desc)
+		cmd.Flags().String(qf.Name, "", desc)
 	}
 
 	// If the operation accepts a body, add --body and --json-body flags
@@ -367,7 +366,7 @@ func requestBodySchema(rb *v3.RequestBody) *base.SchemaProxy {
 func commandName(op *operationInfo) string {
 	if op.OperationID != "" {
 		// Strip the tag prefix if present (e.g., "models-list" from "ModelsList")
-		name := camelToKebab(op.OperationID)
+		name := canonicalName(op.OperationID)
 		tagPrefix := slugify(op.Tag) + "-"
 		name = strings.TrimPrefix(name, tagPrefix)
 		return name
@@ -392,18 +391,20 @@ func slugify(s string) string {
 	return s
 }
 
-// canonicalFlagName derives the CLI flag name for an OpenAPI parameter. The
-// spec names the same concept inconsistently across sibling operations —
-// "branchId" here, "branch_id" there — so camelCase is split into words before
-// slugifying and both spellings land on one flag:
+// canonicalName renders an OpenAPI identifier — a parameter name or an
+// operationId — as the kebab-case spelling the CLI uses for flags and command
+// names. The spec names the same concept inconsistently across sibling
+// operations ("branchId" here, "branch_id" there), so camelCase is split into
+// words before slugifying and both spellings land on one flag:
 //
 //	branchId    → branch-id
 //	branch_id   → branch-id
-//	pageSize    → page-size
 //	baseModelId → base-model-id
+//	ModelsList  → models-list
 //
-// Acronym runs stay intact: "modelURL" → "model-url", "URLPrefix" → "url-prefix".
-func canonicalFlagName(s string) string {
+// Acronym runs stay intact ("modelURL" → "model-url", "URLPrefix" →
+// "url-prefix"), including when pluralized ("apiURLs" → "api-urls").
+func canonicalName(s string) string {
 	var b strings.Builder
 	rs := []rune(s)
 	for i, r := range rs {
@@ -413,8 +414,9 @@ func canonicalFlagName(s string) string {
 			case !unicode.IsUpper(prev) && prev != '-' && prev != '_' && prev != ' ':
 				// lower/digit → upper: a word boundary ("pageSize").
 				b.WriteRune('-')
-			case unicode.IsUpper(prev) && i+1 < len(rs) && unicode.IsLower(rs[i+1]):
-				// End of an acronym run ("URLPrefix" → "URL-Prefix").
+			case unicode.IsUpper(prev) && i+1 < len(rs) && unicode.IsLower(rs[i+1]) && !isPluralS(rs, i+1):
+				// End of an acronym run ("URLPrefix" → "URL-Prefix"), unless the
+				// lowercase letter is just the acronym's plural ("URLs").
 				b.WriteRune('-')
 			}
 		}
@@ -423,19 +425,25 @@ func canonicalFlagName(s string) string {
 	return slugify(b.String())
 }
 
-// reservedFlagKeys are the flag names a generated query-param flag must not
-// claim, keyed by flagLookupKey. They are either the root command's persistent
-// flags (mirrored from addGlobalFlags in cmd/omni/main.go, kept in sync by
-// TestGlobalFlagsAreReserved) or flags a generated command registers for
-// itself.
+// isPluralS reports whether rs[i] is a lone trailing "s" pluralizing the
+// acronym before it, as in "URLs" or "IDsList" — as opposed to the start of a
+// following word, as in "JSONString".
+func isPluralS(rs []rune, i int) bool {
+	return rs[i] == 's' && (i+1 == len(rs) || !unicode.IsLower(rs[i+1]))
+}
+
+// globalFlagKeys are the flag names a generated query-param flag must never
+// claim, keyed by flagLookupKey: the root command's persistent flags (mirrored
+// from addGlobalFlags in cmd/omni/main.go, kept in sync by
+// TestGlobalFlagsAreReserved) plus the --help flag cobra adds everywhere.
 //
-// Shadowing one of these is not merely confusing, it is unsafe. pflag's
+// Shadowing one of these is not merely confusing, it is unsafe: pflag's
 // AddFlagSet skips a persistent flag whose name is already taken locally, so a
-// spec param named "baseUrl" would canonicalize to --base-url, take the slot
-// before the root's persistent flag merged in, and then resolveConfig's
-// GetString("base-url") would read the query param's value — one value both
-// filtering the request and choosing the host it is sent to.
-var reservedFlagKeys = map[string]string{
+// spec param named "baseUrl" would take the --base-url slot before the root's
+// persistent flag merged in, and resolveConfig's GetString("base-url") would
+// then read the query param's value — one value both filtering the request and
+// choosing the host it is sent to.
+var globalFlagKeys = map[string]string{
 	// Root persistent flags.
 	flagLookupKey("profile"):  "profile",
 	flagLookupKey("token"):    "token",
@@ -444,7 +452,13 @@ var reservedFlagKeys = map[string]string{
 	flagLookupKey("format"):   "format",
 	// Added by cobra on every command; must stay a bool.
 	flagLookupKey("help"): "help",
-	// Registered by buildCommand for body-taking operations.
+}
+
+// bodyFlagKeys are the flags buildCommand registers for itself, but only on
+// operations that take a request body. They are therefore reserved only on
+// those commands: a bodyless operation with a param named "field" keeps
+// --field, since nothing else on that command wants it.
+var bodyFlagKeys = map[string]string{
 	flagLookupKey("body"):      "body",
 	flagLookupKey("json-body"): "json-body",
 	flagLookupKey("schema"):    "schema",
@@ -454,28 +468,95 @@ var reservedFlagKeys = map[string]string{
 
 // IsReservedFlagName reports whether name — in any spelling, since matching
 // ignores case and dash/underscore placement — is claimed by a global or
-// built-in CLI flag.
+// built-in flag present on every command. Flags that only some commands
+// register (--body and friends) are handled per-operation by queryFlagName.
 func IsReservedFlagName(name string) bool {
-	_, ok := reservedFlagKeys[flagLookupKey(name)]
+	_, ok := globalFlagKeys[flagLookupKey(name)]
 	return ok
 }
 
-// queryFlagName is the flag name a query param is registered under: its
-// canonical kebab-case name, unless that would shadow a global or built-in
-// flag, in which case it gets a "param-" prefix (a spec param "baseUrl"
+// isReservedFlagName reports whether name is claimed on a command generated for
+// an operation with (or without) a request body.
+func isReservedFlagName(name string, hasBody bool) bool {
+	key := flagLookupKey(name)
+	if _, ok := globalFlagKeys[key]; ok {
+		return true
+	}
+	if !hasBody {
+		return false
+	}
+	_, ok := bodyFlagKeys[key]
+	return ok
+}
+
+// queryFlagName is the name a query param would be registered under on its own:
+// its canonical kebab-case name, unless that would shadow a flag the command
+// already has, in which case it gets a "param-" prefix (a spec param "baseUrl"
 // becomes --param-base-url and leaves --base-url meaning the API endpoint).
 //
 // Renaming rather than failing generation is deliberate: the spec is synced
 // from upstream and can introduce such a param at any time, and a hard failure
-// there would take the entire CLI down — every command, not just the affected
-// one. Renaming keeps the endpoint reachable and the global flag honest, and
-// buildCommand explains the rename in --help.
-func queryFlagName(param string) string {
-	name := canonicalFlagName(param)
-	if IsReservedFlagName(name) {
+// here would take the entire CLI down — every command, not just the affected
+// one.
+func queryFlagName(param string, hasBody bool) string {
+	name := canonicalName(param)
+	if isReservedFlagName(name, hasBody) {
 		return "param-" + name
 	}
 	return name
+}
+
+// queryFlag is a query param together with the flag name it is actually
+// registered under and, when that is not the param's canonical name, the
+// explanation buildCommand puts in --help.
+type queryFlag struct {
+	Param paramInfo
+	Name  string
+	Note  string
+}
+
+// resolveQueryFlags assigns every query param on an operation a flag name that
+// is free: the canonical kebab-case name, "param-"-prefixed if it would shadow
+// a global or built-in flag, then "-2", "-3"... if an earlier param on the same
+// operation already claimed it.
+//
+// Two params that canonicalize alike ("branchId" and "branch_id" on one
+// operation) are upstream spec drift, not a bug here, so the later one is
+// renamed rather than failing generation — which would exit the whole CLI.
+func resolveQueryFlags(op *operationInfo) []queryFlag {
+	claimed := map[string]bool{}
+	for key := range globalFlagKeys {
+		claimed[key] = true
+	}
+	if op.HasBody {
+		for key := range bodyFlagKeys {
+			claimed[key] = true
+		}
+	}
+
+	flags := make([]queryFlag, 0, len(op.QueryParams))
+	for _, q := range op.QueryParams {
+		canonical := canonicalName(q.Name)
+		base, note := canonical, ""
+		if isReservedFlagName(canonical, op.HasBody) {
+			base = "param-" + canonical
+			note = fmt.Sprintf("(query param %q; renamed because --%s is a global CLI flag)", q.Name, canonical)
+		}
+
+		name := base
+		if claimed[flagLookupKey(name)] {
+			if note == "" {
+				note = fmt.Sprintf("(query param %q; renamed because another param on this command also becomes --%s)", q.Name, base)
+			}
+			for n := 2; claimed[flagLookupKey(name)]; n++ {
+				name = fmt.Sprintf("%s-%d", base, n)
+			}
+		}
+
+		claimed[flagLookupKey(name)] = true
+		flags = append(flags, queryFlag{Param: q, Name: name, Note: note})
+	}
+	return flags
 }
 
 // flagLookupKey reduces a flag name to the form used for matching: lowercased,
@@ -494,14 +575,12 @@ func flagLookupKey(name string) string {
 
 // NormalizeFlagName is a pflag normalization function that resolves a flag name
 // the user typed to whichever flag is registered under an equivalent spelling,
-// ignoring case and dash/underscore placement. So --branchid, --branch_id and
+// ignoring case and dash/underscore placement, so --branchid, --branch_id and
 // --branchId all find a registered --branch-id.
 //
-// Names with no registered match are returned unchanged. That matters at
+// Names with no registered match are returned unchanged, which matters at
 // registration time: pflag rewrites Flag.Name to whatever this returns, so
-// returning the raw lookup key would make --help advertise "--branchid". Help
-// output keeps showing only the canonical kebab-case name; the alternates are
-// accepted silently.
+// returning the raw lookup key would make --help advertise "--branchid".
 func NormalizeFlagName(fs *pflag.FlagSet, name string) pflag.NormalizedName {
 	key := flagLookupKey(name)
 	match := ""
@@ -516,66 +595,39 @@ func NormalizeFlagName(fs *pflag.FlagSet, name string) pflag.NormalizedName {
 	return pflag.NormalizedName(name)
 }
 
-// validateFlagNames reports flags on a single generated command whose names
-// collide once normalized. Since lookups ignore case and separators, a command
-// declaring both "branchId" and "branch_id" would register two flags that are
-// indistinguishable — pflag panics on the second one — so fail generation with
-// a message that names the culprits instead.
-//
-// Query params are checked under their effective flag name, i.e. after
-// queryFlagName has moved any that would shadow a global or built-in flag out
-// of the way. Body-shorthand flags are hand-written in this repo, so a
-// collision there is a bug to fix rather than upstream drift to absorb: they
-// are reported, including against the reserved names.
+// validateFlagNames reports a body-shorthand flag that collides with another
+// flag on the same command once normalized, since lookups ignore case and
+// separators and pflag panics on a second flag with an equivalent name.
+// Shorthands are hand-written in this repo, so a collision there is a bug to
+// fix rather than upstream drift to absorb — query params, which come from the
+// synced spec, are renamed by resolveQueryFlags instead of reported.
 func validateFlagNames(op *operationInfo) error {
 	claimed := map[string]string{} // lookup key → description of the claimant
 
-	claim := func(flagName, source string) error {
-		key := flagLookupKey(flagName)
-		desc := fmt.Sprintf("--%s (%s)", flagName, source)
-		if prev, ok := claimed[key]; ok {
-			return fmt.Errorf("%s collides with %s: flag names are matched ignoring case, dashes and underscores, so both resolve to %q", desc, prev, key)
-		}
-		claimed[key] = desc
-		return nil
-	}
-
-	// Reserved names are spoken for on every command, whether or not this
-	// operation registers them itself.
-	for key, display := range reservedFlagKeys {
+	for key, display := range globalFlagKeys {
 		claimed[key] = fmt.Sprintf("--%s (global or built-in flag)", display)
 	}
-
-	for _, q := range op.QueryParams {
-		if err := claim(queryFlagName(q.Name), "query param "+q.Name); err != nil {
-			return err
+	if op.HasBody {
+		for key, display := range bodyFlagKeys {
+			claimed[key] = fmt.Sprintf("--%s (built-in flag)", display)
 		}
+	}
+	for _, qf := range resolveQueryFlags(op) {
+		claimed[flagLookupKey(qf.Name)] = fmt.Sprintf("--%s (query param %s)", qf.Name, qf.Param.Name)
 	}
 
 	if sh := GetBodyShorthand(op.OperationID); sh != nil {
 		for _, f := range sh.Flags {
-			if err := claim(f.FlagName, "body shorthand for "+op.OperationID); err != nil {
-				return err
+			key := flagLookupKey(f.FlagName)
+			desc := fmt.Sprintf("--%s (body shorthand for %s)", f.FlagName, op.OperationID)
+			if prev, ok := claimed[key]; ok {
+				return fmt.Errorf("%s collides with %s: flag names are matched ignoring case, dashes and underscores, so both resolve to %q", desc, prev, key)
 			}
+			claimed[key] = desc
 		}
 	}
 
 	return nil
-}
-
-func camelToKebab(s string) string {
-	var result strings.Builder
-	for i, r := range s {
-		if r >= 'A' && r <= 'Z' {
-			if i > 0 {
-				result.WriteByte('-')
-			}
-			result.WriteRune(r + 32) // toLower
-		} else {
-			result.WriteRune(r)
-		}
-	}
-	return result.String()
 }
 
 func schemaType(proxy *base.SchemaProxy) string {

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -469,41 +469,33 @@ var bodyFlagKeys = map[string]string{
 // IsReservedFlagName reports whether name — in any spelling, since matching
 // ignores case and dash/underscore placement — is claimed by a global or
 // built-in flag present on every command. Flags that only some commands
-// register (--body and friends) are handled per-operation by queryFlagName.
+// register (--body and friends) are handled per-operation by reservedFlagsFor.
 func IsReservedFlagName(name string) bool {
 	_, ok := globalFlagKeys[flagLookupKey(name)]
 	return ok
 }
 
-// isReservedFlagName reports whether name is claimed on a command generated for
-// an operation with (or without) a request body.
-func isReservedFlagName(name string, hasBody bool) bool {
-	key := flagLookupKey(name)
-	if _, ok := globalFlagKeys[key]; ok {
-		return true
+// reservedFlagsFor returns the flag names a generated command claims for
+// itself, keyed by flagLookupKey and mapped to the phrase --help uses when a
+// query param has to be renamed around one. Globals are reserved on every
+// command, --body and friends only on body-taking operations, and body
+// shorthands only on the operation they are written for.
+func reservedFlagsFor(op *operationInfo) map[string]string {
+	reserved := map[string]string{}
+	for key, name := range globalFlagKeys {
+		reserved[key] = fmt.Sprintf("--%s is a global CLI flag", name)
 	}
-	if !hasBody {
-		return false
+	if op.HasBody {
+		for key, name := range bodyFlagKeys {
+			reserved[key] = fmt.Sprintf("--%s is a built-in flag", name)
+		}
 	}
-	_, ok := bodyFlagKeys[key]
-	return ok
-}
-
-// queryFlagName is the name a query param would be registered under on its own:
-// its canonical kebab-case name, unless that would shadow a flag the command
-// already has, in which case it gets a "param-" prefix (a spec param "baseUrl"
-// becomes --param-base-url and leaves --base-url meaning the API endpoint).
-//
-// Renaming rather than failing generation is deliberate: the spec is synced
-// from upstream and can introduce such a param at any time, and a hard failure
-// here would take the entire CLI down — every command, not just the affected
-// one.
-func queryFlagName(param string, hasBody bool) string {
-	name := canonicalName(param)
-	if isReservedFlagName(name, hasBody) {
-		return "param-" + name
+	if sh := GetBodyShorthand(op.OperationID); sh != nil {
+		for _, f := range sh.Flags {
+			reserved[flagLookupKey(f.FlagName)] = fmt.Sprintf("--%s is a body shorthand flag", f.FlagName)
+		}
 	}
-	return name
+	return reserved
 }
 
 // queryFlag is a query param together with the flag name it is actually
@@ -516,31 +508,29 @@ type queryFlag struct {
 }
 
 // resolveQueryFlags assigns every query param on an operation a flag name that
-// is free: the canonical kebab-case name, "param-"-prefixed if it would shadow
-// a global or built-in flag, then "-2", "-3"... if an earlier param on the same
-// operation already claimed it.
+// is free: the canonical kebab-case name, "param-"-prefixed if the command
+// already claims that name (a global flag, --body and friends, a body
+// shorthand), then "-2", "-3"... if an earlier param on the same operation got
+// there first.
 //
-// Two params that canonicalize alike ("branchId" and "branch_id" on one
-// operation) are upstream spec drift, not a bug here, so the later one is
-// renamed rather than failing generation — which would exit the whole CLI.
+// Renaming rather than failing generation is deliberate: the spec is synced
+// from upstream and can introduce a colliding param at any time, and a hard
+// failure here would take the entire CLI down — every command, not just the
+// affected one.
 func resolveQueryFlags(op *operationInfo) []queryFlag {
+	reserved := reservedFlagsFor(op)
 	claimed := map[string]bool{}
-	for key := range globalFlagKeys {
+	for key := range reserved {
 		claimed[key] = true
-	}
-	if op.HasBody {
-		for key := range bodyFlagKeys {
-			claimed[key] = true
-		}
 	}
 
 	flags := make([]queryFlag, 0, len(op.QueryParams))
 	for _, q := range op.QueryParams {
 		canonical := canonicalName(q.Name)
 		base, note := canonical, ""
-		if isReservedFlagName(canonical, op.HasBody) {
+		if reason, ok := reserved[flagLookupKey(canonical)]; ok {
 			base = "param-" + canonical
-			note = fmt.Sprintf("(query param %q; renamed because --%s is a global CLI flag)", q.Name, canonical)
+			note = fmt.Sprintf("(query param %q; renamed because %s)", q.Name, reason)
 		}
 
 		name := base
@@ -595,15 +585,18 @@ func NormalizeFlagName(fs *pflag.FlagSet, name string) pflag.NormalizedName {
 	return pflag.NormalizedName(name)
 }
 
-// validateFlagNames reports a body-shorthand flag that collides with another
-// flag on the same command once normalized, since lookups ignore case and
-// separators and pflag panics on a second flag with an equivalent name.
-// Shorthands are hand-written in this repo, so a collision there is a bug to
-// fix rather than upstream drift to absorb — query params, which come from the
-// synced spec, are renamed by resolveQueryFlags instead of reported.
+// validateFlagNames reports a body-shorthand flag that cannot be registered:
+// one colliding with another shorthand on the same operation, or with a global
+// or built-in flag. Shorthands are hand-written in this repo, so that is a bug
+// to fix here — query params come from the synced spec and are renamed around
+// the shorthands by resolveQueryFlags instead.
 func validateFlagNames(op *operationInfo) error {
-	claimed := map[string]string{} // lookup key → description of the claimant
+	sh := GetBodyShorthand(op.OperationID)
+	if sh == nil {
+		return nil
+	}
 
+	claimed := map[string]string{} // lookup key → description of the claimant
 	for key, display := range globalFlagKeys {
 		claimed[key] = fmt.Sprintf("--%s (global or built-in flag)", display)
 	}
@@ -612,19 +605,14 @@ func validateFlagNames(op *operationInfo) error {
 			claimed[key] = fmt.Sprintf("--%s (built-in flag)", display)
 		}
 	}
-	for _, qf := range resolveQueryFlags(op) {
-		claimed[flagLookupKey(qf.Name)] = fmt.Sprintf("--%s (query param %s)", qf.Name, qf.Param.Name)
-	}
 
-	if sh := GetBodyShorthand(op.OperationID); sh != nil {
-		for _, f := range sh.Flags {
-			key := flagLookupKey(f.FlagName)
-			desc := fmt.Sprintf("--%s (body shorthand for %s)", f.FlagName, op.OperationID)
-			if prev, ok := claimed[key]; ok {
-				return fmt.Errorf("%s collides with %s: flag names are matched ignoring case, dashes and underscores, so both resolve to %q", desc, prev, key)
-			}
-			claimed[key] = desc
+	for _, f := range sh.Flags {
+		key := flagLookupKey(f.FlagName)
+		desc := fmt.Sprintf("--%s (body shorthand for %s)", f.FlagName, op.OperationID)
+		if prev, ok := claimed[key]; ok {
+			return fmt.Errorf("%s collides with %s: flag names are matched ignoring case, dashes and underscores, so both resolve to %q", desc, prev, key)
 		}
+		claimed[key] = desc
 	}
 
 	return nil

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -10,11 +10,13 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // APIRequest is passed to the executor callback when a generated command runs.
@@ -63,6 +65,9 @@ func GenerateCommands(specData []byte, exec Executor) ([]*cobra.Command, error) 
 		}
 
 		for _, op := range ops {
+			if err := validateFlagNames(op); err != nil {
+				return nil, fmt.Errorf("generating command %q: %w", slugify(tag)+" "+commandName(op), err)
+			}
 			tagCmd.AddCommand(buildCommand(op, exec))
 		}
 
@@ -170,7 +175,7 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	name := commandName(op)
 	use := name
 	for _, p := range op.PathParams {
-		use += " <" + slugify(p.Name) + ">"
+		use += " <" + canonicalFlagName(p.Name) + ">"
 	}
 
 	short := op.Summary
@@ -196,11 +201,16 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 				path = strings.Replace(path, "{"+p.Name+"}", url.PathEscape(args[i]), 1)
 			}
 
-			// Build query string from flags
+			// Build query string from flags.
+			//
+			// The flag name is the canonical kebab-case rendering of the param
+			// (branchId → --branch-id), but the query string must use the
+			// param's ORIGINAL spec spelling — query.Set takes q.Name, never
+			// the flag name. The server rejects "branch-id" where it expects
+			// "branchId", so these two must not be conflated.
 			query := url.Values{}
 			for _, q := range op.QueryParams {
-				flagName := slugify(q.Name)
-				val, err := cmd.Flags().GetString(flagName)
+				val, err := cmd.Flags().GetString(canonicalFlagName(q.Name))
 				if err != nil {
 					continue
 				}
@@ -249,9 +259,14 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 		},
 	}
 
+	// Accept any spelling of a registered flag that differs only in case or
+	// dash/underscore placement, so --branchid and --branchId both hit the
+	// canonical --branch-id no matter how the spec spelled the param.
+	cmd.Flags().SetNormalizeFunc(NormalizeFlagName)
+
 	// Register query params as flags
 	for _, q := range op.QueryParams {
-		flagName := slugify(q.Name)
+		flagName := canonicalFlagName(q.Name)
 		desc := q.Description
 		if len(q.Enum) > 0 {
 			desc += fmt.Sprintf(" [%s]", strings.Join(q.Enum, ", "))
@@ -364,6 +379,120 @@ func slugify(s string) string {
 	s = strings.ReplaceAll(s, " ", "-")
 	s = strings.ReplaceAll(s, "_", "-")
 	return s
+}
+
+// canonicalFlagName derives the CLI flag name for an OpenAPI parameter. The
+// spec names the same concept inconsistently across sibling operations —
+// "branchId" here, "branch_id" there — so camelCase is split into words before
+// slugifying and both spellings land on one flag:
+//
+//	branchId    → branch-id
+//	branch_id   → branch-id
+//	pageSize    → page-size
+//	baseModelId → base-model-id
+//
+// Acronym runs stay intact: "modelURL" → "model-url", "URLPrefix" → "url-prefix".
+func canonicalFlagName(s string) string {
+	var b strings.Builder
+	rs := []rune(s)
+	for i, r := range rs {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := rs[i-1]
+			switch {
+			case !unicode.IsUpper(prev) && prev != '-' && prev != '_' && prev != ' ':
+				// lower/digit → upper: a word boundary ("pageSize").
+				b.WriteRune('-')
+			case unicode.IsUpper(prev) && i+1 < len(rs) && unicode.IsLower(rs[i+1]):
+				// End of an acronym run ("URLPrefix" → "URL-Prefix").
+				b.WriteRune('-')
+			}
+		}
+		b.WriteRune(r)
+	}
+	return slugify(b.String())
+}
+
+// flagLookupKey reduces a flag name to the form used for matching: lowercased,
+// with dashes and underscores dropped. "branchId", "branch-id", "branch_id"
+// and "branchid" all reduce to "branchid".
+func flagLookupKey(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if r == '-' || r == '_' {
+			continue
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+// NormalizeFlagName is a pflag normalization function that resolves a flag name
+// the user typed to whichever flag is registered under an equivalent spelling,
+// ignoring case and dash/underscore placement. So --branchid, --branch_id and
+// --branchId all find a registered --branch-id.
+//
+// Names with no registered match are returned unchanged. That matters at
+// registration time: pflag rewrites Flag.Name to whatever this returns, so
+// returning the raw lookup key would make --help advertise "--branchid". Help
+// output keeps showing only the canonical kebab-case name; the alternates are
+// accepted silently.
+func NormalizeFlagName(fs *pflag.FlagSet, name string) pflag.NormalizedName {
+	key := flagLookupKey(name)
+	match := ""
+	fs.VisitAll(func(f *pflag.Flag) {
+		if match == "" && flagLookupKey(f.Name) == key {
+			match = f.Name
+		}
+	})
+	if match != "" {
+		return pflag.NormalizedName(match)
+	}
+	return pflag.NormalizedName(name)
+}
+
+// validateFlagNames reports flags on a single generated command whose names
+// collide once normalized. Since lookups ignore case and separators, a command
+// declaring both "branchId" and "branch_id" would register two flags that are
+// indistinguishable — pflag panics on the second one — so fail generation with
+// a message that names the culprits instead.
+func validateFlagNames(op *operationInfo) error {
+	claimed := map[string]string{} // lookup key → description of the claimant
+
+	claim := func(flagName, source string) error {
+		key := flagLookupKey(flagName)
+		desc := fmt.Sprintf("--%s (%s)", flagName, source)
+		if prev, ok := claimed[key]; ok {
+			return fmt.Errorf("%s collides with %s: flag names are matched ignoring case, dashes and underscores, so both resolve to %q", desc, prev, key)
+		}
+		claimed[key] = desc
+		return nil
+	}
+
+	for _, q := range op.QueryParams {
+		if err := claim(canonicalFlagName(q.Name), "query param "+q.Name); err != nil {
+			return err
+		}
+	}
+
+	if op.HasBody {
+		// --field and --depth are registered defensively (only when free), so
+		// they can't collide; --body, --json-body and --schema always are.
+		for _, reserved := range []string{"body", "json-body", "schema"} {
+			if err := claim(reserved, "built-in flag"); err != nil {
+				return err
+			}
+		}
+	}
+
+	if sh := GetBodyShorthand(op.OperationID); sh != nil {
+		for _, f := range sh.Flags {
+			if err := claim(f.FlagName, "body shorthand for "+op.OperationID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func camelToKebab(s string) string {

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -207,10 +207,12 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 			// (branchId → --branch-id), but the query string must use the
 			// param's ORIGINAL spec spelling — query.Set takes q.Name, never
 			// the flag name. The server rejects "branch-id" where it expects
-			// "branchId", so these two must not be conflated.
+			// "branchId", so these two must not be conflated. That holds for
+			// params queryFlagName had to rename too: --param-base-url still
+			// goes out as baseUrl=.
 			query := url.Values{}
 			for _, q := range op.QueryParams {
-				val, err := cmd.Flags().GetString(canonicalFlagName(q.Name))
+				val, err := cmd.Flags().GetString(queryFlagName(q.Name))
 				if err != nil {
 					continue
 				}
@@ -266,10 +268,19 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 
 	// Register query params as flags
 	for _, q := range op.QueryParams {
-		flagName := canonicalFlagName(q.Name)
+		flagName := queryFlagName(q.Name)
 		desc := q.Description
 		if len(q.Enum) > 0 {
 			desc += fmt.Sprintf(" [%s]", strings.Join(q.Enum, ", "))
+		}
+		if canonical := canonicalFlagName(q.Name); flagName != canonical {
+			// Say so in --help, otherwise the flag looks like a typo next to
+			// the spec's parameter name.
+			desc = strings.TrimSpace(desc)
+			if desc != "" {
+				desc += " "
+			}
+			desc += fmt.Sprintf("(query param %q; renamed because --%s is a global CLI flag)", q.Name, canonical)
 		}
 		cmd.Flags().String(flagName, "", desc)
 	}
@@ -412,6 +423,61 @@ func canonicalFlagName(s string) string {
 	return slugify(b.String())
 }
 
+// reservedFlagKeys are the flag names a generated query-param flag must not
+// claim, keyed by flagLookupKey. They are either the root command's persistent
+// flags (mirrored from addGlobalFlags in cmd/omni/main.go, kept in sync by
+// TestGlobalFlagsAreReserved) or flags a generated command registers for
+// itself.
+//
+// Shadowing one of these is not merely confusing, it is unsafe. pflag's
+// AddFlagSet skips a persistent flag whose name is already taken locally, so a
+// spec param named "baseUrl" would canonicalize to --base-url, take the slot
+// before the root's persistent flag merged in, and then resolveConfig's
+// GetString("base-url") would read the query param's value — one value both
+// filtering the request and choosing the host it is sent to.
+var reservedFlagKeys = map[string]string{
+	// Root persistent flags.
+	flagLookupKey("profile"):  "profile",
+	flagLookupKey("token"):    "token",
+	flagLookupKey("base-url"): "base-url",
+	flagLookupKey("compact"):  "compact",
+	flagLookupKey("format"):   "format",
+	// Added by cobra on every command; must stay a bool.
+	flagLookupKey("help"): "help",
+	// Registered by buildCommand for body-taking operations.
+	flagLookupKey("body"):      "body",
+	flagLookupKey("json-body"): "json-body",
+	flagLookupKey("schema"):    "schema",
+	flagLookupKey("field"):     "field",
+	flagLookupKey("depth"):     "depth",
+}
+
+// IsReservedFlagName reports whether name — in any spelling, since matching
+// ignores case and dash/underscore placement — is claimed by a global or
+// built-in CLI flag.
+func IsReservedFlagName(name string) bool {
+	_, ok := reservedFlagKeys[flagLookupKey(name)]
+	return ok
+}
+
+// queryFlagName is the flag name a query param is registered under: its
+// canonical kebab-case name, unless that would shadow a global or built-in
+// flag, in which case it gets a "param-" prefix (a spec param "baseUrl"
+// becomes --param-base-url and leaves --base-url meaning the API endpoint).
+//
+// Renaming rather than failing generation is deliberate: the spec is synced
+// from upstream and can introduce such a param at any time, and a hard failure
+// there would take the entire CLI down — every command, not just the affected
+// one. Renaming keeps the endpoint reachable and the global flag honest, and
+// buildCommand explains the rename in --help.
+func queryFlagName(param string) string {
+	name := canonicalFlagName(param)
+	if IsReservedFlagName(name) {
+		return "param-" + name
+	}
+	return name
+}
+
 // flagLookupKey reduces a flag name to the form used for matching: lowercased,
 // with dashes and underscores dropped. "branchId", "branch-id", "branch_id"
 // and "branchid" all reduce to "branchid".
@@ -455,6 +521,12 @@ func NormalizeFlagName(fs *pflag.FlagSet, name string) pflag.NormalizedName {
 // declaring both "branchId" and "branch_id" would register two flags that are
 // indistinguishable — pflag panics on the second one — so fail generation with
 // a message that names the culprits instead.
+//
+// Query params are checked under their effective flag name, i.e. after
+// queryFlagName has moved any that would shadow a global or built-in flag out
+// of the way. Body-shorthand flags are hand-written in this repo, so a
+// collision there is a bug to fix rather than upstream drift to absorb: they
+// are reported, including against the reserved names.
 func validateFlagNames(op *operationInfo) error {
 	claimed := map[string]string{} // lookup key → description of the claimant
 
@@ -468,19 +540,15 @@ func validateFlagNames(op *operationInfo) error {
 		return nil
 	}
 
-	for _, q := range op.QueryParams {
-		if err := claim(canonicalFlagName(q.Name), "query param "+q.Name); err != nil {
-			return err
-		}
+	// Reserved names are spoken for on every command, whether or not this
+	// operation registers them itself.
+	for key, display := range reservedFlagKeys {
+		claimed[key] = fmt.Sprintf("--%s (global or built-in flag)", display)
 	}
 
-	if op.HasBody {
-		// --field and --depth are registered defensively (only when free), so
-		// they can't collide; --body, --json-body and --schema always are.
-		for _, reserved := range []string{"body", "json-body", "schema"} {
-			if err := claim(reserved, "built-in flag"); err != nil {
-				return err
-			}
+	for _, q := range op.QueryParams {
+		if err := claim(queryFlagName(q.Name), "query param "+q.Name); err != nil {
+			return err
 		}
 	}
 

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -263,8 +263,8 @@ func TestGenerateCommands_PathParamsFollowPathOrder(t *testing.T) {
 	}
 
 	sub := cmds[0].Commands()[0]
-	if sub.Use != "get-item <outerid> <innerid>" {
-		t.Errorf("Use = %q, want %q", sub.Use, "get-item <outerid> <innerid>")
+	if sub.Use != "get-item <outer-id> <inner-id>" {
+		t.Errorf("Use = %q, want %q", sub.Use, "get-item <outer-id> <inner-id>")
 	}
 
 	// Positional args in path order must substitute into the matching slots.
@@ -402,6 +402,215 @@ func TestBuildCommand_WrongArgCount(t *testing.T) {
 	cmd.SetArgs([]string{}) // 0 args, expects 1
 	if err := cmd.Execute(); err == nil {
 		t.Error("expected error for wrong arg count, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flag-name normalization
+//
+// The spec spells the same concept differently across sibling operations
+// ("branchId" on models validate, "branch_id" on models list-topics). Flag
+// names are derived by splitting camelCase, so both become --branch-id, and
+// lookups ignore case and dash/underscore placement so older spellings keep
+// working.
+// ---------------------------------------------------------------------------
+
+// canonicalFlagName turns an OpenAPI param name into the kebab-case flag name.
+func TestCanonicalFlagName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"branchId", "branch-id"},
+		{"branch_id", "branch-id"},
+		{"branch-id", "branch-id"},
+		{"pageSize", "page-size"},
+		{"modelKind", "model-kind"},
+		{"baseModelId", "base-model-id"},
+		{"cursor", "cursor"},
+		{"id", "id"},
+		{"", ""},
+		// Acronym runs stay together rather than exploding letter by letter.
+		{"modelURL", "model-url"},
+		{"URLPrefix", "url-prefix"},
+		{"parseJSONBody", "parse-json-body"},
+		// Digits attach to the word they follow.
+		{"v2Identifier", "v2-identifier"},
+	}
+	for _, c := range cases {
+		if got := canonicalFlagName(c.in); got != c.want {
+			t.Errorf("canonicalFlagName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// flagLookupKey is the equivalence class used to match a typed flag name
+// against the registered one.
+func TestFlagLookupKey(t *testing.T) {
+	same := []string{"branch-id", "branchId", "branch_id", "branchid", "BRANCH-ID"}
+	want := flagLookupKey(same[0])
+	for _, s := range same {
+		if got := flagLookupKey(s); got != want {
+			t.Errorf("flagLookupKey(%q) = %q, want %q", s, got, want)
+		}
+	}
+	if flagLookupKey("branch-id") == flagLookupKey("branch-ids") {
+		t.Error("distinct flag names must not share a lookup key")
+	}
+}
+
+// A camelCase query param registers a kebab-case flag, and that canonical
+// spelling is the only one --help advertises.
+func TestBuildCommand_CamelCaseQueryParamBecomesKebabFlag(t *testing.T) {
+	op := &operationInfo{
+		Tag:         "models",
+		OperationID: "modelsValidate",
+		Method:      "GET",
+		Path:        "/api/v1/models/validate",
+		QueryParams: []paramInfo{{Name: "branchId", In: "query"}},
+	}
+
+	cmd := buildCommand(op, func(req APIRequest) error { return nil })
+
+	f := cmd.Flags().Lookup("branch-id")
+	if f == nil {
+		t.Fatal("expected a --branch-id flag to be registered")
+	}
+	if f.Name != "branch-id" {
+		t.Errorf("registered flag name = %q, want %q", f.Name, "branch-id")
+	}
+	if usage := cmd.Flags().FlagUsages(); !strings.Contains(usage, "--branch-id") || strings.Contains(usage, "--branchid") {
+		t.Errorf("help output should offer only the canonical spelling, got:\n%s", usage)
+	}
+}
+
+// Every spelling that differs only in case or separators resolves to the same
+// flag, and the value is sent under the param's ORIGINAL spec name.
+func TestBuildCommand_AlternateFlagSpellings(t *testing.T) {
+	for _, spelling := range []string{"--branch-id", "--branchid", "--branchId", "--branch_id", "--BranchID"} {
+		t.Run(spelling, func(t *testing.T) {
+			var captured APIRequest
+			op := &operationInfo{
+				Tag:         "models",
+				OperationID: "modelsValidate",
+				Method:      "GET",
+				Path:        "/api/v1/models/validate",
+				QueryParams: []paramInfo{{Name: "branchId", In: "query"}},
+			}
+			cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+			cmd.SilenceUsage, cmd.SilenceErrors = true, true
+			cmd.SetArgs([]string{spelling, "br-123"})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute(%s): %v", spelling, err)
+			}
+			// The query string uses the spec's spelling, not the flag's.
+			if captured.Path != "/api/v1/models/validate?branchId=br-123" {
+				t.Errorf("path = %q, want branchId=br-123 in the query string", captured.Path)
+			}
+		})
+	}
+}
+
+// The drift this fixes: sibling commands whose spec params differ only in
+// naming style now answer to one flag spelling, in both directions.
+func TestGenerateCommands_SiblingParamsAgreeOnFlagName(t *testing.T) {
+	spec := `{
+		"openapi": "3.1.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/api/v1/models/validate": {
+				"get": {
+					"operationId": "modelsValidate",
+					"tags": ["models"],
+					"parameters": [{"name": "branchId", "in": "query", "schema": {"type": "string"}}],
+					"responses": {"200": {"description": "ok"}}
+				}
+			},
+			"/api/v1/models/topics": {
+				"get": {
+					"operationId": "modelsListTopics",
+					"tags": ["models"],
+					"parameters": [{"name": "branch_id", "in": "query", "schema": {"type": "string"}}],
+					"responses": {"200": {"description": "ok"}}
+				}
+			}
+		}
+	}`
+
+	cmds, err := GenerateCommands([]byte(spec), func(req APIRequest) error { return nil })
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+
+	for _, sub := range cmds[0].Commands() {
+		for _, spelling := range []string{"branch-id", "branchid", "branchId"} {
+			if sub.Flags().Lookup(spelling) == nil {
+				t.Errorf("%s: --%s does not resolve to a registered flag", sub.Name(), spelling)
+			}
+		}
+	}
+}
+
+// Two params on one operation that normalize identically would register two
+// indistinguishable flags (pflag panics on the second), so generation fails
+// with a message naming both.
+func TestGenerateCommands_DetectsFlagCollision(t *testing.T) {
+	spec := `{
+		"openapi": "3.1.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/api/v1/things": {
+				"get": {
+					"operationId": "thingsList",
+					"tags": ["things"],
+					"parameters": [
+						{"name": "branchId", "in": "query", "schema": {"type": "string"}},
+						{"name": "branch_id", "in": "query", "schema": {"type": "string"}}
+					],
+					"responses": {"200": {"description": "ok"}}
+				}
+			}
+		}
+	}`
+
+	_, err := GenerateCommands([]byte(spec), func(req APIRequest) error { return nil })
+	if err == nil {
+		t.Fatal("expected a collision error, got nil")
+	}
+	for _, want := range []string{"things list", "branchId", "branch_id", "branchid"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err.Error(), want)
+		}
+	}
+}
+
+func TestValidateFlagNames(t *testing.T) {
+	// Distinct params are fine, even when one is camelCase and one snake_case.
+	ok := &operationInfo{
+		OperationID: "thingsList",
+		QueryParams: []paramInfo{{Name: "branchId"}, {Name: "page_size"}, {Name: "cursor"}},
+	}
+	if err := validateFlagNames(ok); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// A query param that collides with a built-in body flag is also caught.
+	withBody := &operationInfo{
+		OperationID: "thingsCreate",
+		QueryParams: []paramInfo{{Name: "Body"}},
+		HasBody:     true,
+	}
+	if err := validateFlagNames(withBody); err == nil {
+		t.Error("expected --body collision to be reported")
+	}
+
+	// ...as is one that collides with a promoted body-shorthand flag.
+	// labelsCreate promotes "color" and "description".
+	withShorthand := &operationInfo{
+		OperationID: "labelsCreate",
+		QueryParams: []paramInfo{{Name: "Color"}},
+		HasBody:     true,
+	}
+	if err := validateFlagNames(withShorthand); err == nil {
+		t.Error("expected shorthand flag collision to be reported")
 	}
 }
 

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -38,18 +38,20 @@ func TestSlugify(t *testing.T) {
 	}
 }
 
-// camelToKebab converts operationIds like "aiJobStatus" into kebab-case
-// "ai-job-status" for use as CLI subcommand names.
-func TestCamelToKebab(t *testing.T) {
+// Command names come from the same slug renderer as flag names. Unifying them
+// was only safe because it changes no command name generated from the real spec
+// (TestRealSpec_CommandNamesAreStable) — command spellings have no
+// normalization fallback, so any change would break users.
+func TestCanonicalName_OperationIDs(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"ModelsList", "models-list"},
 		{"aiJobStatus", "ai-job-status"},
 		{"a", "a"},
-		{"ABC", "a-b-c"},
+		{"ABC", "abc"},
 	}
 	for _, c := range cases {
-		if got := camelToKebab(c.in); got != c.want {
-			t.Errorf("camelToKebab(%q) = %q, want %q", c.in, got, c.want)
+		if got := canonicalName(c.in); got != c.want {
+			t.Errorf("canonicalName(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }
@@ -417,8 +419,8 @@ func TestBuildCommand_WrongArgCount(t *testing.T) {
 // working.
 // ---------------------------------------------------------------------------
 
-// canonicalFlagName turns an OpenAPI param name into the kebab-case flag name.
-func TestCanonicalFlagName(t *testing.T) {
+// canonicalName turns an OpenAPI param name into the kebab-case flag name.
+func TestCanonicalName(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"branchId", "branch-id"},
 		{"branch_id", "branch-id"},
@@ -433,12 +435,18 @@ func TestCanonicalFlagName(t *testing.T) {
 		{"modelURL", "model-url"},
 		{"URLPrefix", "url-prefix"},
 		{"parseJSONBody", "parse-json-body"},
+		// A pluralized acronym stays one word instead of splitting on the "s".
+		{"URLs", "urls"},
+		{"IDs", "ids"},
+		{"apiURLs", "api-urls"},
+		{"modelIDs", "model-ids"},
+		{"IDsList", "ids-list"},
 		// Digits attach to the word they follow.
 		{"v2Identifier", "v2-identifier"},
 	}
 	for _, c := range cases {
-		if got := canonicalFlagName(c.in); got != c.want {
-			t.Errorf("canonicalFlagName(%q) = %q, want %q", c.in, got, c.want)
+		if got := canonicalName(c.in); got != c.want {
+			t.Errorf("canonicalName(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }
@@ -551,10 +559,11 @@ func TestGenerateCommands_SiblingParamsAgreeOnFlagName(t *testing.T) {
 	}
 }
 
-// Two params on one operation that normalize identically would register two
-// indistinguishable flags (pflag panics on the second), so generation fails
-// with a message naming both.
-func TestGenerateCommands_DetectsFlagCollision(t *testing.T) {
+// Two params on one operation that normalize identically cannot share a flag
+// (pflag panics on the second), but the spec is synced from upstream, so the
+// later one is renamed out of the way rather than failing generation — which
+// would take down every command in the CLI, not just this one.
+func TestGenerateCommands_DegradesOnFlagCollision(t *testing.T) {
 	spec := `{
 		"openapi": "3.1.0",
 		"info": {"title": "test", "version": "1.0"},
@@ -573,14 +582,42 @@ func TestGenerateCommands_DetectsFlagCollision(t *testing.T) {
 		}
 	}`
 
-	_, err := GenerateCommands([]byte(spec), func(req APIRequest) error { return nil })
-	if err == nil {
-		t.Fatal("expected a collision error, got nil")
+	var captured APIRequest
+	cmds, err := GenerateCommands([]byte(spec), func(req APIRequest) error { captured = req; return nil })
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
 	}
-	for _, want := range []string{"things list", "branchId", "branch_id", "branchid"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q should mention %q", err.Error(), want)
+
+	var cmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "list" {
+			cmd = sub
 		}
+	}
+	if cmd == nil {
+		t.Fatal("expected a generated \"things list\" command")
+	}
+	if cmd.Flags().Lookup("branch-id") == nil {
+		t.Fatal("the first param should keep the canonical --branch-id")
+	}
+	second := cmd.Flags().Lookup("branch-id-2")
+	if second == nil {
+		t.Fatal("the second param should be registered under a fallback name")
+	}
+	// The rename is announced, otherwise --branch-id-2 looks like a typo.
+	if !strings.Contains(second.Usage, `"branch_id"`) {
+		t.Errorf("fallback flag usage should name the original param, got %q", second.Usage)
+	}
+
+	// Both flags still reach the server under their own spec spellings.
+	tagCmd := cmds[0]
+	tagCmd.SilenceUsage, tagCmd.SilenceErrors = true, true
+	tagCmd.SetArgs([]string{"list", "--branch-id", "a", "--branch-id-2", "b"})
+	if err := tagCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(captured.Path, "branchId=a") || !strings.Contains(captured.Path, "branch_id=b") {
+		t.Errorf("path = %q, want both branchId=a and branch_id=b", captured.Path)
 	}
 }
 
@@ -592,6 +629,16 @@ func TestValidateFlagNames(t *testing.T) {
 	}
 	if err := validateFlagNames(ok); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Params that canonicalize alike are renamed by resolveQueryFlags, so they
+	// are not reported either.
+	colliding := &operationInfo{
+		OperationID: "thingsList",
+		QueryParams: []paramInfo{{Name: "branchId"}, {Name: "branch_id"}},
+	}
+	if err := validateFlagNames(colliding); err != nil {
+		t.Errorf("unexpected error for colliding params: %v", err)
 	}
 
 	// A param whose name matches a built-in flag is renamed out of the way
@@ -671,40 +718,75 @@ func TestShorthand_TypedFlagsAcceptAlternateSpellings(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestQueryFlagName_ReservedNamesArePrefixed(t *testing.T) {
-	cases := []struct{ in, want string }{
-		// Reserved: renamed out of the way.
-		{"baseUrl", "param-base-url"},
-		{"base_url", "param-base-url"},
-		{"token", "param-token"},
-		{"profile", "param-profile"},
-		{"compact", "param-compact"},
-		{"format", "param-format"},
-		{"help", "param-help"},
-		{"body", "param-body"},
-		{"schema", "param-schema"},
-		{"field", "param-field"},
-		{"depth", "param-depth"},
+	cases := []struct {
+		in      string
+		hasBody bool
+		want    string
+	}{
+		// Global flags: reserved on every command.
+		{"baseUrl", false, "param-base-url"},
+		{"base_url", false, "param-base-url"},
+		{"token", false, "param-token"},
+		{"profile", false, "param-profile"},
+		{"compact", false, "param-compact"},
+		{"format", false, "param-format"},
+		{"help", false, "param-help"},
+		// Body flags: only registered — and so only reserved — on operations
+		// that take a request body.
+		{"body", true, "param-body"},
+		{"schema", true, "param-schema"},
+		{"field", true, "param-field"},
+		{"depth", true, "param-depth"},
+		{"body", false, "body"},
+		{"schema", false, "schema"},
+		{"field", false, "field"},
+		{"depth", false, "depth"},
 		// Everything else keeps its canonical name.
-		{"branchId", "branch-id"},
-		{"pageSize", "page-size"},
-		{"baseModelId", "base-model-id"},
-		{"formatting", "formatting"},
-		{"tokenId", "token-id"},
+		{"branchId", true, "branch-id"},
+		{"pageSize", false, "page-size"},
+		{"baseModelId", false, "base-model-id"},
+		{"formatting", false, "formatting"},
+		{"tokenId", false, "token-id"},
 	}
 	for _, c := range cases {
-		if got := queryFlagName(c.in); got != c.want {
-			t.Errorf("queryFlagName(%q) = %q, want %q", c.in, got, c.want)
+		if got := queryFlagName(c.in, c.hasBody); got != c.want {
+			t.Errorf("queryFlagName(%q, hasBody=%v) = %q, want %q", c.in, c.hasBody, got, c.want)
 		}
 	}
 }
 
+// A bodyless operation registers no --field, so a param of that name keeps it
+// instead of being renamed on the strength of a flag that is not there.
+func TestBuildCommand_BodylessOperationDoesNotReserveBodyFlags(t *testing.T) {
+	op := &operationInfo{
+		Tag:         "things",
+		OperationID: "thingsList",
+		Method:      "GET",
+		Path:        "/api/v1/things",
+		QueryParams: []paramInfo{{Name: "field", In: "query"}},
+	}
+	cmd := buildCommand(op, func(req APIRequest) error { return nil })
+
+	f := cmd.Flags().Lookup("field")
+	if f == nil {
+		t.Fatal("expected the param to keep --field on a bodyless command")
+	}
+	if strings.Contains(f.Usage, "renamed") {
+		t.Errorf("help should not claim a rename, got %q", f.Usage)
+	}
+	if cmd.Flags().Lookup("param-field") != nil {
+		t.Error("--param-field should not exist on a bodyless command")
+	}
+}
+
 func TestIsReservedFlagName_IgnoresSpelling(t *testing.T) {
-	for _, name := range []string{"base-url", "baseUrl", "base_url", "BASEURL", "json-body", "jsonBody"} {
+	for _, name := range []string{"base-url", "baseUrl", "base_url", "BASEURL", "help", "FORMAT"} {
 		if !IsReservedFlagName(name) {
 			t.Errorf("IsReservedFlagName(%q) = false, want true", name)
 		}
 	}
-	for _, name := range []string{"branch-id", "page-size", "param-base-url", "tokens"} {
+	// Flags only some commands register are not globally reserved.
+	for _, name := range []string{"branch-id", "page-size", "param-base-url", "tokens", "json-body", "field"} {
 		if IsReservedFlagName(name) {
 			t.Errorf("IsReservedFlagName(%q) = true, want false", name)
 		}
@@ -760,9 +842,55 @@ func TestBuildCommand_ReservedQueryParamDoesNotShadowGlobalFlag(t *testing.T) {
 	}
 }
 
-// The real spec must generate cleanly: no operation may declare two params that
-// normalize to one flag. Any param that had to be renamed is logged, since that
-// is a spec change worth noticing on a sync.
+// Command names and flag names share one slug renderer (canonicalName).
+// Unifying them was safe only because it changes no command name the real spec
+// generates — unlike flags, a command spelling has no normalization fallback,
+// so a change would break every user script that calls it. This guards the
+// property: names stay unique within their group and free of the letter-by-
+// letter acronym splits the old renderer produced ("get-u-r-l-info").
+func TestRealSpec_CommandNamesAreStable(t *testing.T) {
+	specData := loadSpec(t)
+	doc, err := libopenapi.NewDocument(specData)
+	if err != nil {
+		t.Fatalf("parsing spec: %v", err)
+	}
+	model, err := doc.BuildV3Model()
+	if err != nil {
+		t.Fatalf("building model: %v", err)
+	}
+
+	groups := map[string][]*operationInfo{}
+	for pair := model.Model.Paths.PathItems.First(); pair != nil; pair = pair.Next() {
+		extractOperations(pair.Key(), pair.Value(), groups)
+	}
+	if len(groups) == 0 {
+		t.Fatal("no operations parsed from the spec")
+	}
+
+	for tag, ops := range groups {
+		seen := map[string]string{}
+		for _, op := range ops {
+			name := commandName(op)
+			if name == "" {
+				t.Errorf("%s: operation %s produced an empty command name", tag, op.OperationID)
+				continue
+			}
+			for _, seg := range strings.Split(name, "-") {
+				if len(seg) == 1 {
+					t.Errorf("%s %s: single-letter segment %q suggests an acronym was split letter by letter", slugify(tag), name, seg)
+				}
+			}
+			if prev, ok := seen[name]; ok {
+				t.Errorf("%s: %s and %s both generate the command %q", slugify(tag), prev, op.OperationID, name)
+			}
+			seen[name] = op.OperationID
+		}
+	}
+}
+
+// The real spec must generate cleanly. Any param that had to be renamed — to
+// avoid a global flag or another param on the same operation — is logged, since
+// that is a spec change worth noticing on a sync.
 func TestRealSpec_NoFlagCollisions(t *testing.T) {
 	specData := loadSpec(t)
 	specOps := parseSpecOperations(t, specData)
@@ -790,15 +918,15 @@ func TestRealSpec_NoFlagCollisions(t *testing.T) {
 			if err := validateFlagNames(op); err != nil {
 				t.Errorf("%s %s: %v", slugify(tag), commandName(op), err)
 			}
-			for _, q := range op.QueryParams {
-				if flag := queryFlagName(q.Name); flag != canonicalFlagName(q.Name) {
+			for _, qf := range resolveQueryFlags(op) {
+				if qf.Note != "" {
 					renamed++
-					t.Logf("%s %s: param %q registered as --%s (reserved name)", slugify(tag), commandName(op), q.Name, flag)
+					t.Logf("%s %s: param %q registered as --%s %s", slugify(tag), commandName(op), qf.Param.Name, qf.Name, qf.Note)
 				}
 			}
 		}
 	}
-	t.Logf("%d query params renamed to avoid global/built-in flags", renamed)
+	t.Logf("%d query params renamed to avoid a flag name that was already taken", renamed)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -613,6 +614,48 @@ func TestValidateFlagNames(t *testing.T) {
 	}
 	if err := validateFlagNames(withShorthand); err == nil {
 		t.Error("expected shorthand flag collision to be reported")
+	}
+}
+
+// Promoted body-shorthand flags are registered with pflag's Var (their type
+// comes from the request schema), not String. Registration still goes through
+// the normalization function, so alternate spellings must reach them too — and
+// the schema-derived typing has to survive the trip.
+func TestShorthand_TypedFlagsAcceptAlternateSpellings(t *testing.T) {
+	op := operationFromRealSpec(t, "aiGenerateQuery")
+
+	// Sanity: the flag is boolean-typed from the spec, not a plain string.
+	probe := buildCommand(op, func(req APIRequest) error { return nil })
+	runQuery := probe.Flags().Lookup("run-query")
+	if runQuery == nil {
+		t.Fatal("expected a --run-query flag")
+	}
+	if runQuery.Value.Type() != "boolean" {
+		t.Fatalf("--run-query type = %q, want %q", runQuery.Value.Type(), "boolean")
+	}
+
+	for _, spelling := range []string{"--run-query", "--runquery", "--runQuery", "--run_query"} {
+		t.Run(spelling, func(t *testing.T) {
+			var captured APIRequest
+			cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+			cmd.SilenceUsage, cmd.SilenceErrors = true, true
+			cmd.SetArgs([]string{"m-1", "how many orders", spelling, "false", "--userid", "u-1"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute(%s): %v", spelling, err)
+			}
+
+			var body map[string]interface{}
+			if err := json.Unmarshal(captured.Body, &body); err != nil {
+				t.Fatalf("unmarshaling body: %v", err)
+			}
+			// Boolean typing survives: a JSON false, not the string "false".
+			if v, ok := body["runQuery"].(bool); !ok || v {
+				t.Errorf("body[runQuery] = %#v, want false (bool)", body["runQuery"])
+			}
+			if body["userId"] != "u-1" {
+				t.Errorf("body[userId] = %#v, want %q", body["userId"], "u-1")
+			}
+		})
 	}
 }
 

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -652,15 +652,25 @@ func TestValidateFlagNames(t *testing.T) {
 		t.Errorf("unexpected error for a reserved-name param: %v", err)
 	}
 
-	// A param colliding with a promoted body-shorthand flag is reported —
-	// labelsCreate promotes "color" and "description".
+	// A param colliding with a promoted body-shorthand flag is renamed too —
+	// labelsCreate promotes "color" and "description" — so nothing is reported.
 	withShorthand := &operationInfo{
 		OperationID: "labelsCreate",
 		QueryParams: []paramInfo{{Name: "Color"}},
 		HasBody:     true,
 	}
+	if err := validateFlagNames(withShorthand); err != nil {
+		t.Errorf("unexpected error for a param colliding with a shorthand: %v", err)
+	}
+
+	// Only hand-written shorthands are reported: one that took a built-in
+	// flag's name could not be registered at all.
+	sh := GetBodyShorthand("labelsCreate")
+	original := sh.Flags
+	sh.Flags = append([]FlagMapping{{FlagName: "body", FieldPath: "name"}}, original...)
+	defer func() { sh.Flags = original }()
 	if err := validateFlagNames(withShorthand); err == nil {
-		t.Error("expected shorthand flag collision to be reported")
+		t.Error("expected a shorthand named after a built-in flag to be reported")
 	}
 }
 
@@ -717,7 +727,7 @@ func TestShorthand_TypedFlagsAcceptAlternateSpellings(t *testing.T) {
 // value both filter the request and choose the host it goes to.
 // ---------------------------------------------------------------------------
 
-func TestQueryFlagName_ReservedNamesArePrefixed(t *testing.T) {
+func TestResolveQueryFlags_ReservedNamesArePrefixed(t *testing.T) {
 	cases := []struct {
 		in      string
 		hasBody bool
@@ -749,9 +759,117 @@ func TestQueryFlagName_ReservedNamesArePrefixed(t *testing.T) {
 		{"tokenId", false, "token-id"},
 	}
 	for _, c := range cases {
-		if got := queryFlagName(c.in, c.hasBody); got != c.want {
-			t.Errorf("queryFlagName(%q, hasBody=%v) = %q, want %q", c.in, c.hasBody, got, c.want)
+		op := &operationInfo{
+			OperationID: "thingsList",
+			QueryParams: []paramInfo{{Name: c.in, In: "query"}},
+			HasBody:     c.hasBody,
 		}
+		if got := resolveQueryFlags(op)[0].Name; got != c.want {
+			t.Errorf("param %q (hasBody=%v) registered as --%s, want --%s", c.in, c.hasBody, got, c.want)
+		}
+	}
+}
+
+// A body shorthand is our hand-written UX sugar; the query param is the
+// endpoint's contract. When a synced spec adds a param that lands on a
+// shorthand's flag name, the param moves aside — generation must not fail, that
+// would take down the whole CLI.
+func TestResolveQueryFlags_ShorthandNamesAreReservedPerOperation(t *testing.T) {
+	// labelsCreate promotes "color" and "description" as shorthand flags.
+	collides := &operationInfo{
+		OperationID: "labelsCreate",
+		QueryParams: []paramInfo{{Name: "color", In: "query"}},
+		HasBody:     true,
+	}
+	got := resolveQueryFlags(collides)[0]
+	if got.Name != "param-color" {
+		t.Errorf("param %q registered as --%s, want --param-color", "color", got.Name)
+	}
+	if !strings.Contains(got.Note, "shorthand") {
+		t.Errorf("help note should explain the shorthand collision, got %q", got.Note)
+	}
+
+	// The same param name on an operation with no shorthand is left alone.
+	free := &operationInfo{
+		OperationID: "thingsList",
+		QueryParams: []paramInfo{{Name: "color", In: "query"}},
+	}
+	if name := resolveQueryFlags(free)[0].Name; name != "color" {
+		t.Errorf("without a shorthand the param should keep --color, got --%s", name)
+	}
+}
+
+// End to end: a synced spec that adds a query param named after one of our
+// shorthand flags still generates, both flags work, and the param goes out
+// under its spec spelling.
+func TestGenerateCommands_QueryParamCollidingWithShorthand(t *testing.T) {
+	// labelsCreate promotes --color as a body shorthand; the spec here also
+	// declares a "color" query param.
+	spec := `{
+		"openapi": "3.1.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/api/v1/labels": {
+				"post": {
+					"operationId": "labelsCreate",
+					"tags": ["labels"],
+					"parameters": [{"name": "color", "in": "query", "schema": {"type": "string"}}],
+					"requestBody": {"content": {"application/json": {"schema": {"type": "object", "properties": {
+						"name": {"type": "string"},
+						"color": {"type": "string"}
+					}}}}},
+					"responses": {"200": {"description": "ok"}}
+				}
+			}
+		}
+	}`
+
+	var captured APIRequest
+	cmds, err := GenerateCommands([]byte(spec), func(req APIRequest) error { captured = req; return nil })
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+
+	var cmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "create" {
+			cmd = sub
+		}
+	}
+	if cmd == nil {
+		t.Fatal("expected a generated \"labels create\" command")
+	}
+
+	// The shorthand keeps --color; the query param moves to --param-color.
+	if f := cmd.Flags().Lookup("color"); f == nil || f.Usage != "hex color (e.g. #0366d6)" {
+		t.Fatalf("--color should still be the body shorthand, got %#v", f)
+	}
+	param := cmd.Flags().Lookup("param-color")
+	if param == nil {
+		t.Fatal("expected the query param to be registered as --param-color")
+	}
+	if !strings.Contains(param.Usage, "shorthand") {
+		t.Errorf("help should explain the rename, got %q", param.Usage)
+	}
+
+	tagCmd := cmds[0]
+	tagCmd.SilenceUsage, tagCmd.SilenceErrors = true, true
+	tagCmd.SetArgs([]string{"create", "important", "--color", "#0366d6", "--param-color", "red"})
+	if err := tagCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// The query param goes out under its spec spelling...
+	if captured.Path != "/api/v1/labels?color=red" {
+		t.Errorf("path = %q, want the param sent as color=red", captured.Path)
+	}
+	// ...and the shorthand still lands in the body.
+	var body map[string]interface{}
+	if err := json.Unmarshal(captured.Body, &body); err != nil {
+		t.Fatalf("unmarshaling body: %v", err)
+	}
+	if body["color"] != "#0366d6" || body["name"] != "important" {
+		t.Errorf("body = %#v, want name=important and color=#0366d6", body)
 	}
 }
 

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/spf13/cobra"
 )
 
 // ---------------------------------------------------------------------------
@@ -592,17 +593,18 @@ func TestValidateFlagNames(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// A query param that collides with a built-in body flag is also caught.
+	// A param whose name matches a built-in flag is renamed out of the way
+	// rather than reported, so it is not a collision.
 	withBody := &operationInfo{
 		OperationID: "thingsCreate",
 		QueryParams: []paramInfo{{Name: "Body"}},
 		HasBody:     true,
 	}
-	if err := validateFlagNames(withBody); err == nil {
-		t.Error("expected --body collision to be reported")
+	if err := validateFlagNames(withBody); err != nil {
+		t.Errorf("unexpected error for a reserved-name param: %v", err)
 	}
 
-	// ...as is one that collides with a promoted body-shorthand flag.
+	// A param colliding with a promoted body-shorthand flag is reported —
 	// labelsCreate promotes "color" and "description".
 	withShorthand := &operationInfo{
 		OperationID: "labelsCreate",
@@ -612,6 +614,148 @@ func TestValidateFlagNames(t *testing.T) {
 	if err := validateFlagNames(withShorthand); err == nil {
 		t.Error("expected shorthand flag collision to be reported")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Reserved (global / built-in) flag names
+//
+// Normalization widened what counts as a collision: a spec param named
+// "baseUrl" used to slugify to the harmless --baseurl, but canonicalizes to
+// --base-url. Registered locally it would win the name — pflag's AddFlagSet
+// skips a persistent flag whose name is already taken — and resolveConfig's
+// GetString("base-url") would then read the query param's value, letting one
+// value both filter the request and choose the host it goes to.
+// ---------------------------------------------------------------------------
+
+func TestQueryFlagName_ReservedNamesArePrefixed(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// Reserved: renamed out of the way.
+		{"baseUrl", "param-base-url"},
+		{"base_url", "param-base-url"},
+		{"token", "param-token"},
+		{"profile", "param-profile"},
+		{"compact", "param-compact"},
+		{"format", "param-format"},
+		{"help", "param-help"},
+		{"body", "param-body"},
+		{"schema", "param-schema"},
+		{"field", "param-field"},
+		{"depth", "param-depth"},
+		// Everything else keeps its canonical name.
+		{"branchId", "branch-id"},
+		{"pageSize", "page-size"},
+		{"baseModelId", "base-model-id"},
+		{"formatting", "formatting"},
+		{"tokenId", "token-id"},
+	}
+	for _, c := range cases {
+		if got := queryFlagName(c.in); got != c.want {
+			t.Errorf("queryFlagName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsReservedFlagName_IgnoresSpelling(t *testing.T) {
+	for _, name := range []string{"base-url", "baseUrl", "base_url", "BASEURL", "json-body", "jsonBody"} {
+		if !IsReservedFlagName(name) {
+			t.Errorf("IsReservedFlagName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"branch-id", "page-size", "param-base-url", "tokens"} {
+		if IsReservedFlagName(name) {
+			t.Errorf("IsReservedFlagName(%q) = true, want false", name)
+		}
+	}
+}
+
+// A spec param that would shadow a global flag is registered under --param-,
+// the global name is left alone, and the value still goes out under the
+// param's original spec spelling.
+func TestBuildCommand_ReservedQueryParamDoesNotShadowGlobalFlag(t *testing.T) {
+	var captured APIRequest
+	op := &operationInfo{
+		Tag:         "things",
+		OperationID: "thingsList",
+		Method:      "GET",
+		Path:        "/api/v1/things",
+		QueryParams: []paramInfo{
+			{Name: "baseUrl", In: "query", Description: "filter by callback base URL"},
+			{Name: "cursor", In: "query"},
+		},
+	}
+	cmd := buildCommand(op, func(req APIRequest) error { captured = req; return nil })
+
+	// The command must not define --base-url itself; that name belongs to the
+	// root's persistent flag, which merges in at parse time.
+	if f := cmd.Flags().Lookup("base-url"); f != nil {
+		t.Fatalf("generated command registered a local --%s, shadowing the global flag", f.Name)
+	}
+	if cmd.Flags().Lookup("param-base-url") == nil {
+		t.Fatal("expected the param to be registered as --param-base-url")
+	}
+	if usage := cmd.Flags().FlagUsages(); !strings.Contains(usage, `"baseUrl"`) {
+		t.Errorf("help should name the original spec param, got:\n%s", usage)
+	}
+
+	// A real root command with the global flag, so parsing mirrors production.
+	root := &cobra.Command{Use: "omni"}
+	root.PersistentFlags().String("base-url", "", "API base URL (overrides profile)")
+	root.SetGlobalNormalizationFunc(NormalizeFlagName)
+	root.AddCommand(cmd)
+	root.SetArgs([]string{"list", "--param-base-url", "https://filter.example", "--base-url", "https://api.example"})
+	root.SilenceUsage, root.SilenceErrors = true, true
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if captured.Path != "/api/v1/things?baseUrl=https%3A%2F%2Ffilter.example" {
+		t.Errorf("path = %q, want the param sent as baseUrl", captured.Path)
+	}
+	// The global flag still holds the value the user gave it.
+	if got, _ := cmd.Flags().GetString("base-url"); got != "https://api.example" {
+		t.Errorf("--base-url = %q, want the global value %q", got, "https://api.example")
+	}
+}
+
+// The real spec must generate cleanly: no operation may declare two params that
+// normalize to one flag. Any param that had to be renamed is logged, since that
+// is a spec change worth noticing on a sync.
+func TestRealSpec_NoFlagCollisions(t *testing.T) {
+	specData := loadSpec(t)
+	specOps := parseSpecOperations(t, specData)
+	if len(specOps) == 0 {
+		t.Fatal("no operations parsed from the spec")
+	}
+
+	doc, err := libopenapi.NewDocument(specData)
+	if err != nil {
+		t.Fatalf("parsing spec: %v", err)
+	}
+	model, err := doc.BuildV3Model()
+	if err != nil {
+		t.Fatalf("building model: %v", err)
+	}
+
+	groups := map[string][]*operationInfo{}
+	for pair := model.Model.Paths.PathItems.First(); pair != nil; pair = pair.Next() {
+		extractOperations(pair.Key(), pair.Value(), groups)
+	}
+
+	renamed := 0
+	for tag, ops := range groups {
+		for _, op := range ops {
+			if err := validateFlagNames(op); err != nil {
+				t.Errorf("%s %s: %v", slugify(tag), commandName(op), err)
+			}
+			for _, q := range op.QueryParams {
+				if flag := queryFlagName(q.Name); flag != canonicalFlagName(q.Name) {
+					renamed++
+					t.Logf("%s %s: param %q registered as --%s (reserved name)", slugify(tag), commandName(op), q.Name, flag)
+				}
+			}
+		}
+	}
+	t.Logf("%d query params renamed to avoid global/built-in flags", renamed)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The spec names the same param `branchId` on some operations and `branch_id` on their siblings, which generated two different flags (`--branchid` vs `--branch-id`). Callers ping-ponged between `unknown flag` errors — 29 audited incidents, ~95k wasted tokens.

- **Canonical kebab-case names**: camelCase is split before slugifying, so `branchId` and `branch_id` both become `--branch-id` (`pageSize` → `--page-size`, etc.).
- **Every old spelling still works**: a pflag normalization function makes `--branchid`, `--branch_id`, `--branchId`, `--branch-id` all the same flag, on every command including hand-written ones and globals. Help shows only the canonical form. No breaking change.
- **Collision guards**: generation fails on two params normalizing identically, and a spec param whose canonical name matches a reserved/global flag (e.g. a future `baseUrl` → `--base-url`) is renamed to `--param-base-url` instead of shadowing the API-endpoint flag.
- **Wire format unchanged**: query strings still use the spec's original param name.

<details>
<summary>Details: the reserved-name shadowing fix, rejected alternatives, and verification</summary>

## The problem

```
omni models validate  <id> --branchid  br-1   # branchId  → --branchid
omni models list-topics <id> --branch-id br-1 # branch_id → --branch-id
```

Nothing about the CLI hints which sibling wants which spelling, so callers (agents especially) ping-pong between `unknown flag: --branchid` and `unknown flag: --branch-id` until one sticks. `pageSize`, `modelKind` and `baseModelId` had the same problem in the other direction (`--pagesize`, `--modelkind`, `--basemodelid`).

## The fix

1. **Canonical names.** Flag names are derived by splitting camelCase before slugifying. Acronym runs stay intact (`modelURL` → `--model-url`). Positional path-param placeholders in usage strings get the same treatment (`<model-id>`, not `<modelid>`).

2. **Forgiving lookups, no breaking change.** A pflag normalization function resolves any name that differs from a registered flag only in case or dash/underscore placement. Unmatched names are returned unchanged, which is what keeps `--help` advertising only the canonical kebab-case form. Installed with cobra's `SetGlobalNormalizationFunc` on the root command, so it covers generated commands, promoted body-shorthand flags (`--userid` → `--user-id`), hand-written commands (`--attrjson` → `--attr-json`) and the root's persistent flags (`--baseurl` → `--base-url`). Main's schema-derived typed flag registration (`Var`) goes through the same normalization — covered by a dedicated test asserting all four spellings of `--run-query` produce a JSON boolean.

3. **Collision detection.** Two params on one operation that normalize identically would register two indistinguishable flags — pflag panics on the second. `GenerateCommands` now fails at generation time with a message naming both offenders instead.

4. **Reserved names can't be shadowed** (added after review). Canonicalization widened the collision surface to the global flags: a spec param named `baseUrl` used to slugify to the harmless `--baseurl`, but canonicalizes to `--base-url`. Registered on the command it would win that name — pflag's `AddFlagSet` skips a persistent flag whose name is already taken locally — and `resolveConfig`'s `GetString("base-url")` would then read the query param's value, so one value would both filter the request *and* choose the host it's sent to. Same shape for `--token`; `--help` would stop being a bool.

   **Policy: rename, don't fail.** A query param whose canonical name is reserved (root persistent flags, cobra's `--help`, and the `--body` / `--json-body` / `--schema` / `--field` / `--depth` built-ins) is registered with a `param-` prefix — `--param-base-url` — and `--help` explains the rename. The value still goes out under the spec's own name (`?baseUrl=`). Failing generation was rejected because the spec is synced from upstream and can add such a param at any time; `GenerateCommands` returning an error takes down *every* command and would brick the CLI until a release shipped. Skipping registration was rejected because it silently drops a filter the endpoint supports.

   `reservedFlagKeys` mirrors `addGlobalFlags` in `cmd/omni/main.go`; `TestGlobalFlagsAreReserved` fails if a global flag is added without being reserved (verified by temporarily adding one).

5. **The wire format is unchanged.** Query-string values still go out under the parameter's ORIGINAL spec name — `?branchId=...` for `models validate`, `?branch_id=...` for `models list-topics`. There's a comment in `RunE` saying so, and a test that asserts it.

`agent-help` and the README now document the rule (and the stale `--pagesize` example is fixed).

## Verification

`make build && make test` — all packages pass, including `TestSpecCoverage` (every operation in the real spec still generates and runs) and `TestRealSpec_NoFlagCollisions` (zero collisions today, 0 params need the `param-` prefix — the reserved-name path is exercised by synthetic specs).

New tests: camelCase → kebab canonical naming (incl. acronyms/digits), lookup-key equivalence, help output showing only the canonical form, all five alternate spellings driving one flag, sibling operations agreeing on `--branch-id` in both directions, generation-time collision detection, query string keeping the spec's original param name, `queryFlagName` prefixing for every reserved name (and *not* prefixing lookalikes such as `tokenId` / `formatting`), an end-to-end parse where a `baseUrl` param and the global `--base-url` each keep their own value, typed-flag normalization (`--run-query`/`--runquery`/`--runQuery`/`--run_query` → JSON boolean), and the `TestGlobalFlagsAreReserved` / `TestHelpFlagIsReserved` drift guards.

End-to-end against a local capture server:

```
omni models validate m-1 --branchid  br-1  → /api/v1/models/m-1/validate?branchId=br-1
omni models validate m-1 --branchId  br-2  → /api/v1/models/m-1/validate?branchId=br-2
omni models list-topics m-1 --branch-id br-3 → /api/v1/models/m-1/topic?branch_id=br-3
omni models list-topics m-1 --branch_id br-4 → /api/v1/models/m-1/topic?branch_id=br-4
omni content list --pagesize 5             → /api/v1/content?pageSize=5
omni models list --modelkind BRANCH --basemodelid bm-9
                                           → /api/v1/models?baseModelId=bm-9&modelKind=BRANCH
omni ai generate-query m-1 "..." --branchid br-7 --userid u-3
                                           → {"branchId":"br-7","userId":"u-3",...}
```

`go.mod` changes only in that `spf13/pflag` moves from indirect to direct — no new dependency.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TwwKSAsAGPBToNb4iUe5s
