### PR TITLE
feat(schema): --schema on every command, plus response shapes

### DIFF
--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -78,18 +78,25 @@ Set OMNI_API_TOKEN env var, or run: omni config init
   users         User/group role management, set user attribute values
   config        CLI configuration profiles
 
-## Discovering request body shapes
-Any command that takes a body accepts --schema. It prints the body's JSON
-schema (field types, descriptions, enums, required fields) plus a filled-in
-example, then exits without making an API call (no token needed). Use this
-instead of guessing the JSON for --body.
+## Discovering request and response shapes
+Every API command accepts --schema, including GET/DELETE commands that take no
+body. It prints the full call contract and exits without making an API call (no
+token or positional args needed):
+  - args:        positional args, with type and description
+  - queryParams: query flags, with type, enum, required, description
+  - body:        the request body's JSON schema plus a filled-in example
+                 (null when the operation takes no body)
+  - response:    the success response's shape (status, content type, schema)
+Use it instead of guessing the JSON for --body, or the shape of a response you
+are about to parse.
+  omni models list --schema      # no body: args, query flags, response shape
   omni query run --schema
   omni connections create --schema --compact
 
-Deeply nested bodies (e.g. documents v2-create) can be large. Narrow the
+Deeply nested shapes (e.g. documents v2-create) can be large. Narrow the
 output with --depth N for a shallow overview, then --field PATH to drill into
-one part. PATH is dotted and auto-descends through arrays and maps, so you can
-name a leaf without knowing the container shape:
+one part of the request body. PATH is dotted and auto-descends through arrays
+and maps, so you can name a leaf without knowing the container shape:
   omni documents v2-create --schema --depth 1                       # top-level overview
   omni documents v2-create --schema --field queryPresentations.data # just the tiles map
   omni documents v2-create --schema --field queryPresentations.data.query
@@ -100,8 +107,9 @@ name a leaf without knowing the container shape:
   --base-url URL  API base URL (overrides config)
   --profile NAME  Config profile to use
   --body JSON     Request body (JSON string or "-" for stdin)
-  --schema        Print the request body's schema + example, then exit
-  --field PATH    With --schema: drill into a dotted field path
+  --schema        Print args, flags, body schema + example, and response shape,
+                  then exit (works on every API command)
+  --field PATH    With --schema: drill into a dotted field path of the body
   --depth N       With --schema: cap nesting depth (lower = smaller)
 
 ## Tips

--- a/cmd/omni/branch_commands.go
+++ b/cmd/omni/branch_commands.go
@@ -96,9 +96,9 @@ func createBranchCmd(exec openapi.Executor) *cobra.Command {
 	// --schema on any command; describe the body it assembles so the flag works
 	// here too. The body is static (the CLI fills modelKind and looks up
 	// connectionId itself), so --field has nothing to drill into.
-	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command) error {
-		if field, _ := c.Flags().GetString("field"); field != "" {
-			return fmt.Errorf("--field is not supported for create-branch; its request body is assembled by the CLI and shown in full")
+	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command, names openapi.SchemaFlags) error {
+		if field, _ := c.Flags().GetString(names.Field); field != "" {
+			return fmt.Errorf("--%s is not supported for create-branch; its request body is assembled by the CLI and shown in full", names.Field)
 		}
 		return openapi.EmitSchemaDoc(c, createBranchSchemaDoc())
 	})

--- a/cmd/omni/branch_commands.go
+++ b/cmd/omni/branch_commands.go
@@ -67,16 +67,7 @@ func createBranchCmd(exec openapi.Executor) *cobra.Command {
 
 			connectionID := modelResp.Records[0].ConnectionID
 
-			body := map[string]interface{}{
-				"modelKind":    "BRANCH",
-				"baseModelId":  baseModelID,
-				"connectionId": connectionID,
-			}
-			if name != "" {
-				body["modelName"] = name
-			}
-
-			bodyBytes, err := json.Marshal(body)
+			bodyBytes, err := json.Marshal(buildCreateBranchBody(baseModelID, connectionID, name))
 			if err != nil {
 				return fmt.Errorf("marshaling request body: %w", err)
 			}
@@ -94,26 +85,35 @@ func createBranchCmd(exec openapi.Executor) *cobra.Command {
 
 	// This command is hand-written rather than generated, but agents reach for
 	// --schema on any command; describe the body it assembles so the flag works
-	// here too. The body is static (the CLI fills modelKind and looks up
-	// connectionId itself), so --field has nothing to drill into.
-	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command, names openapi.SchemaFlags) error {
-		if field, _ := c.Flags().GetString(names.Field); field != "" {
-			return fmt.Errorf("--%s is not supported for create-branch; its request body is assembled by the CLI and shown in full", names.Field)
-		}
-		return openapi.EmitSchemaDoc(c, createBranchSchemaDoc())
-	})
+	// here too.
+	openapi.RegisterSchemaFlag(cmd, openapi.StaticSchemaEmitter("create-branch", createBranchSchemaDoc))
 
 	return cmd
+}
+
+// buildCreateBranchBody assembles the POST /api/v1/models body for a branch:
+// modelKind is fixed, baseModelId is the positional arg, connectionId is the one
+// resolved from the base model, and modelName (from --name) is omitted when
+// empty. createBranchSchemaDoc documents exactly these fields.
+func buildCreateBranchBody(baseModelID, connectionID, name string) map[string]interface{} {
+	body := map[string]interface{}{
+		"modelKind":    "BRANCH",
+		"baseModelId":  baseModelID,
+		"connectionId": connectionID,
+	}
+	if name != "" {
+		body["modelName"] = name
+	}
+	return body
 }
 
 // createBranchSchemaDoc mirrors the generated commands' --schema document for the
 // hand-written create-branch command. The body shown is what the CLI sends to
 // POST /api/v1/models: modelKind is fixed to BRANCH, connectionId is resolved
 // from the base model, and modelName comes from --name.
+// Hand-transcribed, so TestStaticSchemaDocs_ResponseMatchesSpec checks it
+// against the spec and the body-assembly code — keep both in step.
 func createBranchSchemaDoc() openapi.SchemaDoc {
-	str := func(desc string) map[string]interface{} {
-		return map[string]interface{}{"type": "string", "description": desc}
-	}
 	return openapi.SchemaDoc{
 		Method: "POST",
 		Path:   "/api/v1/models",
@@ -128,10 +128,10 @@ func createBranchSchemaDoc() openapi.SchemaDoc {
 			"type":        "object",
 			"description": "Assembled by the CLI from <model-id> and --name; not passed through as JSON.",
 			"properties": map[string]interface{}{
-				"modelKind":    str(`always "BRANCH" for this command`),
-				"baseModelId":  str("the <model-id> positional arg"),
-				"connectionId": str("looked up from the base model; not settable"),
-				"modelName":    str("the --name flag; omitted when --name is unset"),
+				"modelKind":    schemaString(`always "BRANCH" for this command`),
+				"baseModelId":  schemaString("the <model-id> positional arg"),
+				"connectionId": schemaString("looked up from the base model; not settable"),
+				"modelName":    schemaString("the --name flag; omitted when --name is unset"),
 			},
 			"required": []string{"modelKind", "baseModelId", "connectionId"},
 		},
@@ -146,17 +146,18 @@ func createBranchSchemaDoc() openapi.SchemaDoc {
 			ContentType: "application/json",
 			Description: "Model created successfully",
 			Schema: map[string]interface{}{
-				"type": "object",
+				"type":        "object",
+				"description": "Create model response",
 				"properties": map[string]interface{}{
 					"success": map[string]interface{}{"type": "boolean", "description": "Whether the operation succeeded"},
-					"error":   str("Error message if creation failed"),
-					"message": str("Additional message"),
+					"error":   schemaString("Error message if creation failed"),
+					"message": schemaString("Additional message"),
 					"model": map[string]interface{}{
 						"type":        "object",
 						"description": "Created model details",
 						"properties": map[string]interface{}{
 							"id":        map[string]interface{}{"type": "string", "format": "uuid", "description": "Created model ID"},
-							"modelKind": str("Kind of model created"),
+							"modelKind": schemaString("Kind of model created"),
 							"name":      map[string]interface{}{"type": "string | null", "description": "Model name"},
 						},
 						"required": []string{"id", "modelKind", "name"},

--- a/cmd/omni/branch_commands.go
+++ b/cmd/omni/branch_commands.go
@@ -92,5 +92,78 @@ func createBranchCmd(exec openapi.Executor) *cobra.Command {
 
 	cmd.Flags().String("name", "", "name for the new branch")
 
+	// This command is hand-written rather than generated, but agents reach for
+	// --schema on any command; describe the body it assembles so the flag works
+	// here too. The body is static (the CLI fills modelKind and looks up
+	// connectionId itself), so --field has nothing to drill into.
+	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command) error {
+		if field, _ := c.Flags().GetString("field"); field != "" {
+			return fmt.Errorf("--field is not supported for create-branch; its request body is assembled by the CLI and shown in full")
+		}
+		return openapi.EmitSchemaDoc(c, createBranchSchemaDoc())
+	})
+
 	return cmd
+}
+
+// createBranchSchemaDoc mirrors the generated commands' --schema document for the
+// hand-written create-branch command. The body shown is what the CLI sends to
+// POST /api/v1/models: modelKind is fixed to BRANCH, connectionId is resolved
+// from the base model, and modelName comes from --name.
+func createBranchSchemaDoc() openapi.SchemaDoc {
+	str := func(desc string) map[string]interface{} {
+		return map[string]interface{}{"type": "string", "description": desc}
+	}
+	return openapi.SchemaDoc{
+		Method: "POST",
+		Path:   "/api/v1/models",
+		Args: []openapi.SchemaArg{{
+			Name:        "modelId",
+			Placeholder: "<model-id>",
+			Type:        "string",
+			Description: "ID of the base model to branch from",
+		}},
+		Required: []string{"modelKind", "baseModelId", "connectionId"},
+		Body: map[string]interface{}{
+			"type":        "object",
+			"description": "Assembled by the CLI from <model-id> and --name; not passed through as JSON.",
+			"properties": map[string]interface{}{
+				"modelKind":    str(`always "BRANCH" for this command`),
+				"baseModelId":  str("the <model-id> positional arg"),
+				"connectionId": str("looked up from the base model; not settable"),
+				"modelName":    str("the --name flag; omitted when --name is unset"),
+			},
+			"required": []string{"modelKind", "baseModelId", "connectionId"},
+		},
+		Example: map[string]interface{}{
+			"modelKind":    "BRANCH",
+			"baseModelId":  "<model-id>",
+			"connectionId": "<resolved by the CLI>",
+			"modelName":    "<name>",
+		},
+		Response: &openapi.SchemaResponse{
+			Status:      "200",
+			ContentType: "application/json",
+			Description: "Model created successfully",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"success": map[string]interface{}{"type": "boolean", "description": "Whether the operation succeeded"},
+					"error":   str("Error message if creation failed"),
+					"message": str("Additional message"),
+					"model": map[string]interface{}{
+						"type":        "object",
+						"description": "Created model details",
+						"properties": map[string]interface{}{
+							"id":        map[string]interface{}{"type": "string", "format": "uuid", "description": "Created model ID"},
+							"modelKind": str("Kind of model created"),
+							"name":      map[string]interface{}{"type": "string | null", "description": "Model name"},
+						},
+						"required": []string{"id", "modelKind", "name"},
+					},
+				},
+				"required": []string{"success"},
+			},
+		},
+	}
 }

--- a/cmd/omni/branch_commands_test.go
+++ b/cmd/omni/branch_commands_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -189,6 +190,71 @@ func TestCreateBranchCmd_RequiresArg(t *testing.T) {
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected error when no model-id provided")
+	}
+}
+
+// TestCreateBranchCmd_Schema verifies the hand-written command answers --schema
+// with the same document shape as generated commands: no positional arg, no
+// token, no API call.
+func TestCreateBranchCmd_Schema(t *testing.T) {
+	var called bool
+	root := newTestRoot(func(req openapi.APIRequest) error { called = true; return nil })
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"models", "create-branch", "--schema"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute --schema: %v\n%s", err, buf.String())
+	}
+	if called {
+		t.Error("executor was called on a --schema run")
+	}
+
+	var doc openapi.SchemaDoc
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
+	}
+	if doc.Method != "POST" || doc.Path != "/api/v1/models" {
+		t.Errorf("method/path = %q %q, want POST /api/v1/models", doc.Method, doc.Path)
+	}
+	if len(doc.Args) != 1 || doc.Args[0].Placeholder != "<model-id>" {
+		t.Errorf("args = %+v, want the <model-id> positional", doc.Args)
+	}
+	body, ok := doc.Body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("body is not an object: %T", doc.Body)
+	}
+	props, ok := body["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body.properties missing: %v", body)
+	}
+	for _, key := range []string{"modelKind", "baseModelId", "connectionId", "modelName"} {
+		if _, ok := props[key]; !ok {
+			t.Errorf("body properties missing %q", key)
+		}
+	}
+	if doc.Response == nil || doc.Response.Status != "200" || doc.Response.Schema == nil {
+		t.Errorf("response = %+v, want the 200 model-create shape", doc.Response)
+	}
+}
+
+// --field has nothing to drill into here (the body is assembled by the CLI), so
+// it must fail with an explanation rather than being silently ignored.
+func TestCreateBranchCmd_SchemaFieldUnsupported(t *testing.T) {
+	root := newTestRoot(func(req openapi.APIRequest) error { return nil })
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+	root.SetArgs([]string{"models", "create-branch", "--schema", "--field", "modelKind"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error for --field on create-branch")
+	}
+	if !strings.Contains(err.Error(), "--field is not supported") {
+		t.Errorf("error = %q, want it to explain --field is unsupported here", err.Error())
 	}
 }
 

--- a/cmd/omni/schema_doc.go
+++ b/cmd/omni/schema_doc.go
@@ -1,0 +1,11 @@
+package main
+
+// Helpers shared by the hand-written API commands' static --schema documents
+// (see createBranchSchemaDoc and setAttributesSchemaDoc). They keep those
+// documents in the same plain-Go shape the spec describer emits.
+
+// schemaString is a string-typed schema node carrying a description — by far the
+// most common field shape in the static documents.
+func schemaString(desc string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "description": desc}
+}

--- a/cmd/omni/schema_doc_test.go
+++ b/cmd/omni/schema_doc_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/exploreomni/omni-cli/internal/openapi"
+	"github.com/spf13/cobra"
+)
+
+// schemaDocFrom runs args plus --schema against cmd and returns the parsed
+// document. stdout and stderr are captured separately so a test can assert that
+// nothing but JSON reached stdout.
+func schemaDocFrom(t *testing.T, cmd *cobra.Command, args ...string) (openapi.SchemaDoc, string) {
+	t.Helper()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(append(args, "--schema"))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute %v --schema: %v\n%s%s", args, err, out.String(), errBuf.String())
+	}
+	var doc openapi.SchemaDoc
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal schema output: %v\n%s", err, out.String())
+	}
+	return doc, errBuf.String()
+}
+
+// specRoot builds a root command carrying the commands generated from the
+// embedded spec, so a test can ask the real generator what an operation looks
+// like.
+func specRoot(t *testing.T) *cobra.Command {
+	t.Helper()
+	specData, err := specFS.ReadFile("openapi.json")
+	if err != nil {
+		t.Fatalf("reading embedded spec: %v", err)
+	}
+	cmds, err := openapi.GenerateCommands(specData, func(req openapi.APIRequest) error { return nil })
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	root := &cobra.Command{Use: "omni"}
+	root.PersistentFlags().Bool("compact", false, "")
+	for _, cmd := range cmds {
+		root.AddCommand(cmd)
+	}
+	return root
+}
+
+// jsonOf renders a value the way --schema emits it, for order-insensitive
+// comparison of two schema fragments.
+func jsonOf(t *testing.T, v interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(data)
+}
+
+// The hand-written commands' static documents are transcribed by hand, so they
+// can drift from the spec silently. Each one wraps a generated operation; assert
+// its response section is exactly what the describer produces for that
+// operation, so a spec change that alters the response fails here.
+func TestStaticSchemaDocs_ResponseMatchesSpec(t *testing.T) {
+	cases := []struct {
+		name      string
+		static    openapi.SchemaDoc
+		generated []string
+	}{
+		{"create-branch", createBranchSchemaDoc(), []string{"models", "create"}},
+		{"set-attributes", setAttributesSchemaDoc(), []string{"scim", "users-update"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, _ := schemaDocFrom(t, specRoot(t), tc.generated...)
+			if tc.static.Method != doc.Method || tc.static.Path != doc.Path {
+				t.Fatalf("static doc describes %s %s, generated %s describes %s %s",
+					tc.static.Method, tc.static.Path, strings.Join(tc.generated, " "), doc.Method, doc.Path)
+			}
+			if got, want := jsonOf(t, tc.static.Response), jsonOf(t, doc.Response); got != want {
+				t.Errorf("static response has drifted from the spec\n static: %s\n   spec: %s", got, want)
+			}
+		})
+	}
+}
+
+// The static body section is a hand-written description of the body the command
+// actually assembles. Guard the field names against the assembly code so a
+// change to one without the other is caught.
+func TestCreateBranchSchemaDoc_BodyMatchesAssembledBody(t *testing.T) {
+	assembled := buildCreateBranchBody("model-1", "conn-1", "branch")
+	documented := createBranchSchemaDoc().Body.(map[string]interface{})["properties"].(map[string]interface{})
+
+	for key := range assembled {
+		if _, ok := documented[key]; !ok {
+			t.Errorf("body field %q is assembled but not documented in --schema", key)
+		}
+	}
+	for key := range documented {
+		if _, ok := assembled[key]; !ok {
+			t.Errorf("body field %q is documented in --schema but never assembled", key)
+		}
+	}
+	// modelName is the only optional field: it is omitted when --name is unset.
+	withoutName := buildCreateBranchBody("model-1", "conn-1", "")
+	if _, ok := withoutName["modelName"]; ok {
+		t.Error("modelName is sent with an empty --name; --schema documents it as omitted")
+	}
+	for _, key := range createBranchSchemaDoc().Required {
+		if _, ok := withoutName[key]; !ok {
+			t.Errorf("required field %q is missing from the assembled body", key)
+		}
+	}
+}
+
+// Same drift guard for set-attributes: its documented SCIM PatchOp fields must
+// be the ones buildSetAttributesBody actually emits.
+func TestSetAttributesSchemaDoc_BodyMatchesAssembledBody(t *testing.T) {
+	raw, err := buildSetAttributesBody([]string{"region=us-east"}, "")
+	if err != nil {
+		t.Fatalf("buildSetAttributesBody: %v", err)
+	}
+	var assembled map[string]interface{}
+	if err := json.Unmarshal(raw, &assembled); err != nil {
+		t.Fatalf("unmarshal assembled body: %v", err)
+	}
+
+	documented := setAttributesSchemaDoc().Body.(map[string]interface{})["properties"].(map[string]interface{})
+	for key := range assembled {
+		if _, ok := documented[key]; !ok {
+			t.Errorf("body field %q is assembled but not documented in --schema", key)
+		}
+	}
+	for key := range documented {
+		if _, ok := assembled[key]; !ok {
+			t.Errorf("body field %q is documented in --schema but never assembled", key)
+		}
+	}
+
+	// The operation object's own fields, one level in.
+	ops, ok := assembled["Operations"].([]interface{})
+	if !ok || len(ops) != 1 {
+		t.Fatalf("Operations = %v, want exactly one op", assembled["Operations"])
+	}
+	op := ops[0].(map[string]interface{})
+	opProps := documented["Operations"].(map[string]interface{})["items"].(map[string]interface{})["properties"].(map[string]interface{})
+	for key := range op {
+		if _, ok := opProps[key]; !ok {
+			t.Errorf("Operations item field %q is assembled but not documented", key)
+		}
+	}
+	if op["op"] != "replace" {
+		t.Errorf("op = %v, want replace as documented", op["op"])
+	}
+	if _, ok := op["value"].(map[string]interface{})[userAttributePrefix]; !ok {
+		t.Errorf("value is not keyed by %s as documented: %v", userAttributePrefix, op["value"])
+	}
+}
+
+// --depth must truncate a hand-written command's static document exactly as it
+// truncates a generated one, rather than being accepted and ignored.
+func TestStaticSchemaDocs_DepthTruncates(t *testing.T) {
+	cases := []struct {
+		name   string
+		newCmd func() *cobra.Command
+		args   []string
+		// a body property that is a nested object at depth 1
+		nested string
+	}{
+		{
+			name:   "create-branch",
+			newCmd: func() *cobra.Command { return createBranchCmd(func(req openapi.APIRequest) error { return nil }) },
+			nested: "modelKind",
+		},
+		{
+			name:   "set-attributes",
+			newCmd: func() *cobra.Command { return setUserAttributesCmd(func(req openapi.APIRequest) error { return nil }) },
+			nested: "Operations",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			full, _ := schemaDocFrom(t, tc.newCmd())
+			shallow, _ := schemaDocFrom(t, tc.newCmd(), "--depth", "0")
+			if jsonOf(t, full) == jsonOf(t, shallow) {
+				t.Fatal("--depth 0 produced the default document; the flag is a no-op")
+			}
+
+			props := shallow.Body.(map[string]interface{})["properties"].(map[string]interface{})
+			node, ok := props[tc.nested].(map[string]interface{})
+			if !ok {
+				t.Fatalf("body.properties.%s missing: %v", tc.nested, props)
+			}
+			if node["note"] != "max depth reached; expansion omitted" {
+				t.Errorf("body.properties.%s = %v, want the depth placeholder", tc.nested, node)
+			}
+			// The placeholder keeps the node's type, as the describer's does.
+			if _, ok := node["type"]; !ok {
+				t.Errorf("depth placeholder dropped the type: %v", node)
+			}
+			// The response section honors --depth too.
+			respProps := shallow.Response.Schema.(map[string]interface{})["properties"].(map[string]interface{})
+			for name, v := range respProps {
+				if n, ok := v.(map[string]interface{}); !ok || n["note"] != "max depth reached; expansion omitted" {
+					t.Errorf("response property %q was not truncated: %v", name, v)
+				}
+			}
+
+			// A deeper budget expands more than a shallower one.
+			deeper, _ := schemaDocFrom(t, tc.newCmd(), "--depth", "1")
+			if jsonOf(t, deeper) == jsonOf(t, shallow) {
+				t.Error("--depth 1 matched --depth 0; truncation is not depth-sensitive")
+			}
+		})
+	}
+}
+
+// A deprecated operation's --schema output must be pure JSON on stdout: cobra
+// would otherwise print its deprecation notice ahead of the document. PUT
+// /api/v1/documents/{identifier} is deprecated in the shipped spec.
+func TestDeprecatedCommand_SchemaEmitsCleanJSON(t *testing.T) {
+	root := specRoot(t)
+	var out, errBuf bytes.Buffer
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"documents", "put", "--schema", "--compact"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute --schema: %v\n%s%s", err, out.String(), errBuf.String())
+	}
+	var doc openapi.SchemaDoc
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("stdout is not pure JSON (deprecation notice leaked?): %v\n%s", err, out.String())
+	}
+	if doc.Method != "PUT" {
+		t.Errorf("method = %q, want PUT", doc.Method)
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("stderr = %q, want nothing on a --schema run", errBuf.String())
+	}
+}

--- a/cmd/omni/user_commands.go
+++ b/cmd/omni/user_commands.go
@@ -97,15 +97,8 @@ attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
 	cmd.Flags().String("attr-json", "", `JSON object of attributes for numeric/array values, e.g. '{"level":3,"regions":["us","eu"]}'`)
 
 	// Hand-written, but agents reach for --schema on any API command; describe the
-	// SCIM PATCH body it assembles so the flag works here too. That body is built
-	// from --attr/--attr-json rather than passed through, so --field has nothing
-	// to drill into.
-	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command, names openapi.SchemaFlags) error {
-		if field, _ := c.Flags().GetString(names.Field); field != "" {
-			return fmt.Errorf("--%s is not supported for set-attributes; its request body is assembled by the CLI and shown in full", names.Field)
-		}
-		return openapi.EmitSchemaDoc(c, setAttributesSchemaDoc())
-	})
+	// SCIM PATCH body it assembles so the flag works here too.
+	openapi.RegisterSchemaFlag(cmd, openapi.StaticSchemaEmitter("set-attributes", setAttributesSchemaDoc))
 
 	cmd.Example = `  # Set two string attributes (by user ID)
   omni users set-attributes 550e8400-e29b-41d4-a716-446655440000 --attr region=us-east --attr team=growth
@@ -126,10 +119,9 @@ attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
 // the hand-written set-attributes command. The body shown is the SCIM PatchOp
 // the CLI assembles from --attr/--attr-json; the response is the SCIM user
 // representation returned by PATCH /api/scim/v2/Users/{id}.
+// Hand-transcribed, so TestStaticSchemaDocs_ResponseMatchesSpec checks it
+// against the spec and the body-assembly code — keep both in step.
 func setAttributesSchemaDoc() openapi.SchemaDoc {
-	str := func(desc string) map[string]interface{} {
-		return map[string]interface{}{"type": "string", "description": desc}
-	}
 	return openapi.SchemaDoc{
 		Method: "PATCH",
 		Path:   "/api/scim/v2/Users/{id}",
@@ -155,7 +147,7 @@ func setAttributesSchemaDoc() openapi.SchemaDoc {
 					"items": map[string]interface{}{
 						"type": "object",
 						"properties": map[string]interface{}{
-							"op":    str(`always "replace"`),
+							"op":    schemaString(`always "replace"`),
 							"value": map[string]interface{}{"type": "object", "description": "attribute name → value; null clears the attribute"},
 						},
 						"required": []string{"op", "value"},
@@ -165,8 +157,8 @@ func setAttributesSchemaDoc() openapi.SchemaDoc {
 			"required": []string{"schemas", "Operations"},
 		},
 		Example: map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{{
+			"schemas": []interface{}{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []interface{}{map[string]interface{}{
 				"op": "replace",
 				"value": map[string]interface{}{
 					userAttributePrefix: map[string]interface{}{"region": "us-east"},
@@ -181,7 +173,7 @@ func setAttributesSchemaDoc() openapi.SchemaDoc {
 				"type": "object",
 				"properties": map[string]interface{}{
 					"active":      map[string]interface{}{"type": "boolean", "description": "Whether the user is active"},
-					"displayName": str("Display name"),
+					"displayName": schemaString("Display name"),
 					"id":          map[string]interface{}{"type": "string", "format": "uuid", "description": "SCIM user ID"},
 					"schemas":     map[string]interface{}{"type": "array", "description": "SCIM schema URIs", "items": map[string]interface{}{"type": "string"}},
 					"userName":    map[string]interface{}{"type": "string", "format": "email", "description": "Username (email)"},

--- a/cmd/omni/user_commands.go
+++ b/cmd/omni/user_commands.go
@@ -100,9 +100,9 @@ attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
 	// SCIM PATCH body it assembles so the flag works here too. That body is built
 	// from --attr/--attr-json rather than passed through, so --field has nothing
 	// to drill into.
-	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command) error {
-		if field, _ := c.Flags().GetString("field"); field != "" {
-			return fmt.Errorf("--field is not supported for set-attributes; its request body is assembled by the CLI and shown in full")
+	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command, names openapi.SchemaFlags) error {
+		if field, _ := c.Flags().GetString(names.Field); field != "" {
+			return fmt.Errorf("--%s is not supported for set-attributes; its request body is assembled by the CLI and shown in full", names.Field)
 		}
 		return openapi.EmitSchemaDoc(c, setAttributesSchemaDoc())
 	})

--- a/cmd/omni/user_commands.go
+++ b/cmd/omni/user_commands.go
@@ -96,6 +96,17 @@ attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
 	cmd.Flags().StringArray("attr", nil, "user attribute as key=value (repeatable); empty value clears the attribute")
 	cmd.Flags().String("attr-json", "", `JSON object of attributes for numeric/array values, e.g. '{"level":3,"regions":["us","eu"]}'`)
 
+	// Hand-written, but agents reach for --schema on any API command; describe the
+	// SCIM PATCH body it assembles so the flag works here too. That body is built
+	// from --attr/--attr-json rather than passed through, so --field has nothing
+	// to drill into.
+	openapi.RegisterSchemaFlag(cmd, func(c *cobra.Command) error {
+		if field, _ := c.Flags().GetString("field"); field != "" {
+			return fmt.Errorf("--field is not supported for set-attributes; its request body is assembled by the CLI and shown in full")
+		}
+		return openapi.EmitSchemaDoc(c, setAttributesSchemaDoc())
+	})
+
 	cmd.Example = `  # Set two string attributes (by user ID)
   omni users set-attributes 550e8400-e29b-41d4-a716-446655440000 --attr region=us-east --attr team=growth
 
@@ -109,6 +120,76 @@ attribute. Use --attr-json to set numeric or multi-value (array) attributes.`,
   omni users set-attributes user@example.com --attr-json '{"level":3,"regions":["us","eu"]}'`
 
 	return cmd
+}
+
+// setAttributesSchemaDoc mirrors the generated commands' --schema document for
+// the hand-written set-attributes command. The body shown is the SCIM PatchOp
+// the CLI assembles from --attr/--attr-json; the response is the SCIM user
+// representation returned by PATCH /api/scim/v2/Users/{id}.
+func setAttributesSchemaDoc() openapi.SchemaDoc {
+	str := func(desc string) map[string]interface{} {
+		return map[string]interface{}{"type": "string", "description": desc}
+	}
+	return openapi.SchemaDoc{
+		Method: "PATCH",
+		Path:   "/api/scim/v2/Users/{id}",
+		Args: []openapi.SchemaArg{{
+			Name:        "userIdOrEmail",
+			Placeholder: "<user-id-or-email>",
+			Type:        "string",
+			Description: "SCIM user ID, or an email address resolved to one via a SCIM lookup",
+		}},
+		Required: []string{"schemas", "Operations"},
+		Body: map[string]interface{}{
+			"type":        "object",
+			"description": "SCIM PatchOp assembled by the CLI from --attr/--attr-json; not passed through as JSON.",
+			"properties": map[string]interface{}{
+				"schemas": map[string]interface{}{
+					"type":        "array",
+					"description": `always ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]`,
+					"items":       map[string]interface{}{"type": "string"},
+				},
+				"Operations": map[string]interface{}{
+					"type":        "array",
+					"description": "a single replace op nesting the attributes under " + userAttributePrefix,
+					"items": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"op":    str(`always "replace"`),
+							"value": map[string]interface{}{"type": "object", "description": "attribute name → value; null clears the attribute"},
+						},
+						"required": []string{"op", "value"},
+					},
+				},
+			},
+			"required": []string{"schemas", "Operations"},
+		},
+		Example: map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{{
+				"op": "replace",
+				"value": map[string]interface{}{
+					userAttributePrefix: map[string]interface{}{"region": "us-east"},
+				},
+			}},
+		},
+		Response: &openapi.SchemaResponse{
+			Status:      "200",
+			ContentType: "application/json",
+			Description: "SCIM user updated",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"active":      map[string]interface{}{"type": "boolean", "description": "Whether the user is active"},
+					"displayName": str("Display name"),
+					"id":          map[string]interface{}{"type": "string", "format": "uuid", "description": "SCIM user ID"},
+					"schemas":     map[string]interface{}{"type": "array", "description": "SCIM schema URIs", "items": map[string]interface{}{"type": "string"}},
+					"userName":    map[string]interface{}{"type": "string", "format": "email", "description": "Username (email)"},
+				},
+				"required": []string{"active", "displayName", "id", "schemas", "userName"},
+			},
+		},
+	}
 }
 
 // buildSetAttributesBody assembles a SCIM PatchOp body that sets Omni user

--- a/cmd/omni/user_commands_test.go
+++ b/cmd/omni/user_commands_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -289,6 +290,53 @@ func TestSetUserAttributesCmd_RequiresAttr(t *testing.T) {
 	cmd.SetArgs([]string{"user-123"})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected error when no attributes provided")
+	}
+}
+
+// TestSetUserAttributesCmd_Schema verifies the hand-written command answers
+// --schema with the same document shape as generated commands: no positional
+// arg, no attributes, no API call.
+func TestSetUserAttributesCmd_Schema(t *testing.T) {
+	var called bool
+	cmd := setUserAttributesCmd(func(req openapi.APIRequest) error { called = true; return nil })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--schema"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute --schema: %v\n%s", err, buf.String())
+	}
+	if called {
+		t.Error("executor was called on a --schema run")
+	}
+
+	var doc openapi.SchemaDoc
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
+	}
+	if doc.Method != "PATCH" || doc.Path != "/api/scim/v2/Users/{id}" {
+		t.Errorf("method/path = %q %q, want PATCH /api/scim/v2/Users/{id}", doc.Method, doc.Path)
+	}
+	if len(doc.Args) != 1 || doc.Args[0].Placeholder != "<user-id-or-email>" {
+		t.Errorf("args = %+v, want the <user-id-or-email> positional", doc.Args)
+	}
+	body, ok := doc.Body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("body is not an object: %T", doc.Body)
+	}
+	props, ok := body["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body.properties missing: %v", body)
+	}
+	for _, key := range []string{"schemas", "Operations"} {
+		if _, ok := props[key]; !ok {
+			t.Errorf("body properties missing %q", key)
+		}
+	}
+	if doc.Response == nil || doc.Response.Status != "200" || doc.Response.Schema == nil {
+		t.Errorf("response = %+v, want the 200 SCIM user shape", doc.Response)
 	}
 }
 

--- a/internal/openapi/body_shorthand.go
+++ b/internal/openapi/body_shorthand.go
@@ -438,7 +438,7 @@ func shorthandFieldType(bodySchema *base.SchemaProxy, fieldPath string) (string,
 	if bodySchema == nil {
 		return "string", nil
 	}
-	fieldSchema, err := resolveField(bodySchema, fieldPath)
+	fieldSchema, err := resolveField(bodySchema, fieldPath, "field")
 	if err != nil {
 		return "", fmt.Errorf("field %q is not present in the request schema: %w", fieldPath, err)
 	}

--- a/internal/openapi/body_shorthand_test.go
+++ b/internal/openapi/body_shorthand_test.go
@@ -994,7 +994,7 @@ func TestShorthand_AllMappedFieldsExistInSpec(t *testing.T) {
 			continue
 		}
 		for _, arg := range sh.Args {
-			if _, err := resolveField(op.BodySchema, arg.FieldPath); err != nil {
+			if _, err := resolveField(op.BodySchema, arg.FieldPath, "field"); err != nil {
 				t.Errorf("%s: positional field %q is not present in the request schema: %v", opID, arg.FieldPath, err)
 			}
 		}

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
 	"github.com/spf13/cobra"
 )
 
@@ -288,46 +289,36 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 	// Args/RunE, so the short-circuit wraps the final versions. Registered for
 	// every operation — bodyless ones still describe their args, query flags and
 	// response shape.
-	RegisterSchemaFlag(cmd, func(c *cobra.Command) error {
-		return emitBodySchema(c, op)
+	RegisterSchemaFlag(cmd, func(c *cobra.Command, names SchemaFlags) error {
+		return emitBodySchema(c, op, names)
 	})
 
 	return cmd
 }
 
-// schemaRequested reports whether the --schema discovery flag is set.
-func schemaRequested(cmd *cobra.Command) bool {
-	v, err := cmd.Flags().GetBool("schema")
+// schemaRequested reports whether the schema discovery flag — registered under
+// name, which is not always "schema" (see RegisterSchemaFlag) — is set.
+func schemaRequested(cmd *cobra.Command, name string) bool {
+	v, err := cmd.Flags().GetBool(name)
 	return err == nil && v
 }
 
 // requestBodySchema returns the schema for a request body, preferring the
 // application/json media type and falling back to the first declared one.
 func requestBodySchema(rb *v3.RequestBody) *base.SchemaProxy {
-	if rb == nil || rb.Content == nil {
+	if rb == nil {
 		return nil
 	}
-	var first *base.SchemaProxy
-	for pair := rb.Content.First(); pair != nil; pair = pair.Next() {
-		mt := pair.Value()
-		if mt == nil || mt.Schema == nil {
-			continue
-		}
-		if pair.Key() == "application/json" {
-			return mt.Schema
-		}
-		if first == nil {
-			first = mt.Schema
-		}
-	}
-	return first
+	_, schema := pickMediaType(rb.Content)
+	return schema
 }
 
 // successResponse returns the operation's success response: the lowest declared
 // 2xx status (the happy path; a lower code wins so 200 beats a 202 fallback),
-// preferring the application/json media type and falling back to the first
-// declared one. It returns nil when no 2xx status is declared, and a
-// schema-less responseInfo when the status carries no body (e.g. 204).
+// falling back to an OpenAPI range key ("2XX") when only that is declared — a
+// specific code always beats the wildcard. It returns nil when no success status
+// is declared at all, and a schema-less responseInfo when the status carries no
+// body (e.g. 204).
 func successResponse(resps *v3.Responses) *responseInfo {
 	if resps == nil || resps.Codes == nil {
 		return nil
@@ -336,39 +327,88 @@ func successResponse(resps *v3.Responses) *responseInfo {
 	best := 0
 	var bestResp *v3.Response
 	var bestCode string
+	var wildcardResp *v3.Response
+	var wildcardCode string
+
 	for pair := resps.Codes.First(); pair != nil; pair = pair.Next() {
-		code, err := strconv.Atoi(pair.Key())
+		key := pair.Key()
+		if isSuccessRange(key) {
+			if wildcardResp == nil {
+				wildcardCode, wildcardResp = key, pair.Value()
+			}
+			continue
+		}
+		code, err := strconv.Atoi(key)
 		if err != nil || code < 200 || code > 299 {
 			continue
 		}
 		if bestResp == nil || code < best {
-			best, bestCode, bestResp = code, pair.Key(), pair.Value()
+			best, bestCode, bestResp = code, key, pair.Value()
 		}
+	}
+	if bestResp == nil {
+		bestCode, bestResp = wildcardCode, wildcardResp
 	}
 	if bestResp == nil {
 		return nil
 	}
 
 	info := &responseInfo{Status: bestCode, Description: bestResp.Description}
-	if bestResp.Content == nil {
-		return info
-	}
-	for pair := bestResp.Content.First(); pair != nil; pair = pair.Next() {
-		mt := pair.Value()
-		if mt == nil || mt.Schema == nil {
-			continue
-		}
-		if pair.Key() == "application/json" {
-			info.ContentType = pair.Key()
-			info.Schema = mt.Schema
-			return info
-		}
-		if info.Schema == nil {
-			info.ContentType = pair.Key()
-			info.Schema = mt.Schema
-		}
-	}
+	info.ContentType, info.Schema = pickMediaType(bestResp.Content)
 	return info
+}
+
+// isSuccessRange reports whether a response key is the OpenAPI 2xx range
+// wildcard. The spec writes ranges uppercase ("2XX"), but tolerate any casing.
+func isSuccessRange(key string) bool {
+	return len(key) == 3 && key[0] == '2' && (key[1] == 'X' || key[1] == 'x') && (key[2] == 'X' || key[2] == 'x')
+}
+
+// pickMediaType chooses which declared media type to report, preferring
+// application/json and then the first type carrying a schema. A media type that
+// declares no schema is still reported by name with a nil schema: "this comes
+// back as text/csv, shape undocumented" beats implying the response is empty.
+func pickMediaType(content *orderedmap.Map[string, *v3.MediaType]) (string, *base.SchemaProxy) {
+	if content == nil {
+		return "", nil
+	}
+
+	var jsonType string
+	var jsonSchema *base.SchemaProxy
+	var firstWithSchema string
+	var firstSchema *base.SchemaProxy
+	var firstAny string
+
+	for pair := content.First(); pair != nil; pair = pair.Next() {
+		key := pair.Key()
+		var schema *base.SchemaProxy
+		if mt := pair.Value(); mt != nil {
+			schema = mt.Schema
+		}
+		if key == "application/json" {
+			if schema != nil {
+				return key, schema
+			}
+			if jsonType == "" {
+				jsonType, jsonSchema = key, schema
+			}
+		}
+		if schema != nil && firstWithSchema == "" {
+			firstWithSchema, firstSchema = key, schema
+		}
+		if firstAny == "" {
+			firstAny = key
+		}
+	}
+
+	switch {
+	case firstWithSchema != "":
+		return firstWithSchema, firstSchema
+	case jsonType != "":
+		return jsonType, jsonSchema
+	default:
+		return firstAny, nil
+	}
 }
 
 // commandName derives a CLI subcommand name from the operationId or method+path.

--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/pb33f/libopenapi"
@@ -92,7 +93,17 @@ type operationInfo struct {
 	QueryParams []paramInfo
 	HasBody     bool
 	BodySchema  *base.SchemaProxy // request body schema, when HasBody
+	Response    *responseInfo     // success (2xx) response, when the spec declares one
 	Deprecated  bool
+}
+
+// responseInfo captures the operation's success response so --schema can show
+// callers what shape comes back — otherwise invisible without making a call.
+type responseInfo struct {
+	Status      string
+	ContentType string
+	Description string
+	Schema      *base.SchemaProxy // nil when the status declares no body/schema
 }
 
 func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*operationInfo) {
@@ -160,6 +171,8 @@ func extractOperations(pathStr string, item *v3.PathItem, groups map[string][]*o
 			info.HasBody = true
 			info.BodySchema = requestBodySchema(op.RequestBody)
 		}
+
+		info.Response = successResponse(op.Responses)
 
 		groups[tag] = append(groups[tag], info)
 	}
@@ -271,40 +284,13 @@ func buildCommand(op *operationInfo, exec Executor) *cobra.Command {
 		applyBodyShorthand(cmd, op, sh)
 	}
 
-	// Add the --schema discovery flag last, wrapping arg validation and RunE so
-	// it short-circuits before any positional-arg checks, body assembly, auth,
-	// or network call. This lets `omni <cmd> --schema` work with no args/token.
-	if op.HasBody {
-		cmd.Flags().Bool("schema", false, "print the request body's JSON schema and a filled-in example, then exit (no API call)")
-		// --field / --depth refine the --schema output for deeply nested bodies.
-		// Guarded so a future query/path param of the same name can't panic the
-		// flag registration.
-		if cmd.Flags().Lookup("field") == nil {
-			cmd.Flags().String("field", "", "with --schema: drill into a dotted field path (e.g. queryPresentations.data.query); auto-descends arrays and maps")
-		}
-		if cmd.Flags().Lookup("depth") == nil {
-			cmd.Flags().Int("depth", maxSchemaDepth, "with --schema: max nesting depth to expand; lower for a compact overview")
-		}
-
-		innerArgs := cmd.Args
-		cmd.Args = func(c *cobra.Command, args []string) error {
-			if schemaRequested(c) || innerArgs == nil {
-				return nil
-			}
-			return innerArgs(c, args)
-		}
-
-		innerRun := cmd.RunE
-		cmd.RunE = func(c *cobra.Command, args []string) error {
-			if schemaRequested(c) {
-				// A schema error (e.g. a bad --field path) should print just the
-				// helpful message, not the full usage block.
-				c.SilenceUsage = true
-				return emitBodySchema(c, op)
-			}
-			return innerRun(c, args)
-		}
-	}
+	// Add the --schema discovery flag last, after any shorthand has replaced
+	// Args/RunE, so the short-circuit wraps the final versions. Registered for
+	// every operation — bodyless ones still describe their args, query flags and
+	// response shape.
+	RegisterSchemaFlag(cmd, func(c *cobra.Command) error {
+		return emitBodySchema(c, op)
+	})
 
 	return cmd
 }
@@ -335,6 +321,54 @@ func requestBodySchema(rb *v3.RequestBody) *base.SchemaProxy {
 		}
 	}
 	return first
+}
+
+// successResponse returns the operation's success response: the lowest declared
+// 2xx status (the happy path; a lower code wins so 200 beats a 202 fallback),
+// preferring the application/json media type and falling back to the first
+// declared one. It returns nil when no 2xx status is declared, and a
+// schema-less responseInfo when the status carries no body (e.g. 204).
+func successResponse(resps *v3.Responses) *responseInfo {
+	if resps == nil || resps.Codes == nil {
+		return nil
+	}
+
+	best := 0
+	var bestResp *v3.Response
+	var bestCode string
+	for pair := resps.Codes.First(); pair != nil; pair = pair.Next() {
+		code, err := strconv.Atoi(pair.Key())
+		if err != nil || code < 200 || code > 299 {
+			continue
+		}
+		if bestResp == nil || code < best {
+			best, bestCode, bestResp = code, pair.Key(), pair.Value()
+		}
+	}
+	if bestResp == nil {
+		return nil
+	}
+
+	info := &responseInfo{Status: bestCode, Description: bestResp.Description}
+	if bestResp.Content == nil {
+		return info
+	}
+	for pair := bestResp.Content.First(); pair != nil; pair = pair.Next() {
+		mt := pair.Value()
+		if mt == nil || mt.Schema == nil {
+			continue
+		}
+		if pair.Key() == "application/json" {
+			info.ContentType = pair.Key()
+			info.Schema = mt.Schema
+			return info
+		}
+		if info.Schema == nil {
+			info.ContentType = pair.Key()
+			info.Schema = mt.Schema
+		}
+	}
+	return info
 }
 
 // commandName derives a CLI subcommand name from the operationId or method+path.

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/spf13/cobra"
 )
 
 // ---------------------------------------------------------------------------
@@ -416,12 +417,16 @@ func TestGenerateCommands_SchemaFlagOnEveryCommand(t *testing.T) {
 		t.Fatalf("GenerateCommands: %v", err)
 	}
 
+	// A spec param may legitimately own one of these names, in which case the
+	// discovery flag lives under its fallback — but it must exist either way.
+	fallbacks := map[string]string{"schema": "schema-doc", "field": "schema-field", "depth": "schema-depth"}
+
 	checked := 0
 	for _, tagCmd := range cmds {
 		for _, sub := range tagCmd.Commands() {
-			for _, flag := range []string{"schema", "field", "depth"} {
-				if sub.Flags().Lookup(flag) == nil {
-					t.Errorf("%s %s: missing --%s", tagCmd.Name(), sub.Name(), flag)
+			for flag, fallback := range fallbacks {
+				if sub.Flags().Lookup(flag) == nil && sub.Flags().Lookup(fallback) == nil {
+					t.Errorf("%s %s: neither --%s nor --%s registered", tagCmd.Name(), sub.Name(), flag, fallback)
 				}
 			}
 			checked++
@@ -431,6 +436,26 @@ func TestGenerateCommands_SchemaFlagOnEveryCommand(t *testing.T) {
 		t.Fatal("no subcommands were checked")
 	}
 	t.Logf("checked --schema registration on %d subcommands", checked)
+}
+
+// freeFlagName must never give up: when both the preferred name and its
+// fallback are taken it keeps suffixing until it finds a free one, so the
+// discovery flag is always registered somewhere.
+func TestFreeFlagName(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	if got := freeFlagName(cmd, "schema", "schema-doc"); got != "schema" {
+		t.Errorf("freeFlagName on an empty command = %q, want schema", got)
+	}
+
+	cmd.Flags().String("schema", "", "a spec param")
+	if got := freeFlagName(cmd, "schema", "schema-doc"); got != "schema-doc" {
+		t.Errorf("freeFlagName with schema taken = %q, want schema-doc", got)
+	}
+
+	cmd.Flags().String("schema-doc", "", "another spec param")
+	if got := freeFlagName(cmd, "schema", "schema-doc"); got != "schema-doc-2" {
+		t.Errorf("freeFlagName with both taken = %q, want schema-doc-2", got)
+	}
 }
 
 // --schema must short-circuit before positional-arg validation, so a command

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -405,6 +405,65 @@ func TestBuildCommand_WrongArgCount(t *testing.T) {
 	}
 }
 
+// Every generated command must accept --schema (and its --field/--depth
+// refinements), including bodyless GET/DELETE ones. Agents reach for --schema
+// first, so a command missing the flag costs a wasted call.
+func TestGenerateCommands_SchemaFlagOnEveryCommand(t *testing.T) {
+	specData := loadSpec(t)
+	noop := func(req APIRequest) error { return nil }
+	cmds, err := GenerateCommands(specData, noop)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+
+	checked := 0
+	for _, tagCmd := range cmds {
+		for _, sub := range tagCmd.Commands() {
+			for _, flag := range []string{"schema", "field", "depth"} {
+				if sub.Flags().Lookup(flag) == nil {
+					t.Errorf("%s %s: missing --%s", tagCmd.Name(), sub.Name(), flag)
+				}
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no subcommands were checked")
+	}
+	t.Logf("checked --schema registration on %d subcommands", checked)
+}
+
+// --schema must short-circuit before positional-arg validation, so a command
+// with required path params still answers without them (and without a token).
+func TestBuildCommand_SchemaSkipsArgValidation(t *testing.T) {
+	var called bool
+	exec := func(req APIRequest) error { called = true; return nil }
+
+	op := &operationInfo{
+		Tag:         "test",
+		OperationID: "testGetWidget",
+		Method:      "GET",
+		Path:        "/api/v1/widgets/{widgetId}",
+		PathParams:  []paramInfo{{Name: "widgetId", In: "path", Type: "string"}},
+	}
+
+	cmd := buildCommand(op, exec)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--schema"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute --schema with no args: %v", err)
+	}
+	if called {
+		t.Error("executor was called on a --schema run")
+	}
+	if !strings.Contains(buf.String(), `"body": null`) {
+		t.Errorf("schema output missing an explicit null body: %s", buf.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Spec coverage reporter
 //

--- a/internal/openapi/schema.go
+++ b/internal/openapi/schema.go
@@ -50,10 +50,12 @@ type SchemaResponse struct {
 // (authoritative shape plus a copy-pasteable Example) and the success response
 // shape. Body is explicitly null for operations that take no request body, so
 // "no body" is unambiguous rather than merely absent. Response is always present
-// (null when the spec declares no 2xx status).
+// (null when the spec declares no 2xx status). SchemaFlags appears only when a
+// spec parameter forced a discovery flag off its preferred name.
 type SchemaDoc struct {
 	Method      string             `json:"method"`
 	Path        string             `json:"path"`
+	SchemaFlags *SchemaFlags       `json:"schemaFlags,omitempty"`
 	Field       string             `json:"field,omitempty"`
 	Args        []SchemaArg        `json:"args,omitempty"`
 	QueryParams []SchemaQueryParam `json:"queryParams,omitempty"`
@@ -70,34 +72,57 @@ type describer struct {
 	maxDepth int
 }
 
+// SchemaFlags carries the flag names the discovery flags were actually
+// registered under. They are the preferred names (schema/field/depth) unless a
+// spec parameter already owns one, in which case the discovery flag falls back
+// to a prefixed name. The emit callback must read the flags through these names
+// rather than hardcoding them.
+type SchemaFlags struct {
+	Schema string `json:"schema"`
+	Field  string `json:"field"`
+	Depth  string `json:"depth"`
+}
+
+// Renamed reports whether any discovery flag had to fall back off its preferred
+// name because a spec parameter owns it.
+func (f SchemaFlags) Renamed() bool {
+	return f.Schema != "schema" || f.Field != "field" || f.Depth != "depth"
+}
+
 // RegisterSchemaFlag adds the --schema discovery flag (plus its --field and
 // --depth refinements) to cmd and wraps arg validation and RunE so --schema
 // short-circuits before any positional-arg check, body assembly, auth, or
 // network call. That lets `omni <cmd> --schema` work with no args and no token.
-// emit is called to produce the document when --schema is set.
+// emit is called with the resolved flag names to produce the document.
 //
 // Every command registers this, including bodyless GET/DELETE operations: agents
 // reach for --schema first, and "unknown flag: --schema" wastes a whole call.
-func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command) error) {
-	// A spec parameter that already claims this flag name wins; re-registering
-	// would panic at startup, and every generated command now comes through here.
-	if cmd.Flags().Lookup("schema") != nil {
-		return
+//
+// Collision policy: a spec parameter always keeps its own flag name — it is the
+// operation's contract, and silently reinterpreting e.g. an endpoint's --depth
+// query param as a discovery control would corrupt requests. When a parameter
+// owns one of these names, that discovery flag is registered under a
+// deterministic "schema-" prefixed fallback (--schema-doc / --schema-field /
+// --schema-depth, and -2, -3… if those are taken too) and its help text says so.
+// Discovery is therefore never unavailable, just occasionally renamed.
+func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command, SchemaFlags) error) SchemaFlags {
+	names := SchemaFlags{
+		Schema: freeFlagName(cmd, "schema", "schema-doc"),
+		Field:  freeFlagName(cmd, "field", "schema-field"),
+		Depth:  freeFlagName(cmd, "depth", "schema-depth"),
 	}
-	cmd.Flags().Bool("schema", false, "print this command's args, flags, request body and response shape, then exit (no API call)")
+
+	cmd.Flags().Bool(names.Schema, false,
+		renameNote("print this command's args, flags, request body and response shape, then exit (no API call)", "schema", names.Schema))
 	// --field / --depth refine the --schema output for deeply nested shapes.
-	// Guarded so a query/path param of the same name can't panic the flag
-	// registration.
-	if cmd.Flags().Lookup("field") == nil {
-		cmd.Flags().String("field", "", "with --schema: drill into a dotted field path of the request body (e.g. queryPresentations.data.query); auto-descends arrays and maps; does not affect the response section")
-	}
-	if cmd.Flags().Lookup("depth") == nil {
-		cmd.Flags().Int("depth", maxSchemaDepth, "with --schema: max nesting depth to expand (request body and response); lower for a compact overview")
-	}
+	cmd.Flags().String(names.Field, "",
+		renameNote(fmt.Sprintf("with --%s: drill into a dotted field path of the request body (e.g. queryPresentations.data.query); auto-descends arrays and maps; does not affect the response section", names.Schema), "field", names.Field))
+	cmd.Flags().Int(names.Depth, maxSchemaDepth,
+		renameNote(fmt.Sprintf("with --%s: max nesting depth to expand (request body and response); lower for a compact overview", names.Schema), "depth", names.Depth))
 
 	innerArgs := cmd.Args
 	cmd.Args = func(c *cobra.Command, args []string) error {
-		if schemaRequested(c) || innerArgs == nil {
+		if schemaRequested(c, names.Schema) || innerArgs == nil {
 			return nil
 		}
 		return innerArgs(c, args)
@@ -105,27 +130,57 @@ func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command) error) {
 
 	innerRun := cmd.RunE
 	cmd.RunE = func(c *cobra.Command, args []string) error {
-		if schemaRequested(c) {
+		if schemaRequested(c, names.Schema) {
 			// A schema error (e.g. a bad --field path) should print just the
 			// helpful message, not the full usage block.
 			c.SilenceUsage = true
-			return emit(c)
+			return emit(c, names)
 		}
 		if innerRun == nil {
 			return nil
 		}
 		return innerRun(c, args)
 	}
+
+	return names
+}
+
+// freeFlagName returns preferred if no flag owns it, otherwise fallback, and
+// otherwise fallback with the lowest "-N" suffix that is free. Registration
+// therefore always succeeds — a discovery flag never silently disappears, and a
+// spec parameter is never shadowed.
+func freeFlagName(cmd *cobra.Command, preferred, fallback string) string {
+	if cmd.Flags().Lookup(preferred) == nil {
+		return preferred
+	}
+	if cmd.Flags().Lookup(fallback) == nil {
+		return fallback
+	}
+	for n := 2; ; n++ {
+		candidate := fmt.Sprintf("%s-%d", fallback, n)
+		if cmd.Flags().Lookup(candidate) == nil {
+			return candidate
+		}
+	}
+}
+
+// renameNote appends an explanation to a discovery flag's help when it had to
+// give up its preferred name, so `--help` still leads the reader to it.
+func renameNote(desc, preferred, actual string) string {
+	if preferred == actual {
+		return desc
+	}
+	return fmt.Sprintf("%s (named --%s here because --%s is a parameter of this endpoint)", desc, actual, preferred)
 }
 
 // emitBodySchema writes a generated operation's schema document to the command's
 // stdout, honoring the global --compact flag. It makes no network call and needs
 // no auth. The optional --field flag drills into a dotted sub-path of the request
 // body; --depth caps how deep nested objects expand.
-func emitBodySchema(cmd *cobra.Command, op *operationInfo) error {
-	field, _ := cmd.Flags().GetString("field")
+func emitBodySchema(cmd *cobra.Command, op *operationInfo, names SchemaFlags) error {
+	field, _ := cmd.Flags().GetString(names.Field)
 
-	doc, err := describeBody(op, field, schemaDepth(cmd))
+	doc, err := describeBody(op, field, schemaDepth(cmd, names.Depth), names)
 	if err != nil {
 		return err
 	}
@@ -153,10 +208,10 @@ func EmitSchemaDoc(cmd *cobra.Command, doc SchemaDoc) error {
 	return nil
 }
 
-// schemaDepth reads the --depth flag, falling back to the default cap when it is
+// schemaDepth reads the depth flag, falling back to the default cap when it is
 // unset or nonsensical.
-func schemaDepth(cmd *cobra.Command) int {
-	depth, err := cmd.Flags().GetInt("depth")
+func schemaDepth(cmd *cobra.Command, name string) int {
+	depth, err := cmd.Flags().GetInt(name)
 	if err != nil || depth < 0 {
 		return maxSchemaDepth
 	}
@@ -168,8 +223,14 @@ func schemaDepth(cmd *cobra.Command) int {
 // drills to that dotted sub-path of the request body; maxDepth caps nested
 // expansion. Drilling restarts the depth budget from the resolved node, so a deep
 // field still expands fully.
-func describeBody(op *operationInfo, field string, maxDepth int) (SchemaDoc, error) {
+func describeBody(op *operationInfo, field string, maxDepth int, names SchemaFlags) (SchemaDoc, error) {
 	doc := SchemaDoc{Method: op.Method, Path: op.Path, Field: field}
+	if names.Renamed() {
+		// Surface the fallback names in the document too, so an agent that got
+		// here via --schema-doc learns what to pass for the refinements.
+		renamed := names
+		doc.SchemaFlags = &renamed
+	}
 	d := &describer{maxDepth: maxDepth}
 
 	for _, p := range op.PathParams {
@@ -201,16 +262,16 @@ func describeBody(op *operationInfo, field string, maxDepth int) (SchemaDoc, err
 				"note": "this operation takes a request body, but the spec declares no schema for it",
 			}
 		}
-		// Either way there is nothing for --field to drill into.
+		// Either way there is nothing for the field flag to drill into.
 		if field != "" {
-			return doc, fmt.Errorf("--field is only meaningful for operations with a request body schema; %s %s has none", op.Method, op.Path)
+			return doc, fmt.Errorf("--%s is only meaningful for operations with a request body schema; %s %s has none", names.Field, op.Method, op.Path)
 		}
 		return doc, nil
 	}
 
 	root := op.BodySchema
 	if field != "" {
-		resolved, err := resolveField(root, field)
+		resolved, err := resolveField(root, field, names.Field)
 		if err != nil {
 			return doc, err
 		}
@@ -253,17 +314,17 @@ func describeResponse(d *describer, resp *responseInfo) *SchemaResponse {
 // "queryPresentations.data.query" without knowing data is a map keyed by tab
 // ID. It returns the resolved proxy, or an error naming the failing segment and
 // listing the fields available there.
-func resolveField(root *base.SchemaProxy, path string) (*base.SchemaProxy, error) {
+func resolveField(root *base.SchemaProxy, path, flagName string) (*base.SchemaProxy, error) {
 	cur := root
 	segs := strings.Split(path, ".")
 	for i, seg := range segs {
 		seg = strings.TrimSpace(seg)
 		if seg == "" {
-			return nil, fmt.Errorf("--field %q has an empty path segment", path)
+			return nil, fmt.Errorf("--%s %q has an empty path segment", flagName, path)
 		}
 		next, err := descendTo(cur, seg)
 		if err != nil {
-			return nil, fmt.Errorf("--field %q: %v", strings.Join(segs[:i+1], "."), err)
+			return nil, fmt.Errorf("--%s %q: %v", flagName, strings.Join(segs[:i+1], "."), err)
 		}
 		cur = next
 	}

--- a/internal/openapi/schema.go
+++ b/internal/openapi/schema.go
@@ -11,21 +11,56 @@ import (
 )
 
 // maxSchemaDepth caps how deep we expand nested objects when describing a
-// request body. Some bodies (notably the v2 document content blob) nest very
-// deeply; without a cap a single --schema dump could be megabytes. Beyond this
-// depth we emit a short placeholder noting the omission rather than recursing.
+// request body or response. Some shapes (notably the v2 document content blob)
+// nest very deeply; without a cap a single --schema dump could be megabytes.
+// Beyond this depth we emit a short placeholder noting the omission rather than
+// recursing.
 const maxSchemaDepth = 8
 
-// bodySchemaDoc is the JSON document emitted by `omni <cmd> --schema`. It gives
-// an agent both the authoritative contract (Body) and a copy-pasteable starting
-// point (Example) for an operation's request body.
-type bodySchemaDoc struct {
-	Method   string      `json:"method"`
-	Path     string      `json:"path"`
-	Field    string      `json:"field,omitempty"`
-	Required []string    `json:"required,omitempty"`
-	Body     interface{} `json:"body"`
-	Example  interface{} `json:"example,omitempty"`
+// SchemaArg describes a positional argument, derived from a spec path param.
+type SchemaArg struct {
+	Name        string `json:"name"`
+	Placeholder string `json:"placeholder"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// SchemaQueryParam describes a query parameter as it is exposed on the CLI.
+type SchemaQueryParam struct {
+	Flag        string   `json:"flag"`
+	Name        string   `json:"name"`
+	Type        string   `json:"type,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Required    bool     `json:"required"`
+	Description string   `json:"description,omitempty"`
+}
+
+// SchemaResponse describes the operation's success response: the lowest 2xx
+// status the spec declares, its media type, and the simplified schema. Schema is
+// nil when that status carries no body (e.g. 204) or declares no schema.
+type SchemaResponse struct {
+	Status      string      `json:"status,omitempty"`
+	ContentType string      `json:"contentType,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Schema      interface{} `json:"schema"`
+}
+
+// SchemaDoc is the JSON document emitted by `omni <cmd> --schema`. It gives an
+// agent the full call contract: positional args, query flags, the request body
+// (authoritative shape plus a copy-pasteable Example) and the success response
+// shape. Body is explicitly null for operations that take no request body, so
+// "no body" is unambiguous rather than merely absent. Response is always present
+// (null when the spec declares no 2xx status).
+type SchemaDoc struct {
+	Method      string             `json:"method"`
+	Path        string             `json:"path"`
+	Field       string             `json:"field,omitempty"`
+	Args        []SchemaArg        `json:"args,omitempty"`
+	QueryParams []SchemaQueryParam `json:"queryParams,omitempty"`
+	Required    []string           `json:"required,omitempty"`
+	Body        interface{}        `json:"body"`
+	Example     interface{}        `json:"example,omitempty"`
+	Response    *SchemaResponse    `json:"response"`
 }
 
 // describer carries the per-invocation expansion budget so --depth can override
@@ -35,24 +70,77 @@ type describer struct {
 	maxDepth int
 }
 
-// emitBodySchema writes the resolved request-body schema and a synthesized
-// example to the command's stdout, honoring the global --compact flag. It makes
-// no network call and needs no auth. The optional --field flag drills into a
-// dotted sub-path of the body; --depth caps how deep nested objects expand.
-func emitBodySchema(cmd *cobra.Command, op *operationInfo) error {
-	field, _ := cmd.Flags().GetString("field")
-	depth, derr := cmd.Flags().GetInt("depth")
-	if derr != nil || depth < 0 {
-		depth = maxSchemaDepth
+// RegisterSchemaFlag adds the --schema discovery flag (plus its --field and
+// --depth refinements) to cmd and wraps arg validation and RunE so --schema
+// short-circuits before any positional-arg check, body assembly, auth, or
+// network call. That lets `omni <cmd> --schema` work with no args and no token.
+// emit is called to produce the document when --schema is set.
+//
+// Every command registers this, including bodyless GET/DELETE operations: agents
+// reach for --schema first, and "unknown flag: --schema" wastes a whole call.
+func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command) error) {
+	// A spec parameter that already claims this flag name wins; re-registering
+	// would panic at startup, and every generated command now comes through here.
+	if cmd.Flags().Lookup("schema") != nil {
+		return
+	}
+	cmd.Flags().Bool("schema", false, "print this command's args, flags, request body and response shape, then exit (no API call)")
+	// --field / --depth refine the --schema output for deeply nested shapes.
+	// Guarded so a query/path param of the same name can't panic the flag
+	// registration.
+	if cmd.Flags().Lookup("field") == nil {
+		cmd.Flags().String("field", "", "with --schema: drill into a dotted field path of the request body (e.g. queryPresentations.data.query); auto-descends arrays and maps; does not affect the response section")
+	}
+	if cmd.Flags().Lookup("depth") == nil {
+		cmd.Flags().Int("depth", maxSchemaDepth, "with --schema: max nesting depth to expand (request body and response); lower for a compact overview")
 	}
 
-	doc, err := describeBody(op, field, depth)
+	innerArgs := cmd.Args
+	cmd.Args = func(c *cobra.Command, args []string) error {
+		if schemaRequested(c) || innerArgs == nil {
+			return nil
+		}
+		return innerArgs(c, args)
+	}
+
+	innerRun := cmd.RunE
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		if schemaRequested(c) {
+			// A schema error (e.g. a bad --field path) should print just the
+			// helpful message, not the full usage block.
+			c.SilenceUsage = true
+			return emit(c)
+		}
+		if innerRun == nil {
+			return nil
+		}
+		return innerRun(c, args)
+	}
+}
+
+// emitBodySchema writes a generated operation's schema document to the command's
+// stdout, honoring the global --compact flag. It makes no network call and needs
+// no auth. The optional --field flag drills into a dotted sub-path of the request
+// body; --depth caps how deep nested objects expand.
+func emitBodySchema(cmd *cobra.Command, op *operationInfo) error {
+	field, _ := cmd.Flags().GetString("field")
+
+	doc, err := describeBody(op, field, schemaDepth(cmd))
 	if err != nil {
 		return err
 	}
+	return EmitSchemaDoc(cmd, doc)
+}
 
+// EmitSchemaDoc writes a schema document as JSON to the command's stdout,
+// honoring the global --compact flag. Hand-written commands use it to emit the
+// same document shape as generated ones.
+func EmitSchemaDoc(cmd *cobra.Command, doc SchemaDoc) error {
 	compact, _ := cmd.Flags().GetBool("compact")
-	var data []byte
+	var (
+		data []byte
+		err  error
+	)
 	if compact {
 		data, err = json.Marshal(doc)
 	} else {
@@ -65,13 +153,58 @@ func emitBodySchema(cmd *cobra.Command, op *operationInfo) error {
 	return nil
 }
 
-// describeBody builds the schema document for an operation's request body. When
-// field is non-empty it drills to that dotted sub-path; maxDepth caps nested
-// expansion. Drilling restarts the depth budget from the resolved node, so a
-// deep field still expands fully.
-func describeBody(op *operationInfo, field string, maxDepth int) (bodySchemaDoc, error) {
-	doc := bodySchemaDoc{Method: op.Method, Path: op.Path, Field: field}
+// schemaDepth reads the --depth flag, falling back to the default cap when it is
+// unset or nonsensical.
+func schemaDepth(cmd *cobra.Command) int {
+	depth, err := cmd.Flags().GetInt("depth")
+	if err != nil || depth < 0 {
+		return maxSchemaDepth
+	}
+	return depth
+}
+
+// describeBody builds the schema document for an operation: its positional args,
+// query flags, request body and success response. When field is non-empty it
+// drills to that dotted sub-path of the request body; maxDepth caps nested
+// expansion. Drilling restarts the depth budget from the resolved node, so a deep
+// field still expands fully.
+func describeBody(op *operationInfo, field string, maxDepth int) (SchemaDoc, error) {
+	doc := SchemaDoc{Method: op.Method, Path: op.Path, Field: field}
+	d := &describer{maxDepth: maxDepth}
+
+	for _, p := range op.PathParams {
+		doc.Args = append(doc.Args, SchemaArg{
+			Name:        p.Name,
+			Placeholder: "<" + slugify(p.Name) + ">",
+			Type:        p.Type,
+			Description: p.Description,
+		})
+	}
+	for _, q := range op.QueryParams {
+		doc.QueryParams = append(doc.QueryParams, SchemaQueryParam{
+			Flag:        "--" + slugify(q.Name),
+			Name:        q.Name,
+			Type:        q.Type,
+			Enum:        q.Enum,
+			Required:    q.Required,
+			Description: q.Description,
+		})
+	}
+	doc.Response = describeResponse(d, op.Response)
+
 	if op.BodySchema == nil {
+		// Body stays nil (rendered as null) so a bodyless operation is explicit
+		// rather than ambiguous. An operation that declares a body but no schema
+		// says so instead, so null always means "sends nothing".
+		if op.HasBody {
+			doc.Body = map[string]interface{}{
+				"note": "this operation takes a request body, but the spec declares no schema for it",
+			}
+		}
+		// Either way there is nothing for --field to drill into.
+		if field != "" {
+			return doc, fmt.Errorf("--field is only meaningful for operations with a request body schema; %s %s has none", op.Method, op.Path)
+		}
 		return doc, nil
 	}
 
@@ -84,7 +217,6 @@ func describeBody(op *operationInfo, field string, maxDepth int) (bodySchemaDoc,
 		root = resolved
 	}
 
-	d := &describer{maxDepth: maxDepth}
 	body := d.simplify(root, 0, nil)
 	doc.Body = body
 	if m, ok := body.(map[string]interface{}); ok {
@@ -94,6 +226,23 @@ func describeBody(op *operationInfo, field string, maxDepth int) (bodySchemaDoc,
 	}
 	doc.Example = d.synth(root, "", 0, nil)
 	return doc, nil
+}
+
+// describeResponse renders the captured success response. --field deliberately
+// does not apply here: it drills the request body only.
+func describeResponse(d *describer, resp *responseInfo) *SchemaResponse {
+	if resp == nil {
+		return nil
+	}
+	out := &SchemaResponse{
+		Status:      resp.Status,
+		ContentType: resp.ContentType,
+		Description: resp.Description,
+	}
+	if resp.Schema != nil {
+		out.Schema = d.simplify(resp.Schema, 0, nil)
+	}
+	return out
 }
 
 // resolveField walks a dotted path (e.g. "queryPresentations.data.query") from

--- a/internal/openapi/schema.go
+++ b/internal/openapi/schema.go
@@ -17,6 +17,11 @@ import (
 // recursing.
 const maxSchemaDepth = 8
 
+// depthNote replaces a schema node that sits past the expansion budget. Both the
+// spec describer and the depth limiter for hand-written commands' static
+// documents emit it, so truncation reads identically everywhere.
+const depthNote = "max depth reached; expansion omitted"
+
 // SchemaArg describes a positional argument, derived from a spec path param.
 type SchemaArg struct {
 	Name        string `json:"name"`
@@ -45,13 +50,12 @@ type SchemaResponse struct {
 	Schema      interface{} `json:"schema"`
 }
 
-// SchemaDoc is the JSON document emitted by `omni <cmd> --schema`. It gives an
-// agent the full call contract: positional args, query flags, the request body
-// (authoritative shape plus a copy-pasteable Example) and the success response
-// shape. Body is explicitly null for operations that take no request body, so
-// "no body" is unambiguous rather than merely absent. Response is always present
-// (null when the spec declares no 2xx status). SchemaFlags appears only when a
-// spec parameter forced a discovery flag off its preferred name.
+// SchemaDoc is the JSON document emitted by `omni <cmd> --schema`: the full call
+// contract — positional args, query flags, the request body (shape plus a
+// copy-pasteable Example) and the success response shape. Body and Response are
+// always present, explicitly null when the operation takes no body / the spec
+// declares no 2xx status, so absence is never ambiguous. SchemaFlags appears
+// only when a spec parameter forced a discovery flag off its preferred name.
 type SchemaDoc struct {
 	Method      string             `json:"method"`
 	Path        string             `json:"path"`
@@ -91,20 +95,17 @@ func (f SchemaFlags) Renamed() bool {
 
 // RegisterSchemaFlag adds the --schema discovery flag (plus its --field and
 // --depth refinements) to cmd and wraps arg validation and RunE so --schema
-// short-circuits before any positional-arg check, body assembly, auth, or
-// network call. That lets `omni <cmd> --schema` work with no args and no token.
-// emit is called with the resolved flag names to produce the document.
+// short-circuits before any positional-arg check, body assembly, auth or network
+// call, calling emit with the resolved flag names instead. Every command
+// registers it, bodyless ones included: agents reach for --schema first, and
+// "unknown flag: --schema" wastes a whole call.
 //
-// Every command registers this, including bodyless GET/DELETE operations: agents
-// reach for --schema first, and "unknown flag: --schema" wastes a whole call.
-//
-// Collision policy: a spec parameter always keeps its own flag name — it is the
-// operation's contract, and silently reinterpreting e.g. an endpoint's --depth
-// query param as a discovery control would corrupt requests. When a parameter
-// owns one of these names, that discovery flag is registered under a
-// deterministic "schema-" prefixed fallback (--schema-doc / --schema-field /
-// --schema-depth, and -2, -3… if those are taken too) and its help text says so.
-// Discovery is therefore never unavailable, just occasionally renamed.
+// Collision policy: a spec parameter always keeps its own flag name — silently
+// reinterpreting e.g. an endpoint's --depth query param as a discovery control
+// would corrupt requests. A colliding discovery flag is instead registered under
+// a deterministic "schema-" prefixed fallback (--schema-doc / --schema-field /
+// --schema-depth, and -2, -3… if those are taken too) which its help text and
+// the document's schemaFlags both name, so discovery is never unavailable.
 func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command, SchemaFlags) error) SchemaFlags {
 	names := SchemaFlags{
 		Schema: freeFlagName(cmd, "schema", "schema-doc"),
@@ -119,6 +120,17 @@ func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command, SchemaFlag
 		renameNote(fmt.Sprintf("with --%s: drill into a dotted field path of the request body (e.g. queryPresentations.data.query); auto-descends arrays and maps; does not affect the response section", names.Schema), "field", names.Field))
 	cmd.Flags().Int(names.Depth, maxSchemaDepth,
 		renameNote(fmt.Sprintf("with --%s: max nesting depth to expand (request body and response); lower for a compact overview", names.Schema), "depth", names.Depth))
+
+	// Cobra prints a Deprecated notice at the top of execute() — before flags are
+	// even parsed — which would put plain text ahead of --schema's JSON. Take
+	// ownership of the notice: clear the field so cobra stays quiet, keep the
+	// command out of help listings the way Deprecated did (via Hidden), and
+	// re-print the notice to stderr ourselves on real runs only.
+	deprecated := cmd.Deprecated
+	if deprecated != "" {
+		cmd.Deprecated = ""
+		cmd.Hidden = true
+	}
 
 	innerArgs := cmd.Args
 	cmd.Args = func(c *cobra.Command, args []string) error {
@@ -135,6 +147,9 @@ func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command, SchemaFlag
 			// helpful message, not the full usage block.
 			c.SilenceUsage = true
 			return emit(c, names)
+		}
+		if deprecated != "" {
+			fmt.Fprintf(c.ErrOrStderr(), "Command %q is deprecated, %s\n", c.Name(), deprecated)
 		}
 		if innerRun == nil {
 			return nil
@@ -185,6 +200,109 @@ func emitBodySchema(cmd *cobra.Command, op *operationInfo, names SchemaFlags) er
 		return err
 	}
 	return EmitSchemaDoc(cmd, doc)
+}
+
+// StaticSchemaEmitter returns a RegisterSchemaFlag callback for a hand-written
+// command that documents itself with a static document (build). Such a command
+// assembles its request body from its own flags rather than passing JSON
+// through, so --field has nothing to drill into and is rejected by name; --depth
+// is applied to the document so it truncates exactly as it does on generated
+// commands.
+func StaticSchemaEmitter(cmdName string, build func() SchemaDoc) func(*cobra.Command, SchemaFlags) error {
+	return func(c *cobra.Command, names SchemaFlags) error {
+		if field, _ := c.Flags().GetString(names.Field); field != "" {
+			return fmt.Errorf("--%s is not supported for %s; its request body is assembled by the CLI and shown in full", names.Field, cmdName)
+		}
+		return EmitSchemaDoc(c, limitDocDepth(build(), schemaDepth(c, names.Depth)))
+	}
+}
+
+// limitDocDepth truncates an already-materialized schema document to maxDepth,
+// mirroring what the describer does while walking the spec. It is how a static
+// document honors --depth without a second implementation of the placeholder
+// convention.
+func limitDocDepth(doc SchemaDoc, maxDepth int) SchemaDoc {
+	doc.Body = limitSchemaDepth(doc.Body, 0, maxDepth)
+	doc.Example = limitValueDepth(doc.Example, 0, maxDepth)
+	if doc.Response != nil {
+		resp := *doc.Response
+		resp.Schema = limitSchemaDepth(resp.Schema, 0, maxDepth)
+		doc.Response = &resp
+	}
+	return doc
+}
+
+// limitSchemaDepth walks a plain-Go schema map the way simplify walks a spec
+// schema — properties, items, additionalProperties and union members each nest
+// one level — and replaces anything past maxDepth with the depthNote
+// placeholder, keeping the node's type and $ref like simplify does.
+func limitSchemaDepth(v interface{}, depth, maxDepth int) interface{} {
+	node, ok := v.(map[string]interface{})
+	if !ok {
+		return v
+	}
+	if depth > maxDepth {
+		out := map[string]interface{}{"note": depthNote}
+		if t, ok := node["type"]; ok {
+			out["type"] = t
+		}
+		if r, ok := node["$ref"]; ok {
+			out["$ref"] = r
+		}
+		return out
+	}
+
+	out := make(map[string]interface{}, len(node))
+	for k, val := range node {
+		switch k {
+		case "properties":
+			if props, ok := val.(map[string]interface{}); ok {
+				limited := make(map[string]interface{}, len(props))
+				for name, p := range props {
+					limited[name] = limitSchemaDepth(p, depth+1, maxDepth)
+				}
+				out[k] = limited
+				continue
+			}
+		case "items", "additionalProperties":
+			out[k] = limitSchemaDepth(val, depth+1, maxDepth)
+			continue
+		case "oneOf", "anyOf":
+			if members, ok := val.([]interface{}); ok {
+				limited := make([]interface{}, 0, len(members))
+				for _, m := range members {
+					limited = append(limited, limitSchemaDepth(m, depth+1, maxDepth))
+				}
+				out[k] = limited
+				continue
+			}
+		}
+		out[k] = val
+	}
+	return out
+}
+
+// limitValueDepth truncates an example value the way synth does: an object past
+// the budget collapses to {}, while scalars and array wrappers are kept.
+func limitValueDepth(v interface{}, depth, maxDepth int) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		if depth > maxDepth {
+			return map[string]interface{}{}
+		}
+		out := make(map[string]interface{}, len(val))
+		for k, item := range val {
+			out[k] = limitValueDepth(item, depth+1, maxDepth)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, 0, len(val))
+		for _, item := range val {
+			out = append(out, limitValueDepth(item, depth+1, maxDepth))
+		}
+		return out
+	}
+	return v
 }
 
 // EmitSchemaDoc writes a schema document as JSON to the command's stdout,
@@ -251,9 +369,24 @@ func describeBody(op *operationInfo, field string, maxDepth int, names SchemaFla
 			Description: q.Description,
 		})
 	}
+	// Resolve --field before describing anything: an invalid path is an error, and
+	// the response schema alone can run to hundreds of kilobytes.
+	root := op.BodySchema
+	if root == nil {
+		if field != "" {
+			return doc, fmt.Errorf("--%s is only meaningful for operations with a request body schema; %s %s has none", names.Field, op.Method, op.Path)
+		}
+	} else if field != "" {
+		resolved, err := resolveField(root, field, names.Field)
+		if err != nil {
+			return doc, err
+		}
+		root = resolved
+	}
+
 	doc.Response = describeResponse(d, op.Response)
 
-	if op.BodySchema == nil {
+	if root == nil {
 		// Body stays nil (rendered as null) so a bodyless operation is explicit
 		// rather than ambiguous. An operation that declares a body but no schema
 		// says so instead, so null always means "sends nothing".
@@ -262,20 +395,7 @@ func describeBody(op *operationInfo, field string, maxDepth int, names SchemaFla
 				"note": "this operation takes a request body, but the spec declares no schema for it",
 			}
 		}
-		// Either way there is nothing for the field flag to drill into.
-		if field != "" {
-			return doc, fmt.Errorf("--%s is only meaningful for operations with a request body schema; %s %s has none", names.Field, op.Method, op.Path)
-		}
 		return doc, nil
-	}
-
-	root := op.BodySchema
-	if field != "" {
-		resolved, err := resolveField(root, field, names.Field)
-		if err != nil {
-			return doc, err
-		}
-		root = resolved
 	}
 
 	body := d.simplify(root, 0, nil)
@@ -423,7 +543,7 @@ func (d *describer) simplify(proxy *base.SchemaProxy, depth int, seen map[string
 	}
 
 	if depth > d.maxDepth {
-		out := map[string]interface{}{"note": "max depth reached; expansion omitted"}
+		out := map[string]interface{}{"note": depthNote}
 		if len(sch.Type) > 0 {
 			out["type"] = joinTypes(sch.Type)
 		}

--- a/internal/openapi/schema_test.go
+++ b/internal/openapi/schema_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // schemaTestSpec exercises the body-schema describer: allOf composition,
@@ -776,6 +778,274 @@ func TestSchema_BodyOperationStaysBackwardCompatible(t *testing.T) {
 	if doc.Response == nil || doc.Response.Status != "200" {
 		t.Errorf("response = %+v, want the declared 200", doc.Response)
 	}
+}
+
+// collidingParamsSpec declares query params literally named schema, field and
+// depth — all three preferred discovery flag names. The params must keep their
+// own flags (they are the endpoint's contract) and discovery must still be
+// reachable, under its fallback names.
+const collidingParamsSpec = `{
+  "openapi": "3.1.0",
+  "info": {"title": "test", "version": "1.0"},
+  "paths": {
+    "/api/v1/things": {
+      "get": {
+        "operationId": "thingsList",
+        "tags": ["things"],
+        "parameters": [
+          {"name": "schema", "in": "query", "description": "Database schema to inspect", "schema": {"type": "string"}},
+          {"name": "field", "in": "query", "description": "Field to group by", "schema": {"type": "string"}},
+          {"name": "depth", "in": "query", "description": "Traversal depth", "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Things",
+            "content": {"application/json": {"schema": {"type": "object", "properties": {"a": {"type": "object", "properties": {"b": {"type": "string"}}}}}}}
+          }
+        }
+      }
+    }
+  }
+}`
+
+// A spec param owning a discovery flag name must not disable discovery: the
+// flags move to deterministic fallbacks, and the document reports where they
+// went.
+func TestSchema_ParamNameCollisionFallsBackToPrefixedFlags(t *testing.T) {
+	doc, err := runSchemaCmdFlag(t, collidingParamsSpec, "list", "schema-doc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Method != "GET" || doc.Path != "/api/v1/things" {
+		t.Errorf("method/path = %q %q", doc.Method, doc.Path)
+	}
+	if doc.SchemaFlags == nil {
+		t.Fatal("schemaFlags section missing; agents can't discover the renamed flags")
+	}
+	want := SchemaFlags{Schema: "schema-doc", Field: "schema-field", Depth: "schema-depth"}
+	if *doc.SchemaFlags != want {
+		t.Errorf("schemaFlags = %+v, want %+v", *doc.SchemaFlags, want)
+	}
+	// The colliding query params are still described as query params.
+	flags := map[string]bool{}
+	for _, q := range doc.QueryParams {
+		flags[q.Flag] = true
+	}
+	for _, f := range []string{"--schema", "--field", "--depth"} {
+		if !flags[f] {
+			t.Errorf("query param %s missing from the document", f)
+		}
+	}
+}
+
+// The renamed refinement flags must work, and the renaming must be visible in
+// --help so a reader can find them.
+func TestSchema_RenamedRefinementFlagsWork(t *testing.T) {
+	doc, err := runSchemaCmdFlag(t, collidingParamsSpec, "list", "schema-doc", "--schema-depth", "0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, _ := json.Marshal(doc.Response)
+	if !strings.Contains(string(raw), "max depth reached") {
+		t.Errorf("--schema-depth 0 did not bound the response: %s", raw)
+	}
+
+	sub := subcommand(t, collidingParamsSpec, "list")
+	help := sub.LocalFlags().FlagUsages()
+	for _, want := range []string{"--schema-doc", "--schema-field", "--schema-depth", "because --schema is a parameter"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("flag help does not mention %q:\n%s", want, help)
+		}
+	}
+}
+
+// A colliding param must still be sent as a query param — never swallowed as a
+// discovery control.
+func TestSchema_CollidingParamsStillReachTheRequest(t *testing.T) {
+	var captured APIRequest
+	exec := func(req APIRequest) error { captured = req; return nil }
+	cmds, err := GenerateCommands([]byte(collidingParamsSpec), exec)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	group := cmds[0]
+	group.SilenceUsage = true
+	group.SilenceErrors = true
+	group.SetArgs([]string{"list", "--schema", "public", "--field", "name", "--depth", "3"})
+	if err := group.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"schema=public", "field=name", "depth=3"} {
+		if !strings.Contains(captured.Path, want) {
+			t.Errorf("path %q missing %s", captured.Path, want)
+		}
+	}
+}
+
+// wildcardResponseSpec exercises response declarations that are easy to lose:
+// an operation whose only success status is the "2XX" range key, one where a
+// specific code must beat the range key, and one whose media type declares no
+// schema.
+const wildcardResponseSpec = `{
+  "openapi": "3.1.0",
+  "info": {"title": "test", "version": "1.0"},
+  "paths": {
+    "/api/v1/ranged": {
+      "get": {
+        "operationId": "rangedOnly",
+        "tags": ["resp"],
+        "responses": {
+          "2XX": {"description": "Ranged success", "content": {"application/json": {"schema": {"type": "object", "properties": {"ok": {"type": "boolean"}}}}}},
+          "4XX": {"description": "Ranged failure"}
+        }
+      }
+    },
+    "/api/v1/both": {
+      "get": {
+        "operationId": "rangedAndSpecific",
+        "tags": ["resp"],
+        "responses": {
+          "2XX": {"description": "Ranged success", "content": {"application/json": {"schema": {"type": "string"}}}},
+          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object", "properties": {"id": {"type": "string"}}}}}}
+        }
+      }
+    },
+    "/api/v1/schemaless": {
+      "get": {
+        "operationId": "schemalessMedia",
+        "tags": ["resp"],
+        "responses": {
+          "200": {"description": "A file", "content": {"text/csv": {}}}
+        }
+      }
+    },
+    "/api/v1/mixed": {
+      "get": {
+        "operationId": "mixedMedia",
+        "tags": ["resp"],
+        "responses": {
+          "200": {
+            "description": "Mixed",
+            "content": {"application/json": {}, "text/ndjson": {"schema": {"type": "object", "properties": {"row": {"type": "string"}}}}}
+          }
+        }
+      }
+    }
+  }
+}`
+
+// A success response declared only under the "2XX" range key must still be
+// reported rather than dropped.
+func TestSchema_ResponseAcceptsRangeWildcard(t *testing.T) {
+	doc, err := runSchemaCmd(t, wildcardResponseSpec, "ranged-only")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Response == nil {
+		t.Fatal("response section missing for a 2XX-only operation")
+	}
+	if doc.Response.Status != "2XX" {
+		t.Errorf("response.status = %q, want 2XX", doc.Response.Status)
+	}
+	schema, ok := doc.Response.Schema.(map[string]interface{})
+	if !ok || schema["type"] != "object" {
+		t.Errorf("response.schema = %v, want the declared object", doc.Response.Schema)
+	}
+}
+
+// A specific 2xx code beats the range wildcard.
+func TestSchema_SpecificCodeBeatsRangeWildcard(t *testing.T) {
+	doc, err := runSchemaCmd(t, wildcardResponseSpec, "ranged-and-specific")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Response == nil || doc.Response.Status != "201" {
+		t.Fatalf("response = %+v, want the specific 201 to win over 2XX", doc.Response)
+	}
+	schema, ok := doc.Response.Schema.(map[string]interface{})
+	if !ok || schema["type"] != "object" {
+		t.Errorf("response.schema = %v, want the 201 object, not the 2XX string", doc.Response.Schema)
+	}
+}
+
+// A media type declared without a schema must still be reported by name —
+// "text/csv, shape undocumented" beats implying an empty response.
+func TestSchema_ResponseMediaTypeWithoutSchema(t *testing.T) {
+	doc, err := runSchemaCmd(t, wildcardResponseSpec, "schemaless-media")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Response == nil {
+		t.Fatal("response section missing")
+	}
+	if doc.Response.ContentType != "text/csv" {
+		t.Errorf("response.contentType = %q, want text/csv (the declared media type was dropped)", doc.Response.ContentType)
+	}
+	if doc.Response.Schema != nil {
+		t.Errorf("response.schema = %v, want null for an undocumented media type", doc.Response.Schema)
+	}
+}
+
+// When application/json declares no schema but another media type does, report
+// the one that actually carries a shape.
+func TestSchema_ResponsePrefersMediaTypeThatHasASchema(t *testing.T) {
+	doc, err := runSchemaCmd(t, wildcardResponseSpec, "mixed-media")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Response == nil {
+		t.Fatal("response section missing")
+	}
+	if doc.Response.ContentType != "text/ndjson" {
+		t.Errorf("response.contentType = %q, want text/ndjson (the only type with a schema)", doc.Response.ContentType)
+	}
+	if doc.Response.Schema == nil {
+		t.Error("response.schema is null; the declared ndjson schema was dropped")
+	}
+}
+
+// subcommand generates commands from a spec and returns the named subcommand of
+// the first group.
+func subcommand(t *testing.T, spec, name string) *cobra.Command {
+	t.Helper()
+	noop := func(req APIRequest) error { return nil }
+	cmds, err := GenerateCommands([]byte(spec), noop)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == name {
+			return sub
+		}
+	}
+	t.Fatalf("subcommand %q not found", name)
+	return nil
+}
+
+// runSchemaCmdFlag is runSchemaCmd for commands whose discovery flag was
+// renamed by a parameter collision.
+func runSchemaCmdFlag(t *testing.T, spec, name, schemaFlag string, extra ...string) (SchemaDoc, error) {
+	t.Helper()
+	noop := func(req APIRequest) error { return nil }
+	cmds, err := GenerateCommands([]byte(spec), noop)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	group := cmds[0]
+	group.SilenceUsage = true
+	group.SilenceErrors = true
+	var buf bytes.Buffer
+	group.SetOut(&buf)
+	group.SetErr(&buf)
+	group.SetArgs(append([]string{name, "--" + schemaFlag}, extra...))
+	if execErr := group.Execute(); execErr != nil {
+		return SchemaDoc{}, execErr
+	}
+	var doc SchemaDoc
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
+	}
+	return doc, nil
 }
 
 // Without --schema, the command must still enforce normal behavior (here, that

--- a/internal/openapi/schema_test.go
+++ b/internal/openapi/schema_test.go
@@ -68,33 +68,45 @@ const schemaTestSpec = `{
   }
 }`
 
-// runSchema generates commands from a spec and runs the "widgets create"
-// command with --schema, returning the parsed JSON document. It dispatches
-// through the parent group with the full arg path, since cobra's Execute()
-// re-parses from the root regardless of the receiver.
-func runSchema(t *testing.T) SchemaDoc {
+// execSchema generates commands from spec and dispatches args through the first
+// command group, returning the parsed schema document or the execution error
+// (usage/errors silenced so an error carries only the message under test). It
+// dispatches through the parent group with the full arg path, since cobra's
+// Execute() re-parses from the root regardless of the receiver. Every schema
+// test runs through here.
+func execSchema(t *testing.T, spec string, args ...string) (SchemaDoc, error) {
 	t.Helper()
 	noop := func(req APIRequest) error { return nil }
-	cmds, err := GenerateCommands([]byte(schemaTestSpec), noop)
+	cmds, err := GenerateCommands([]byte(spec), noop)
 	if err != nil {
 		t.Fatalf("GenerateCommands: %v", err)
 	}
-	if len(cmds) != 1 {
-		t.Fatalf("expected 1 group, got %d", len(cmds))
-	}
 	group := cmds[0]
+	group.SilenceUsage = true
+	group.SilenceErrors = true
 
 	var buf bytes.Buffer
 	group.SetOut(&buf)
 	group.SetErr(&buf)
-	group.SetArgs([]string{"create", "--schema"})
-	if err := group.Execute(); err != nil {
-		t.Fatalf("Execute --schema: %v\n%s", err, buf.String())
+	group.SetArgs(args)
+	if execErr := group.Execute(); execErr != nil {
+		return SchemaDoc{}, execErr
 	}
 
 	var doc SchemaDoc
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
 		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
+	}
+	return doc, nil
+}
+
+// runSchema runs "create --schema" against schemaTestSpec, failing the test if
+// it errors.
+func runSchema(t *testing.T) SchemaDoc {
+	t.Helper()
+	doc, err := execSchema(t, schemaTestSpec, "create", "--schema")
+	if err != nil {
+		t.Fatalf("Execute --schema: %v", err)
 	}
 	return doc
 }
@@ -450,31 +462,10 @@ func TestSchema_DescribeOnRefFieldDrill(t *testing.T) {
 	}
 }
 
-// runSchemaWith runs "create --schema" plus extra flags against a spec. On
-// success it returns the parsed doc; on failure it returns the execution error
-// (usage/errors silenced so the error carries only the message under test).
+// runSchemaWith runs "create --schema" plus extra flags against a spec.
 func runSchemaWith(t *testing.T, spec string, extra ...string) (SchemaDoc, error) {
 	t.Helper()
-	noop := func(req APIRequest) error { return nil }
-	cmds, err := GenerateCommands([]byte(spec), noop)
-	if err != nil {
-		t.Fatalf("GenerateCommands: %v", err)
-	}
-	group := cmds[0]
-	group.SilenceUsage = true
-	group.SilenceErrors = true
-	var buf bytes.Buffer
-	group.SetOut(&buf)
-	group.SetErr(&buf)
-	group.SetArgs(append([]string{"create", "--schema"}, extra...))
-	if execErr := group.Execute(); execErr != nil {
-		return SchemaDoc{}, execErr
-	}
-	var doc SchemaDoc
-	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
-		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
-	}
-	return doc, nil
+	return execSchema(t, spec, append([]string{"create", "--schema"}, extra...)...)
 }
 
 // --field drills to a nested property; the $ref ("child" → Node) is resolved
@@ -611,26 +602,7 @@ const bodylessTestSpec = `{
 // positional args — --schema must short-circuit before arg validation.
 func runSchemaCmd(t *testing.T, spec, name string, extra ...string) (SchemaDoc, error) {
 	t.Helper()
-	noop := func(req APIRequest) error { return nil }
-	cmds, err := GenerateCommands([]byte(spec), noop)
-	if err != nil {
-		t.Fatalf("GenerateCommands: %v", err)
-	}
-	group := cmds[0]
-	group.SilenceUsage = true
-	group.SilenceErrors = true
-	var buf bytes.Buffer
-	group.SetOut(&buf)
-	group.SetErr(&buf)
-	group.SetArgs(append([]string{name, "--schema"}, extra...))
-	if execErr := group.Execute(); execErr != nil {
-		return SchemaDoc{}, execErr
-	}
-	var doc SchemaDoc
-	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
-		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
-	}
-	return doc, nil
+	return execSchema(t, spec, append([]string{name, "--schema"}, extra...)...)
 }
 
 // --schema on a bodyless GET works with no positional args and describes the
@@ -1026,26 +998,7 @@ func subcommand(t *testing.T, spec, name string) *cobra.Command {
 // renamed by a parameter collision.
 func runSchemaCmdFlag(t *testing.T, spec, name, schemaFlag string, extra ...string) (SchemaDoc, error) {
 	t.Helper()
-	noop := func(req APIRequest) error { return nil }
-	cmds, err := GenerateCommands([]byte(spec), noop)
-	if err != nil {
-		t.Fatalf("GenerateCommands: %v", err)
-	}
-	group := cmds[0]
-	group.SilenceUsage = true
-	group.SilenceErrors = true
-	var buf bytes.Buffer
-	group.SetOut(&buf)
-	group.SetErr(&buf)
-	group.SetArgs(append([]string{name, "--" + schemaFlag}, extra...))
-	if execErr := group.Execute(); execErr != nil {
-		return SchemaDoc{}, execErr
-	}
-	var doc SchemaDoc
-	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
-		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
-	}
-	return doc, nil
+	return execSchema(t, spec, append([]string{name, "--" + schemaFlag}, extra...)...)
 }
 
 // Without --schema, the command must still enforce normal behavior (here, that
@@ -1066,5 +1019,116 @@ func TestSchema_FlagDoesNotAffectNormalRun(t *testing.T) {
 	}
 	if !called {
 		t.Error("executor was not called on a normal (non --schema) run")
+	}
+}
+
+// deprecatedTestSpec declares a deprecated operation, whose notice cobra would
+// print as plain text ahead of --schema's JSON if we left it to cobra.
+const deprecatedTestSpec = `{
+  "openapi": "3.1.0",
+  "info": {"title": "test", "version": "1.0"},
+  "paths": {
+    "/api/v1/legacy": {
+      "put": {
+        "operationId": "legacyUpdate",
+        "tags": ["legacy"],
+        "deprecated": true,
+        "requestBody": {
+          "content": {"application/json": {"schema": {"type": "object", "properties": {"name": {"type": "string"}}}}}
+        },
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  }
+}`
+
+// runDeprecated dispatches args against the deprecated spec's group, returning
+// stdout and stderr separately so the two streams can be asserted on
+// independently.
+func runDeprecated(t *testing.T, args ...string) (stdout, stderr string) {
+	t.Helper()
+	noop := func(req APIRequest) error { return nil }
+	cmds, err := GenerateCommands([]byte(deprecatedTestSpec), noop)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	group := cmds[0]
+	group.SilenceUsage = true
+	group.SilenceErrors = true
+	var out, errBuf bytes.Buffer
+	group.SetOut(&out)
+	group.SetErr(&errBuf)
+	group.SetArgs(args)
+	if execErr := group.Execute(); execErr != nil {
+		t.Fatalf("Execute %v: %v\n%s%s", args, execErr, out.String(), errBuf.String())
+	}
+	return out.String(), errBuf.String()
+}
+
+// --schema on a deprecated operation must emit JSON and nothing else: an agent
+// pipes this straight into a parser, and cobra's deprecation notice would
+// corrupt it.
+func TestSchema_DeprecatedOperationEmitsCleanJSON(t *testing.T) {
+	stdout, stderr := runDeprecated(t, "update", "--schema")
+	if strings.Contains(stdout, "deprecated") || !strings.HasPrefix(strings.TrimSpace(stdout), "{") {
+		t.Fatalf("stdout is not pure JSON: %q", stdout)
+	}
+	var doc SchemaDoc
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("unmarshal schema output: %v\n%s", err, stdout)
+	}
+	if doc.Method != "PUT" || doc.Path != "/api/v1/legacy" {
+		t.Errorf("method/path = %q %q", doc.Method, doc.Path)
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want nothing on a --schema run", stderr)
+	}
+}
+
+// A real (non --schema) run still warns that the operation is deprecated, on
+// stderr so it never mixes into the JSON response body on stdout.
+func TestSchema_DeprecatedOperationStillWarnsOnRealRun(t *testing.T) {
+	stdout, stderr := runDeprecated(t, "update", "--body", `{"name":"x"}`)
+	if !strings.Contains(stderr, "deprecated") {
+		t.Errorf("stderr = %q, want a deprecation notice", stderr)
+	}
+	if strings.Contains(stdout, "deprecated") {
+		t.Errorf("deprecation notice leaked to stdout: %q", stdout)
+	}
+}
+
+// Taking the notice over from cobra must not resurrect the command in help
+// listings: Deprecated hid it, so Hidden has to keep hiding it.
+func TestSchema_DeprecatedOperationStaysOutOfHelp(t *testing.T) {
+	cmd := subcommand(t, deprecatedTestSpec, "update")
+	if cmd.IsAvailableCommand() {
+		t.Error("deprecated command is listed in help; it was hidden before")
+	}
+}
+
+// limitDocDepth is how a hand-written command's static document honors --depth.
+// Its truncation must be indistinguishable from the describer's, so the
+// placeholder emitted at the same depth is identical.
+func TestSchema_StaticDepthLimitMatchesDescriber(t *testing.T) {
+	generated, err := runSchemaWith(t, schemaTestSpec, "--depth", "0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	genProps := generated.Body.(map[string]interface{})["properties"].(map[string]interface{})
+	wantPlaceholder := genProps["name"]
+
+	static := SchemaDoc{Body: map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"name": map[string]interface{}{"type": "string", "example": "my-widget"},
+		},
+	}}
+	limited := limitDocDepth(static, 0)
+	gotProps := limited.Body.(map[string]interface{})["properties"].(map[string]interface{})
+
+	got, _ := json.Marshal(gotProps["name"])
+	want, _ := json.Marshal(wantPlaceholder)
+	if string(got) != string(want) {
+		t.Errorf("static truncation = %s, describer truncation = %s", got, want)
 	}
 }

--- a/internal/openapi/schema_test.go
+++ b/internal/openapi/schema_test.go
@@ -70,7 +70,7 @@ const schemaTestSpec = `{
 // command with --schema, returning the parsed JSON document. It dispatches
 // through the parent group with the full arg path, since cobra's Execute()
 // re-parses from the root regardless of the receiver.
-func runSchema(t *testing.T) bodySchemaDoc {
+func runSchema(t *testing.T) SchemaDoc {
 	t.Helper()
 	noop := func(req APIRequest) error { return nil }
 	cmds, err := GenerateCommands([]byte(schemaTestSpec), noop)
@@ -90,7 +90,7 @@ func runSchema(t *testing.T) bodySchemaDoc {
 		t.Fatalf("Execute --schema: %v\n%s", err, buf.String())
 	}
 
-	var doc bodySchemaDoc
+	var doc SchemaDoc
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
 		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
 	}
@@ -225,7 +225,7 @@ const mapTestSpec = `{
   }
 }`
 
-func runMapSchema(t *testing.T) bodySchemaDoc {
+func runMapSchema(t *testing.T) SchemaDoc {
 	t.Helper()
 	noop := func(req APIRequest) error { return nil }
 	cmds, err := GenerateCommands([]byte(mapTestSpec), noop)
@@ -243,7 +243,7 @@ func runMapSchema(t *testing.T) bodySchemaDoc {
 	if err := group.Execute(); err != nil {
 		t.Fatalf("Execute --schema: %v\n%s", err, buf.String())
 	}
-	var doc bodySchemaDoc
+	var doc SchemaDoc
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
 		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
 	}
@@ -451,7 +451,7 @@ func TestSchema_DescribeOnRefFieldDrill(t *testing.T) {
 // runSchemaWith runs "create --schema" plus extra flags against a spec. On
 // success it returns the parsed doc; on failure it returns the execution error
 // (usage/errors silenced so the error carries only the message under test).
-func runSchemaWith(t *testing.T, spec string, extra ...string) (bodySchemaDoc, error) {
+func runSchemaWith(t *testing.T, spec string, extra ...string) (SchemaDoc, error) {
 	t.Helper()
 	noop := func(req APIRequest) error { return nil }
 	cmds, err := GenerateCommands([]byte(spec), noop)
@@ -466,9 +466,9 @@ func runSchemaWith(t *testing.T, spec string, extra ...string) (bodySchemaDoc, e
 	group.SetErr(&buf)
 	group.SetArgs(append([]string{"create", "--schema"}, extra...))
 	if execErr := group.Execute(); execErr != nil {
-		return bodySchemaDoc{}, execErr
+		return SchemaDoc{}, execErr
 	}
-	var doc bodySchemaDoc
+	var doc SchemaDoc
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
 		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
 	}
@@ -549,6 +549,232 @@ func TestSchema_DepthLimitsExpansion(t *testing.T) {
 	rawFull, _ := json.Marshal(full.Body)
 	if strings.Contains(string(rawFull), "max depth reached") {
 		t.Errorf("default depth should not truncate this small schema: %s", rawFull)
+	}
+}
+
+// bodylessTestSpec exercises --schema on operations that take no request body:
+// a GET with a path param, two query params (one enum-valued and required) and a
+// bare-array 200 response, plus a DELETE whose only success status (204) carries
+// no content. The 202 is declared before the 200 so the "lowest 2xx wins"
+// selection can't pass by accident of declaration order, and text/csv sits
+// before application/json so the media-type preference is exercised too.
+const bodylessTestSpec = `{
+  "openapi": "3.1.0",
+  "info": {"title": "test", "version": "1.0"},
+  "paths": {
+    "/api/v1/widgets/{widgetId}/checks": {
+      "get": {
+        "operationId": "widgetsChecks",
+        "tags": ["widgets"],
+        "parameters": [
+          {"name": "widgetId", "in": "path", "required": true, "description": "Widget UUID", "schema": {"type": "string"}},
+          {"name": "limit", "in": "query", "description": "Max results", "schema": {"type": "integer"}},
+          {"name": "severity", "in": "query", "required": true, "description": "Filter by severity", "schema": {"type": "string", "enum": ["error", "warning"]}}
+        ],
+        "responses": {
+          "202": {"description": "queued", "content": {"application/json": {"schema": {"type": "object"}}}},
+          "200": {
+            "description": "Check results",
+            "content": {
+              "text/csv": {"schema": {"type": "string"}},
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Bare top-level array of issues.",
+                  "items": {
+                    "type": "object",
+                    "required": ["message"],
+                    "properties": {"message": {"type": "string"}, "nested": {"type": "object", "properties": {"deep": {"type": "string"}}}}
+                  }
+                }
+              }
+            }
+          },
+          "404": {"description": "not found"}
+        }
+      },
+      "delete": {
+        "operationId": "widgetsDeleteChecks",
+        "tags": ["widgets"],
+        "parameters": [
+          {"name": "widgetId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {"204": {"description": "Checks cleared"}}
+      }
+    }
+  }
+}`
+
+// runSchemaCmd runs "<name> --schema" plus extra flags against a spec, with no
+// positional args — --schema must short-circuit before arg validation.
+func runSchemaCmd(t *testing.T, spec, name string, extra ...string) (SchemaDoc, error) {
+	t.Helper()
+	noop := func(req APIRequest) error { return nil }
+	cmds, err := GenerateCommands([]byte(spec), noop)
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+	group := cmds[0]
+	group.SilenceUsage = true
+	group.SilenceErrors = true
+	var buf bytes.Buffer
+	group.SetOut(&buf)
+	group.SetErr(&buf)
+	group.SetArgs(append([]string{name, "--schema"}, extra...))
+	if execErr := group.Execute(); execErr != nil {
+		return SchemaDoc{}, execErr
+	}
+	var doc SchemaDoc
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal schema output: %v\n%s", err, buf.String())
+	}
+	return doc, nil
+}
+
+// --schema on a bodyless GET works with no positional args and describes the
+// call: args, query flags, and an explicit null body.
+func TestSchema_BodylessGetDescribesArgsAndQueryParams(t *testing.T) {
+	doc, err := runSchemaCmd(t, bodylessTestSpec, "checks")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Method != "GET" || doc.Path != "/api/v1/widgets/{widgetId}/checks" {
+		t.Errorf("method/path = %q %q", doc.Method, doc.Path)
+	}
+	if doc.Body != nil {
+		t.Errorf("body = %v, want null for a bodyless operation", doc.Body)
+	}
+	if len(doc.Args) != 1 {
+		t.Fatalf("args = %v, want 1 entry", doc.Args)
+	}
+	arg := doc.Args[0]
+	if arg.Name != "widgetId" || arg.Placeholder != "<widgetid>" || arg.Type != "string" || arg.Description != "Widget UUID" {
+		t.Errorf("arg = %+v, want the widgetId path param", arg)
+	}
+
+	byFlag := map[string]SchemaQueryParam{}
+	for _, q := range doc.QueryParams {
+		byFlag[q.Flag] = q
+	}
+	limit, ok := byFlag["--limit"]
+	if !ok {
+		t.Fatalf("query params %v missing --limit", doc.QueryParams)
+	}
+	if limit.Type != "integer" || limit.Required || limit.Description != "Max results" {
+		t.Errorf("--limit = %+v, want an optional integer with its description", limit)
+	}
+	severity, ok := byFlag["--severity"]
+	if !ok {
+		t.Fatalf("query params %v missing --severity", doc.QueryParams)
+	}
+	if !severity.Required {
+		t.Errorf("--severity.required = false, want true")
+	}
+	if strings.Join(severity.Enum, ",") != "error,warning" {
+		t.Errorf("--severity.enum = %v, want [error warning]", severity.Enum)
+	}
+}
+
+// The response section reports the lowest declared 2xx, prefers application/json
+// over other media types, and renders a bare top-level array as such — the shape
+// a caller would otherwise have to discover by crashing on it.
+func TestSchema_ResponseBareArray(t *testing.T) {
+	doc, err := runSchemaCmd(t, bodylessTestSpec, "checks")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := doc.Response
+	if resp == nil {
+		t.Fatal("response section missing")
+	}
+	if resp.Status != "200" {
+		t.Errorf("response.status = %q, want 200 (lowest 2xx wins over 202)", resp.Status)
+	}
+	if resp.ContentType != "application/json" {
+		t.Errorf("response.contentType = %q, want application/json", resp.ContentType)
+	}
+	if resp.Description != "Check results" {
+		t.Errorf("response.description = %q", resp.Description)
+	}
+	schema, ok := resp.Schema.(map[string]interface{})
+	if !ok {
+		t.Fatalf("response.schema is not an object: %T", resp.Schema)
+	}
+	if schema["type"] != "array" {
+		t.Errorf("response.schema.type = %v, want array", schema["type"])
+	}
+	items, ok := schema["items"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response.schema.items missing: %v", schema)
+	}
+	props, ok := items["properties"].(map[string]interface{})
+	if !ok || props["message"] == nil {
+		t.Errorf("response item properties = %v, want a message field", items["properties"])
+	}
+}
+
+// A 2xx with no content still reports the status, so a caller can tell "no body"
+// from "unknown".
+func TestSchema_ResponseWithoutContent(t *testing.T) {
+	doc, err := runSchemaCmd(t, bodylessTestSpec, "delete-checks")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Response == nil {
+		t.Fatal("response section missing")
+	}
+	if doc.Response.Status != "204" {
+		t.Errorf("response.status = %q, want 204", doc.Response.Status)
+	}
+	if doc.Response.Schema != nil {
+		t.Errorf("response.schema = %v, want null for a contentless status", doc.Response.Schema)
+	}
+}
+
+// --depth bounds the response expansion too, not just the request body.
+func TestSchema_DepthLimitsResponseExpansion(t *testing.T) {
+	doc, err := runSchemaCmd(t, bodylessTestSpec, "checks", "--depth", "1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, _ := json.Marshal(doc.Response)
+	if !strings.Contains(string(raw), "max depth reached") {
+		t.Errorf("expected a depth-truncation note in the response at --depth 1: %s", raw)
+	}
+}
+
+// --field only drills the request body, so asking for it on a bodyless operation
+// must say so plainly rather than silently returning an empty body.
+func TestSchema_FieldOnBodylessOperationErrors(t *testing.T) {
+	_, err := runSchemaCmd(t, bodylessTestSpec, "checks", "--field", "anything")
+	if err == nil {
+		t.Fatal("expected an error for --field on a bodyless operation")
+	}
+	if !strings.Contains(err.Error(), "request body") {
+		t.Errorf("error = %q, want it to explain that --field needs a request body", err.Error())
+	}
+}
+
+// A body operation's document keeps its established shape (method, path,
+// required, body, example) and gains the response section — existing consumers
+// must not break.
+func TestSchema_BodyOperationStaysBackwardCompatible(t *testing.T) {
+	doc := runSchema(t)
+	if doc.Method != "POST" || doc.Path != "/api/v1/widgets" {
+		t.Errorf("method/path = %q %q", doc.Method, doc.Path)
+	}
+	if len(doc.Required) == 0 {
+		t.Error("required is empty; the body op's required list regressed")
+	}
+	if _, ok := doc.Body.(map[string]interface{}); !ok {
+		t.Errorf("body is not an object: %T", doc.Body)
+	}
+	if _, ok := doc.Example.(map[string]interface{}); !ok {
+		t.Errorf("example is not an object: %T", doc.Example)
+	}
+	// schemaTestSpec's 200 declares a description but no content.
+	if doc.Response == nil || doc.Response.Status != "200" {
+		t.Errorf("response = %+v, want the declared 200", doc.Response)
 	}
 }
 


### PR DESCRIPTION
`--schema` now works on **every** API command — GETs, DELETEs, and the hand-written ones included — and the emitted document gained a `response` section, so response shapes are no longer invisible. Previously `--schema` on a bodyless command was an `unknown flag` error (13 audited incidents), and nothing could tell you that e.g. `models validate` returns a bare array.

- Bodyless ops describe their positional `args` and `queryParams`, with an explicit `"body": null`.
- `response` shows the lowest declared 2xx schema (wildcard `2XX` accepted), rendered with the same `--depth` handling as bodies.
- Body-op output is backward compatible — the new sections are additive.
- Still zero-friction: no args, no token, no network call.

<details>
<summary>Details: flag-collision policy, response capture rules, trade-offs, and verification</summary>

## What changed

- **`--schema` (and `--field`/`--depth`) on every generated command.** Registration and the Args/RunE short-circuit moved into a shared `openapi.RegisterSchemaFlag` helper.
- **Bodyless operations describe themselves.** The document carries `args` (name, placeholder, type, description) and `queryParams` (flag, name, type, enum, required, description), and an explicit `"body": null` so "takes no body" is unambiguous rather than merely absent.
- **`response` section for all operations.** Captured in `operationInfo` and rendered through the existing `describer.simplify`, honoring `--depth`. A contentless status (e.g. 204) reports its status with a null schema.
- **`--field` still drills the request body only** — documented in the flag help, and it returns a clear error instead of silently doing nothing when the operation has no body schema.
- **Hand-written commands too**: `models create-branch` and `users set-attributes` emit the same document shape from a static description of the body the CLI assembles, so agent-help's "every API command" claim holds.
- **`omni agent-help`** documents the four sections and that `--schema` works everywhere.

## Flag-collision policy

A spec parameter always keeps its own flag name — it is the operation's contract, and silently reinterpreting an endpoint's `--depth` query param as a discovery control would corrupt requests. When a parameter owns `schema`, `field` or `depth`, that discovery flag is registered under a deterministic fallback instead: `--schema-doc`, `--schema-field`, `--schema-depth` (and `-2`, `-3`… if those are taken too). The rename is announced in the flag's `--help` text ("named `--schema-doc` here because `--schema` is a parameter of this endpoint") and echoed in a `schemaFlags` section of the emitted document. Discovery is therefore never unavailable, only occasionally renamed. The current spec has no such collisions; the behavior is covered by a synthetic spec whose GET declares query params named `schema`, `field` and `depth`.

## Response capture

The success response is the lowest declared 2xx status, falling back to an OpenAPI range key (`2XX`) when only that is declared — a specific code always beats the wildcard. Media-type selection prefers `application/json` with a schema, then the first type that carries a schema; a media type declared without a schema is still reported by name with a null schema, since "comes back as `text/csv`, shape undocumented" beats implying an empty response. `requestBodySchema` shares the same picker so request and response selection cannot drift.

## Trade-off worth knowing

Response schemas make some documents large — `documents v2-*` now dumps ~165 KB at the default depth of 8, the same order as its request body already did. `--depth N` and `--field PATH` remain the way to narrow that, and agent-help points at them.

## Verification

- `make build && make test` — all packages pass.
- New unit tests (including the review follow-ups: flag-name collisions, `2XX`-only and `2XX`-vs-specific responses, media types without a schema, and `freeFlagName` exhausting its fallbacks): `--schema` on a GET with path/query params (including required + enum), bare-array 200 response, contentless 204, `--depth` truncating the response, `--field` on a bodyless op erroring, body-op backward compatibility, `--schema` registered on every command generated from the real spec, `--schema` skipping arg validation, plus `create-branch --schema` / `set-attributes --schema` and their `--field` rejection.
- Swept the built binary: `--schema --compact` succeeds on all 210 API subcommands (the only non-accepting commands are `completion` and `config`, which make no API call); every operation reports a response section.
- Sanity: `./omni models list --schema`, `./omni query run --schema`, `./omni models validate --schema` (previously an unknown-flag error).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TwwKSAsAGPBToNb4iUe5s
