### PR TITLE
sync spec: composite-topic imported_model_ids on v2 document queries

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2460,9 +2460,9 @@
           "code": {
             "type": "string",
             "enum": [
+              "not_expressible",
               "no_query",
               "malformed_query",
-              "no_gate",
               "dry_run_failed",
               "no_condition_detected"
             ],
@@ -26102,6 +26102,13 @@
                 },
                 "description": "Filters that were embedded directly in raw SQL (read-only)."
               },
+              "imported_model_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model IDs (UUIDs) the query reaches through its composite topic's imports — the topic's import_models entries, which must be model ids, not names. Authorization requires the run gate on each; omit only for queries that do not touch imported topics."
+              },
               "join_paths_from_topic_name": {
                 "type": "string",
                 "description": "Topic name that determines join path precedence for parsed SQL queries."
@@ -30403,6 +30410,13 @@
                   ]
                 },
                 "description": "Filters that were embedded directly in raw SQL (read-only)."
+              },
+              "imported_model_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model IDs (UUIDs) the query reaches through its composite topic's imports — the topic's import_models entries, which must be model ids, not names. Authorization requires the run gate on each; omit only for queries that do not touch imported topics."
               },
               "join_paths_from_topic_name": {
                 "type": "string",
@@ -44764,6 +44778,7 @@
     },
     "/api/v1/dashboards/{identifier}/download": {
       "post": {
+        "description": "The artifact includes cross-model tiles the download runs as (the target user when one is named, else the API key’s user); tiles on a model they cannot query are omitted.",
         "operationId": "dashboardsDownload",
         "summary": "Initiate dashboard download",
         "tags": [
@@ -50128,7 +50143,7 @@
     },
     "/api/v1/models/{modelId}": {
       "patch": {
-        "description": "Update metadata for an existing model. Currently supports renaming the model via the `name` field.",
+        "description": "Update metadata for an existing model. Currently supports renaming the model via the `name` field. Renaming a schema, shared, or shared extension model requires Connection Admin; renaming a branch requires Modeler.",
         "operationId": "modelsUpdate",
         "summary": "Update model",
         "tags": [

--- a/cmd/omni/openapi.json
+++ b/cmd/omni/openapi.json
@@ -2460,9 +2460,9 @@
           "code": {
             "type": "string",
             "enum": [
+              "not_expressible",
               "no_query",
               "malformed_query",
-              "no_gate",
               "dry_run_failed",
               "no_condition_detected"
             ],
@@ -26102,6 +26102,13 @@
                 },
                 "description": "Filters that were embedded directly in raw SQL (read-only)."
               },
+              "imported_model_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model IDs (UUIDs) the query reaches through its composite topic's imports — the topic's import_models entries, which must be model ids, not names. Authorization requires the run gate on each; omit only for queries that do not touch imported topics."
+              },
               "join_paths_from_topic_name": {
                 "type": "string",
                 "description": "Topic name that determines join path precedence for parsed SQL queries."
@@ -30403,6 +30410,13 @@
                   ]
                 },
                 "description": "Filters that were embedded directly in raw SQL (read-only)."
+              },
+              "imported_model_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model IDs (UUIDs) the query reaches through its composite topic's imports — the topic's import_models entries, which must be model ids, not names. Authorization requires the run gate on each; omit only for queries that do not touch imported topics."
               },
               "join_paths_from_topic_name": {
                 "type": "string",
@@ -44764,6 +44778,7 @@
     },
     "/api/v1/dashboards/{identifier}/download": {
       "post": {
+        "description": "The artifact includes cross-model tiles the download runs as (the target user when one is named, else the API key’s user); tiles on a model they cannot query are omitted.",
         "operationId": "dashboardsDownload",
         "summary": "Initiate dashboard download",
         "tags": [
@@ -50128,7 +50143,7 @@
     },
     "/api/v1/models/{modelId}": {
       "patch": {
-        "description": "Update metadata for an existing model. Currently supports renaming the model via the `name` field.",
+        "description": "Update metadata for an existing model. Currently supports renaming the model via the `name` field. Renaming a schema, shared, or shared extension model requires Connection Admin; renaming a branch requires Modeler.",
         "operationId": "modelsUpdate",
         "summary": "Update model",
         "tags": [


### PR DESCRIPTION
## Summary

Syncs `api/openapi.json` (and the embedded `cmd/omni/openapi.json`) from `exploreomni/omni@main` (`f75cae25d89`).

**Headline change**

- `queryPresentations.data.*.query.imported_model_ids` (`string[]`) added to the v2 document bodies — `documentsV2Create`, `documentsV2PatchDraftBody` — and to the v2 read response. These are the model IDs a query reaches through its composite topic's imports; the API authorizes the run gate on each.

**Side effects pulled in by the full sync**

- `models update` (`PATCH /api/v1/models/{modelId}`): description now spells out that renaming a schema, shared, or shared-extension model requires Connection Admin, and renaming a branch requires Modeler.
- `dashboards download` (`POST /api/v1/dashboards/{identifier}/download`): new description covering how cross-model tiles resolve (the target user when named, else the API key's user) and that tiles on unqueryable models are omitted.
- AI routine failure `code` enum: `no_gate` removed, `not_expressible` added.

**Command surface**

No new operations, and no new query or path params — the CLI's command and flag surface is unchanged. `imported_model_ids` is a request-body field, so it arrives via `--body` rather than as a flag.

## Test plan

- [x] `make build`
- [x] `make test` — all packages pass
- [x] `./bin/omni models update --help` and `./bin/omni dashboards download --help` reflect the new descriptions
- [x] `./bin/omni documents v2-create --schema --field queryPresentations.data.query` shows `imported_model_ids`
- [ ] Live API call exercising `imported_model_ids` (not run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP53YBDjhQkkn3WAqMR3sf