### PR TITLE
fix(help): spell Arguments-block names the way the usage line does

### DIFF
--- a/internal/openapi/generate.go
+++ b/internal/openapi/generate.go
@@ -341,7 +341,10 @@ func argumentsHelp(op *operationInfo, sh *BodyShorthand) string {
 	var lines []argLine
 
 	for _, p := range op.PathParams {
-		lines = append(lines, argLine{"<" + slugify(p.Name) + ">", firstLine(p.Description)})
+		// canonicalName, not slugify: the usage line spells positionals the
+		// canonical way ("<model-id>"), and a differently-spelled name here
+		// reads as a second, unrelated argument.
+		lines = append(lines, argLine{"<" + canonicalName(p.Name) + ">", firstLine(p.Description)})
 	}
 	if sh != nil {
 		for _, a := range sh.Args {

--- a/internal/openapi/generate_test.go
+++ b/internal/openapi/generate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -1390,7 +1391,10 @@ func TestBuildCommand_ArgumentsSection(t *testing.T) {
 	if !strings.Contains(cmd.Long, "Arguments:") {
 		t.Fatalf("Long = %q, expected an Arguments section", cmd.Long)
 	}
-	for _, want := range []string{"<modelid>", "Model UUID", "<branchname>", "Branch name"} {
+	// The names must match the usage line's spelling, which is canonical
+	// kebab-case — "<modelid>" here next to "<model-id>" there reads as two
+	// different arguments.
+	for _, want := range []string{"<model-id>", "Model UUID", "<branch-name>", "Branch name"} {
 		if !strings.Contains(cmd.Long, want) {
 			t.Errorf("Long = %q, expected it to contain %q", cmd.Long, want)
 		}
@@ -1467,6 +1471,39 @@ func TestGenerateCommands_ArgumentsSectionFromSpec(t *testing.T) {
 	}
 	if !strings.Contains(merge.Long, "Branch name") {
 		t.Errorf("Long = %q, expected the spec's branchName description", merge.Long)
+	}
+}
+
+// The Arguments block and the usage line describe the same positionals, so a
+// reader comparing them must see the same names. They are built from separate
+// code paths, which is exactly how they drifted before ("<modelid>" in the
+// Arguments block, "<model-id>" in the usage line).
+func TestGenerateCommands_ArgumentNamesMatchUsageLine(t *testing.T) {
+	specData := loadSpec(t)
+	cmds, err := GenerateCommands(specData, func(req APIRequest) error { return nil })
+	if err != nil {
+		t.Fatalf("GenerateCommands: %v", err)
+	}
+
+	placeholder := regexp.MustCompile(`<[^>]+>`)
+	checked := 0
+	for _, tagCmd := range cmds {
+		for _, sub := range tagCmd.Commands() {
+			names := placeholder.FindAllString(sub.Use, -1)
+			if len(names) == 0 {
+				continue
+			}
+			checked++
+			for _, name := range names {
+				if !strings.Contains(sub.Long, "\n  "+name) {
+					t.Errorf("%s %s: usage line has %s but the Arguments block does not:\n%s",
+						tagCmd.Use, sub.Name(), name, sub.Long)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no commands with positional args found; the spec or generator changed")
 	}
 }
 


### PR DESCRIPTION
`omni models merge-branch --help` described its two positionals twice, under two different names:

```
Arguments:
  <modelid>     Model UUID
  <branchname>  Branch name

Usage:
  omni models merge-branch <model-id> <branch-name> [flags]
```

The Arguments block exists to tell a reader that the second positional is a branch **name**, not a UUID. That only lands if both blocks are recognizably about the same argument — under two spellings they read as four arguments.

The usage line has used `canonicalName` since #77; `argumentsHelp` kept calling `slugify`, which lowercases but doesn't split camelCase. Both now use `canonicalName`.

Help text only — nothing is parsed from these strings, and flag/arg matching is unaffected.

<details>
<summary>Details: scope and verification</summary>

## Scope

One line in `argumentsHelp`. Only the path-param branch needed it; body-shorthand arg names (`model-id`, `prompt`, …) are authored in kebab-case already and were never affected.

Every generated command with a camelCase path param was showing the wrong spelling — `ai conversation-detail` (`<conversationid>`), `ai job-cancel` (`<jobid>`), `models merge-branch`, and so on.

## After

```
Arguments:
  <model-id>     Model UUID
  <branch-name>  Branch name

Usage:
  omni models merge-branch <model-id> <branch-name> [flags]
```

## Verification

`make build && go test ./...` — all packages pass.

`TestBuildCommand_ArgumentsSection` updated to expect the canonical spelling, and a new `TestGenerateCommands_ArgumentNamesMatchUsageLine` walks every generated command in `api/openapi.json` and asserts each `<placeholder>` in the usage line appears in the Arguments block — the two are built by separate code paths, which is how they drifted in the first place.

Both fail against the pre-fix code (checked by reverting the one-line change): the spec-wide test flags `ai conversation-detail`, `ai job-cancel`, and the rest.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP53YBDjhQkkn3WAqMR3sf