### PR TITLE
fix(config): stop reporting broken configs and unknown profiles as "no API token"

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,11 +5,13 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -82,8 +84,13 @@ type ResolvedConfig struct {
 func Resolve(profileName, tokenFlag, baseURLFlag string) (*ResolvedConfig, error) {
 	rc := &ResolvedConfig{}
 
-	// Start from config file
-	cfg, _ := Load()
+	// Start from config file. A missing file is normal (env/flags may carry
+	// everything); any other failure is remembered and reported below if the
+	// config turns out to be needed, instead of masquerading as "no token".
+	cfg, loadErr := Load()
+	if loadErr != nil && errors.Is(loadErr, os.ErrNotExist) {
+		loadErr = nil
+	}
 	var profile *Profile
 	if cfg != nil {
 		name := profileName
@@ -91,15 +98,26 @@ func Resolve(profileName, tokenFlag, baseURLFlag string) (*ResolvedConfig, error
 			name = cfg.DefaultProfile
 		}
 		if name != "" {
-			if p, ok := cfg.Profiles[name]; ok {
-				profile = &p
-				rc.BaseURL = p.APIEndpoint
-				switch p.AuthMethod {
-				case "oauth":
-					rc.Token = p.AccessToken
-				default: // "api-key"
-					rc.Token = p.APIKey
+			p, ok := cfg.Profiles[name]
+			if !ok {
+				names := make([]string, 0, len(cfg.Profiles))
+				for n := range cfg.Profiles {
+					names = append(names, n)
 				}
+				sort.Strings(names)
+				which := "profile"
+				if profileName == "" {
+					which = "default profile"
+				}
+				return nil, fmt.Errorf("%s %q not found in %s (available: %s)", which, name, ConfigPath(), strings.Join(names, ", "))
+			}
+			profile = &p
+			rc.BaseURL = p.APIEndpoint
+			switch p.AuthMethod {
+			case "oauth":
+				rc.Token = p.AccessToken
+			default: // "api-key"
+				rc.Token = p.APIKey
 			}
 		}
 	}
@@ -151,6 +169,9 @@ func Resolve(profileName, tokenFlag, baseURLFlag string) (*ResolvedConfig, error
 	}
 
 	// Validate
+	if loadErr != nil && (rc.Token == "" || rc.BaseURL == "") {
+		return nil, fmt.Errorf("loading config %s: %w", ConfigPath(), loadErr)
+	}
 	if rc.Token == "" {
 		return nil, fmt.Errorf("no API token configured. Set OMNI_API_TOKEN, use --token, or run `omni config init`")
 	}
@@ -256,4 +277,3 @@ func ConfigPath() string {
 	}
 	return filepath.Join(configDir(), "config.json")
 }
-

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -715,3 +715,45 @@ func TestLoad_MissingFile(t *testing.T) {
 		t.Fatal("expected error loading nonexistent file, got nil")
 	}
 }
+
+func TestResolve_UnknownProfileNamesAvailable(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OMNI_CONFIG_DIR", dir)
+	t.Setenv("OMNI_API_TOKEN", "")
+	cfg := &Config{Version: 1, DefaultProfile: "a", Profiles: map[string]Profile{
+		"a": {APIEndpoint: "https://a.omniapp.co", AuthMethod: "api-key", APIKey: "k"},
+		"b": {APIEndpoint: "https://b.omniapp.co", AuthMethod: "api-key", APIKey: "k"},
+	}}
+	if err := Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Resolve("nope", "", "")
+	if err == nil {
+		t.Fatal("expected error for unknown profile")
+	}
+	for _, want := range []string{`profile "nope" not found`, "available: a, b"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "no API token") {
+		t.Errorf("unknown profile must not be reported as a missing token: %q", err)
+	}
+}
+
+func TestResolve_MalformedConfigIsReported(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OMNI_CONFIG_DIR", dir)
+	t.Setenv("OMNI_API_TOKEN", "")
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"version":1,"profiles":{`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Resolve("", "", "")
+	if err == nil || !strings.Contains(err.Error(), "loading config") || strings.Contains(err.Error(), "no API token") {
+		t.Errorf("want a parse error naming the config file, got %v", err)
+	}
+	// With everything supplied on the command line the broken file is irrelevant.
+	if _, err := Resolve("", "tok", "https://x.omniapp.co"); err != nil {
+		t.Errorf("flags should bypass the broken config, got %v", err)
+	}
+}


### PR DESCRIPTION
`config.Resolve` did `cfg, _ := Load()`, so three unrelated failures all produced the same message — *"no API token configured. Set OMNI_API_TOKEN, use --token, or run `omni config init`"*:

- `omni -p typo models list`
- a malformed / unreadable `config.json`
- (and consequently any transient read failure)

Now:

```
$ omni -p nope models list
Error: profile "nope" not found in ~/.config/omni-cli/config.json (available: acme, prod, …)

$ omni models list   # with a truncated config.json
Error: loading config ~/.config/omni-cli/config.json: parsing config: unexpected end of JSON input
```

A missing config file is still silent (env/flags may carry everything), and a broken file is ignored when both `--token` and `--base-url` are supplied. Tests added for both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ei8UYaG1bW5PJhk93EaqzA