### PR TITLE
ci(notify-docs): dispatch the docs sync on release only

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -6,8 +6,15 @@ on:
   push:
     branches: [main]
     paths:
+      # Prose changes.
       - "**/*.md"
+      # Anything that changes the generated command surface: flags, args,
+      # help text, agent-help, and the spec every command is derived from.
+      - "cmd/**"
+      - "internal/openapi/**"
+      - "api/openapi.json"
       - "!.github/**"
+      - "!**/*_test.go"
 
 jobs:
   notify:

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,20 +1,11 @@
 name: Notify Docs on Changes
 
 on:
+  # Release-only: the receiver diffs previous tag..this tag, so one dispatch per
+  # release carries every change since the last one. Pushes to main are
+  # deliberately not a trigger — they produced a docs PR per merge.
   release:
     types: [published]
-  push:
-    branches: [main]
-    paths:
-      # Prose changes.
-      - "**/*.md"
-      # Anything that changes the generated command surface: flags, args,
-      # help text, agent-help, and the spec every command is derived from.
-      - "cmd/**"
-      - "internal/openapi/**"
-      - "api/openapi.json"
-      - "!.github/**"
-      - "!**/*_test.go"
 
 jobs:
   notify:


### PR DESCRIPTION
Drops the `push: main` trigger from `notify-docs.yml` so the docs sync runs **only on a published release**. The receiver (`mintlify-omni/sync-upstream-docs.yml`) already diffs `previous tag..release tag` and reads the release notes, so one dispatch per release carries every change since the last one; per-merge pushes only produced a docs PR per merge (and, this week, a run per `CLAUDE.md` edit).

Note: the workflow has failed on every run since April with *"Repository not found, OR token has insufficient permissions"* — `DOCS_REPO_TOKEN` (set 2026-04-09) needs rotating before any trigger change matters. This PR doesn't fix that.

Companion PR in `mintlify-omni` (exploreomni/mintlify-omni#2118) points the sync prompt at `developers/cli/*.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ei8UYaG1bW5PJhk93EaqzA