### PR TITLE
fix(config): honour -p/--profile in config login and logout

### DIFF
--- a/cmd/omni/config_commands.go
+++ b/cmd/omni/config_commands.go
@@ -390,6 +390,22 @@ func configDeleteCmd() *cobra.Command {
 	return cmd
 }
 
+// targetProfileName resolves which profile a login/logout command should act
+// on: the positional argument wins, then the global -p/--profile flag, then the
+// configured default profile.
+func targetProfileName(cmd *cobra.Command, args []string, cfg *config.Config) (string, error) {
+	if len(args) > 0 && args[0] != "" {
+		return args[0], nil
+	}
+	if flag, _ := cmd.Flags().GetString("profile"); flag != "" {
+		return flag, nil
+	}
+	if cfg.DefaultProfile != "" {
+		return cfg.DefaultProfile, nil
+	}
+	return "", fmt.Errorf("no profile specified and no default profile set")
+}
+
 func configLoginCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "login [profile]",
@@ -401,15 +417,9 @@ func configLoginCmd() *cobra.Command {
 				return fmt.Errorf("no config found — run `omni config init` first")
 			}
 
-			name := ""
-			if len(args) > 0 {
-				name = args[0]
-			}
-			if name == "" {
-				name = cfg.DefaultProfile
-			}
-			if name == "" {
-				return fmt.Errorf("no profile specified and no default profile set")
+			name, err := targetProfileName(cmd, args, cfg)
+			if err != nil {
+				return err
 			}
 
 			p, ok := cfg.Profiles[name]
@@ -449,15 +459,9 @@ func configLogoutCmd() *cobra.Command {
 				return fmt.Errorf("no config found — run `omni config init` first")
 			}
 
-			name := ""
-			if len(args) > 0 {
-				name = args[0]
-			}
-			if name == "" {
-				name = cfg.DefaultProfile
-			}
-			if name == "" {
-				return fmt.Errorf("no profile specified and no default profile set")
+			name, err := targetProfileName(cmd, args, cfg)
+			if err != nil {
+				return err
 			}
 
 			p, ok := cfg.Profiles[name]

--- a/cmd/omni/config_commands_test.go
+++ b/cmd/omni/config_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/exploreomni/omni-cli/internal/config"
+	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
 
@@ -566,5 +567,71 @@ func TestConfigDelete_UnknownProfile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `"nope" not found`) {
 		t.Errorf("error = %q, want it to mention the missing profile", err.Error())
+	}
+}
+
+// Regression for #83: the global -p/--profile flag must be honoured when no
+// positional profile is given, instead of silently acting on the default.
+func TestConfigLogout_ProfileFlagOverridesDefault(t *testing.T) {
+	withConfig(t, &config.Config{
+		Version:        1,
+		DefaultProfile: "playground",
+		Profiles: map[string]config.Profile{
+			"playground": {AuthMethod: "oauth", AccessToken: "keep", RefreshToken: "keep"},
+			"prod":       {AuthMethod: "oauth", AccessToken: "a", RefreshToken: "r"},
+		},
+	})
+
+	cmd := configLogoutCmd()
+	cmd.Flags().StringP("profile", "p", "", "")
+	if err := cmd.Flags().Set("profile", "prod"); err != nil {
+		t.Fatal(err)
+	}
+	_ = captureStdout(t, func() {
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("RunE: %v", err)
+		}
+	})
+
+	cfg, _ := config.Load()
+	if cfg.Profiles["prod"].AccessToken != "" {
+		t.Error("-p prod: prod tokens were not cleared")
+	}
+	if cfg.Profiles["playground"].AccessToken != "keep" {
+		t.Error("-p prod: default profile was modified")
+	}
+}
+
+func TestTargetProfileName(t *testing.T) {
+	cfg := &config.Config{DefaultProfile: "playground"}
+	newCmd := func(flag string) *cobra.Command {
+		c := &cobra.Command{}
+		c.Flags().StringP("profile", "p", "", "")
+		if flag != "" {
+			_ = c.Flags().Set("profile", flag)
+		}
+		return c
+	}
+	tests := []struct {
+		name string
+		args []string
+		flag string
+		want string
+	}{
+		{"positional wins over flag", []string{"prod"}, "staging", "prod"},
+		{"flag wins over default", nil, "prod", "prod"},
+		{"default when neither", nil, "", "playground"},
+	}
+	for _, tc := range tests {
+		got, err := targetProfileName(newCmd(tc.flag), tc.args, cfg)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+	if _, err := targetProfileName(newCmd(""), nil, &config.Config{}); err == nil {
+		t.Error("expected error when no profile and no default")
 	}
 }


### PR DESCRIPTION
Fixes #83

## Problem
`omni config login -p <profile>` ignored the global `-p/--profile` flag and stored OAuth tokens on the **default** profile, leaving the named profile without a token. `config logout` had the same blind spot.

## Fix
- Add `targetProfileName()` which resolves the profile as: positional arg → `-p/--profile` flag → default profile.
- Use it in both `config login` and `config logout`.
- The OAuth flow already uses the resolved profile's `apiEndpoint`, so with the right profile picked it now hits the correct instance.

## Tests
- `TestConfigLogout_ProfileFlagOverridesDefault` — regression test: `-p prod` clears `prod`, leaves the default untouched.
- `TestTargetProfileName` — precedence of arg / flag / default, plus the no-profile error.

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvL1csJEAzYe5Yvu6eZq2K