### PR TITLE
Notify users and agents about CLI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ The binary is written to `./bin/omni`.
 
 In an interactive terminal, Omni checks for a newer stable release at most
 once every 24 hours and prints an upgrade notice after a successful command.
-The check is best-effort and is skipped in CI and when output is redirected.
-Set `OMNI_NO_UPDATE_NOTIFIER=1` to disable it.
+A failed or interrupted check backs off for 15 minutes rather than retrying on
+the next command, and concurrent runs coordinate through a lock file in the
+cache directory, so several shells make one request between them. The check is
+best-effort and is skipped in CI and whenever output isn't human-formatted on a
+terminal. Set `OMNI_NO_UPDATE_NOTIFIER=1` to disable it.
 
 To check explicitly, including from an agent or script:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ make build
 
 The binary is written to `./bin/omni`.
 
+### Updates
+
+In an interactive terminal, Omni checks for a newer stable release at most
+once every 24 hours and prints an upgrade notice after a successful command.
+The check is best-effort and is skipped in CI and when output is redirected.
+Set `OMNI_NO_UPDATE_NOTIFIER=1` to disable it.
+
+To check explicitly, including from an agent or script:
+
+```bash
+omni update check --format json
+```
+
 ## Quick start
 
 ### Configure a profile

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The binary is written to `./bin/omni`.
 
 ### Updates
 
-In an interactive terminal, Omni checks for a newer stable release at most
-once every 24 hours and prints an upgrade notice after a successful command.
+In an interactive terminal, Omni waits 24 hours after a successful check for a
+newer stable release and prints an upgrade notice after a successful command.
 A failed or interrupted check backs off for 15 minutes rather than retrying on
 the next command, and concurrent runs coordinate through a lock file in the
 cache directory, so several shells make one request between them. The check is

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -14,7 +14,7 @@ const agentHelpText = `# Omni CLI — Agent Guide
 All output is JSON to stdout. Errors are JSON to stderr.
 Use --compact for non-indented output (good for piping to jq).
 
-Check once per agent session whether this CLI is current:
+Automatic update notices are disabled for non-interactive runs. Check explicitly:
   omni update check --format json --compact
 
 ## Streams and exit codes

--- a/cmd/omni/agent_help.go
+++ b/cmd/omni/agent_help.go
@@ -14,6 +14,9 @@ const agentHelpText = `# Omni CLI — Agent Guide
 All output is JSON to stdout. Errors are JSON to stderr.
 Use --compact for non-indented output (good for piping to jq).
 
+Check once per agent session whether this CLI is current:
+  omni update check --format json --compact
+
 ## Streams and exit codes
 On failure nothing is written to stdout — the API's error body, the error
 message, and any suggestions all go to stderr, and the exit code is non-zero.
@@ -117,6 +120,7 @@ Multipart body fields are generated as flags; binary fields take file paths.
   user-attributes  User attribute definitions
   users         User/group role management, set user attribute values
   config        CLI configuration profiles
+  update        Check for CLI updates
 
 ## Discovering request and response shapes
 Every API command accepts --schema, including GET/DELETE commands that take no

--- a/cmd/omni/config_commands.go
+++ b/cmd/omni/config_commands.go
@@ -162,8 +162,9 @@ accepted as a flag, so it can't leak into shell history.`,
 
 func configShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show",
-		Short: "Display current configuration",
+		Use:         "show",
+		Short:       "Display current configuration",
+		Annotations: map[string]string{machineOutputAnnotation: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Args are validated: failures below are runtime errors, not usage errors.
 			cmd.SilenceUsage = true

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -30,11 +30,20 @@ func init() {
 
 func main() {
 	checker := updatecheck.New()
+	var updater automaticUpdate
 	root := &cobra.Command{
 		Use:     "omni",
 		Short:   "Omni CLI — programmatic access to the Omni API",
 		Version: version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Started here, not from os.Args: cobra has resolved the command
+			// and parsed its flags, so eligibility sees the real command and
+			// the real --format (including -ojson and --FORMAT json). The
+			// hook runs immediately before RunE, so the check still overlaps
+			// with the work the user asked for. --help and --version never
+			// reach it; cobra answers those before the hooks run.
+			updater = startAutomaticUpdate(checker, version, cmd, os.Stdout, os.Stderr)
+
 			// Skip auth for config commands
 			if cmd.Name() == "init" || cmd.Name() == "show" || cmd.Name() == "use" || cmd.Name() == "login" || cmd.Name() == "logout" || cmd.Name() == "config" {
 				return nil
@@ -89,10 +98,9 @@ func main() {
 	// help flag, including for `omni models list-branches --help`, where the
 	// "help" is really an unknown-subcommand error. UnknownSubcommand asks the
 	// command that ran whether that's what happened.
-	automaticUpdate := startAutomaticUpdate(checker, version, os.Args[1:], os.Stdout, os.Stderr)
 	cmd, err := root.ExecuteC()
 	success := err == nil && !openapi.UnknownSubcommand(cmd)
-	automaticUpdate.finish(success, os.Stderr)
+	updater.finish(success, os.Stderr)
 	if !success {
 		os.Exit(1)
 	}

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/exploreomni/omni-cli/internal/auth"
 	"github.com/exploreomni/omni-cli/internal/config"
 	"github.com/exploreomni/omni-cli/internal/openapi"
+	"github.com/exploreomni/omni-cli/internal/updatecheck"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -28,6 +29,7 @@ func init() {
 }
 
 func main() {
+	checker := updatecheck.New()
 	root := &cobra.Command{
 		Use:     "omni",
 		Short:   "Omni CLI — programmatic access to the Omni API",
@@ -60,6 +62,7 @@ func main() {
 	// Hand-written commands (not from spec)
 	addConfigCommands(root)
 	addAgentHelpCommand(root)
+	addUpdateCommand(root, checker, version)
 
 	// Load OpenAPI spec and generate API commands
 	specData, err := specFS.ReadFile("openapi.json")
@@ -86,8 +89,11 @@ func main() {
 	// help flag, including for `omni models list-branches --help`, where the
 	// "help" is really an unknown-subcommand error. UnknownSubcommand asks the
 	// command that ran whether that's what happened.
+	automaticUpdate := startAutomaticUpdate(checker, version, os.Args[1:], os.Stdout, os.Stderr)
 	cmd, err := root.ExecuteC()
-	if err != nil || openapi.UnknownSubcommand(cmd) {
+	success := err == nil && !openapi.UnknownSubcommand(cmd)
+	automaticUpdate.finish(success, os.Stderr)
+	if !success {
 		os.Exit(1)
 	}
 }

--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -36,12 +36,8 @@ func main() {
 		Short:   "Omni CLI — programmatic access to the Omni API",
 		Version: version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Started here, not from os.Args: cobra has resolved the command
-			// and parsed its flags, so eligibility sees the real command and
-			// the real --format (including -ojson and --FORMAT json). The
-			// hook runs immediately before RunE, so the check still overlaps
-			// with the work the user asked for. --help and --version never
-			// reach it; cobra answers those before the hooks run.
+			// This hook runs immediately before RunE, so the check overlaps
+			// with the work the user asked for.
 			updater = startAutomaticUpdate(checker, version, cmd, os.Stdout, os.Stderr)
 
 			// Skip auth for config commands

--- a/cmd/omni/update_command.go
+++ b/cmd/omni/update_command.go
@@ -16,7 +16,7 @@ import (
 )
 
 type releaseChecker interface {
-	Check(ctx context.Context, currentVersion string, force bool) (updatecheck.Result, error)
+	Check(ctx context.Context, currentVersion string) (updatecheck.Result, error)
 }
 
 func addUpdateCommand(root *cobra.Command, checker releaseChecker, currentVersion string) {
@@ -30,17 +30,26 @@ func addUpdateCommand(root *cobra.Command, checker releaseChecker, currentVersio
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			result, err := checker.Check(cmd.Context(), currentVersion, true)
-			if err != nil {
-				return err
-			}
+			// Resolve the format before checking: a failure has to be reported
+			// in the format the caller asked for, not as cobra's plain
+			// "Error: ..." line, which would break the JSON contract agents
+			// rely on.
 			formatFlag, _ := cmd.Flags().GetString("format")
+			compact, _ := cmd.Flags().GetBool("compact")
 			format := config.ResolveOutputFormat(formatFlag, writerIsTerminal(cmd.OutOrStdout()))
+
+			result, err := checker.Check(cmd.Context(), currentVersion)
+			if err != nil {
+				// Same contract as a failed API call: exactly one document on
+				// stderr, nothing on stdout, and no duplicate line from cobra.
+				writeError(cmd.ErrOrStderr(), format, 0, err.Error(), nil, compact)
+				cmd.SilenceErrors = true
+				return &apiError{detail: err.Error()}
+			}
 			if format == config.FormatHuman {
 				writeHumanUpdateResult(cmd, result)
 				return nil
 			}
-			compact, _ := cmd.Flags().GetBool("compact")
 			enc := json.NewEncoder(cmd.OutOrStdout())
 			if !compact {
 				enc.SetIndent("", "  ")
@@ -57,8 +66,12 @@ func writeHumanUpdateResult(cmd *cobra.Command, r updatecheck.Result) {
 		return
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "A newer Omni CLI is available: %s -> %s\n", displayVersion(r.CurrentVersion), displayVersion(r.LatestVersion))
-	fmt.Fprintf(cmd.OutOrStdout(), "Homebrew: %s\n", r.Upgrade.Homebrew)
-	fmt.Fprintf(cmd.OutOrStdout(), "Other:    %s\n", r.Upgrade.Other)
+	if r.Upgrade.Homebrew != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Homebrew: %s\n", r.Upgrade.Homebrew)
+		fmt.Fprintf(cmd.OutOrStdout(), "Other:    %s\n", r.Upgrade.Other)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Upgrade:  %s\n", r.Upgrade.Other)
+	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Release:  %s\n", r.ReleaseURL)
 }
 

--- a/cmd/omni/update_command.go
+++ b/cmd/omni/update_command.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/exploreomni/omni-cli/internal/config"
+	"github.com/exploreomni/omni-cli/internal/openapi"
 	"github.com/exploreomni/omni-cli/internal/updatecheck"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -20,10 +21,8 @@ type releaseChecker interface {
 }
 
 func addUpdateCommand(root *cobra.Command, checker releaseChecker, currentVersion string) {
-	updateCmd := &cobra.Command{
-		Use:   "update",
-		Short: "Check for Omni CLI updates",
-	}
+	// Same unknown-subcommand handling as the generated groups.
+	updateCmd := openapi.NewGroupCommand("update", "Check for Omni CLI updates")
 	updateCmd.AddCommand(&cobra.Command{
 		Use:   "check",
 		Short: "Check whether a newer Omni CLI release is available",

--- a/cmd/omni/update_command.go
+++ b/cmd/omni/update_command.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/exploreomni/omni-cli/internal/config"
+	"github.com/exploreomni/omni-cli/internal/updatecheck"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+type releaseChecker interface {
+	Check(ctx context.Context, currentVersion string, force bool) (updatecheck.Result, error)
+}
+
+func addUpdateCommand(root *cobra.Command, checker releaseChecker, currentVersion string) {
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Check for Omni CLI updates",
+	}
+	updateCmd.AddCommand(&cobra.Command{
+		Use:   "check",
+		Short: "Check whether a newer Omni CLI release is available",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			result, err := checker.Check(cmd.Context(), currentVersion, true)
+			if err != nil {
+				return err
+			}
+			formatFlag, _ := cmd.Flags().GetString("format")
+			format := config.ResolveOutputFormat(formatFlag, writerIsTerminal(cmd.OutOrStdout()))
+			if format == config.FormatHuman {
+				writeHumanUpdateResult(cmd, result)
+				return nil
+			}
+			compact, _ := cmd.Flags().GetBool("compact")
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			if !compact {
+				enc.SetIndent("", "  ")
+			}
+			return enc.Encode(result)
+		},
+	})
+	root.AddCommand(updateCmd)
+}
+
+func writeHumanUpdateResult(cmd *cobra.Command, r updatecheck.Result) {
+	if !r.UpdateAvailable {
+		fmt.Fprintf(cmd.OutOrStdout(), "Omni CLI %s is up to date.\n", displayVersion(r.CurrentVersion))
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "A newer Omni CLI is available: %s -> %s\n", displayVersion(r.CurrentVersion), displayVersion(r.LatestVersion))
+	fmt.Fprintf(cmd.OutOrStdout(), "Homebrew: %s\n", r.Upgrade.Homebrew)
+	fmt.Fprintf(cmd.OutOrStdout(), "Other:    %s\n", r.Upgrade.Other)
+	fmt.Fprintf(cmd.OutOrStdout(), "Release:  %s\n", r.ReleaseURL)
+}
+
+func recentHomebrewRelease(r updatecheck.Result, now time.Time) bool {
+	return !r.PublishedAt.IsZero() && now.Sub(r.PublishedAt) < 24*time.Hour
+}
+
+func writerIsTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+func displayVersion(version string) string {
+	return "v" + strings.TrimPrefix(version, "v")
+}

--- a/cmd/omni/update_command_test.go
+++ b/cmd/omni/update_command_test.go
@@ -15,12 +15,10 @@ import (
 type fakeReleaseChecker struct {
 	result updatecheck.Result
 	err    error
-	force  bool
 	checks int
 }
 
-func (f *fakeReleaseChecker) Check(_ context.Context, _ string, force bool) (updatecheck.Result, error) {
-	f.force = force
+func (f *fakeReleaseChecker) Check(_ context.Context, _ string) (updatecheck.Result, error) {
 	f.checks++
 	return f.result, f.err
 }
@@ -45,8 +43,8 @@ func TestUpdateCheckJSON(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !checker.force || checker.checks != 1 {
-		t.Fatalf("checker force=%v checks=%d", checker.force, checker.checks)
+	if checker.checks != 1 {
+		t.Fatalf("checks = %d, want one explicit check", checker.checks)
 	}
 	var got updatecheck.Result
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
@@ -77,13 +75,54 @@ func TestUpdateCheckHuman(t *testing.T) {
 	}
 }
 
-func TestUpdateCheckFailure(t *testing.T) {
+// A failed check keeps the CLI's stream contract: nothing on stdout, exactly
+// one JSON document on stderr, and no second report from cobra.
+func TestUpdateCheckFailureJSON(t *testing.T) {
 	checker := &fakeReleaseChecker{err: errors.New("network unavailable")}
-	root := &cobra.Command{Use: "omni", SilenceErrors: true, SilenceUsage: true}
+	root := &cobra.Command{Use: "omni"}
 	addGlobalFlags(root)
 	addUpdateCommand(root, checker, "v1.2.0")
-	root.SetArgs([]string{"update", "check"})
-	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "network unavailable") {
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"update", "check", "--format", "json", "--compact"})
+
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "network unavailable") {
 		t.Fatalf("error = %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want nothing on a failure", stdout.String())
+	}
+	var envelope struct {
+		Error  string `json:"error"`
+		Status int    `json:"status"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr is not a single JSON document (%v): %q", err, stderr.String())
+	}
+	if envelope.Error != "network unavailable" || envelope.Status != 0 {
+		t.Fatalf("envelope = %+v", envelope)
+	}
+}
+
+func TestUpdateCheckFailureHuman(t *testing.T) {
+	checker := &fakeReleaseChecker{err: errors.New("network unavailable")}
+	root := &cobra.Command{Use: "omni"}
+	addGlobalFlags(root)
+	addUpdateCommand(root, checker, "v1.2.0")
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"update", "check", "--format", "human"})
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected an error")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if got := stderr.String(); got != "Error: network unavailable\n" {
+		t.Fatalf("stderr = %q", got)
 	}
 }

--- a/cmd/omni/update_command_test.go
+++ b/cmd/omni/update_command_test.go
@@ -126,3 +126,39 @@ func TestUpdateCheckFailureHuman(t *testing.T) {
 		t.Fatalf("stderr = %q", got)
 	}
 }
+
+// The hand-written update group must behave like the generated ones: a bare
+// group or a mistyped subcommand is an error on stderr with an empty stdout,
+// not help printed to stdout with exit 0.
+func TestUpdateGroupRequiresSubcommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"bare group", []string{"update"}, "requires a subcommand"},
+		{"typo", []string{"update", "chekc"}, `unknown subcommand "chekc"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "omni"}
+			addGlobalFlags(root)
+			addUpdateCommand(root, &fakeReleaseChecker{}, "v1.2.0")
+			var stdout, stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(tt.args)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("expected an error, got nil (stdout %q)", stdout.String())
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tt.wantErr)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q, want empty", stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/omni/update_command_test.go
+++ b/cmd/omni/update_command_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/exploreomni/omni-cli/internal/updatecheck"
+	"github.com/spf13/cobra"
+)
+
+type fakeReleaseChecker struct {
+	result updatecheck.Result
+	err    error
+	force  bool
+	checks int
+}
+
+func (f *fakeReleaseChecker) Check(_ context.Context, _ string, force bool) (updatecheck.Result, error) {
+	f.force = force
+	f.checks++
+	return f.result, f.err
+}
+
+func TestUpdateCheckJSON(t *testing.T) {
+	checker := &fakeReleaseChecker{result: updatecheck.Result{
+		UpdateAvailable: true,
+		CurrentVersion:  "v1.2.0",
+		LatestVersion:   "v1.3.0",
+		ReleaseURL:      "https://example.test/v1.3.0",
+		Upgrade: updatecheck.UpgradeInstructions{
+			Homebrew: "brew upgrade omni",
+			Other:    "install command",
+		},
+	}}
+	root := &cobra.Command{Use: "omni"}
+	addGlobalFlags(root)
+	addUpdateCommand(root, checker, "v1.2.0")
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{"update", "check", "--format", "json", "--compact"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !checker.force || checker.checks != 1 {
+		t.Fatalf("checker force=%v checks=%d", checker.force, checker.checks)
+	}
+	var got updatecheck.Result
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON %q: %v", stdout.String(), err)
+	}
+	if !got.UpdateAvailable || got.LatestVersion != "v1.3.0" {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+func TestUpdateCheckHuman(t *testing.T) {
+	checker := &fakeReleaseChecker{result: updatecheck.Result{
+		UpdateAvailable: false,
+		CurrentVersion:  "v1.3.0",
+		LatestVersion:   "v1.3.0",
+	}}
+	root := &cobra.Command{Use: "omni"}
+	addGlobalFlags(root)
+	addUpdateCommand(root, checker, "v1.3.0")
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{"update", "check", "--format", "human"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "v1.3.0 is up to date") {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestUpdateCheckFailure(t *testing.T) {
+	checker := &fakeReleaseChecker{err: errors.New("network unavailable")}
+	root := &cobra.Command{Use: "omni", SilenceErrors: true, SilenceUsage: true}
+	addGlobalFlags(root)
+	addUpdateCommand(root, checker, "v1.2.0")
+	root.SetArgs([]string{"update", "check"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "network unavailable") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/cmd/omni/update_notice.go
+++ b/cmd/omni/update_notice.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/exploreomni/omni-cli/internal/config"
+	"github.com/exploreomni/omni-cli/internal/updatecheck"
+	"golang.org/x/term"
+)
+
+type automaticReleaseChecker interface {
+	Check(ctx context.Context, currentVersion string, force bool) (updatecheck.Result, error)
+	NotificationDue(updatecheck.Result) bool
+	MarkNotified(version string) error
+}
+
+type updateOutcome struct {
+	result updatecheck.Result
+	err    error
+}
+
+type automaticUpdate struct {
+	cancel   context.CancelFunc
+	result   <-chan updateOutcome
+	checker  automaticReleaseChecker
+	enabled  bool
+	version  string
+	homebrew bool
+	now      func() time.Time
+}
+
+func startAutomaticUpdate(checker automaticReleaseChecker, currentVersion string, args []string, stdout, stderr *os.File) automaticUpdate {
+	if !automaticUpdatesEnabled(currentVersion, args, stdout, stderr) {
+		return automaticUpdate{}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan updateOutcome, 1)
+	go func() {
+		r, err := checker.Check(ctx, currentVersion, false)
+		result <- updateOutcome{result: r, err: err}
+	}()
+	return automaticUpdate{
+		cancel: cancel, result: result, checker: checker, enabled: true,
+		version: currentVersion, homebrew: isHomebrewInstall(), now: time.Now,
+	}
+}
+
+func (u automaticUpdate) finish(success bool, stderr io.Writer) {
+	if !u.enabled {
+		return
+	}
+	u.cancel()
+	outcome := <-u.result
+	if !success || outcome.err != nil || !u.checker.NotificationDue(outcome.result) {
+		return
+	}
+
+	if u.homebrew && recentHomebrewRelease(outcome.result, u.now()) {
+		return
+	}
+	fmt.Fprintf(stderr, "\nA newer Omni CLI is available: %s -> %s\n", displayVersion(u.version), displayVersion(outcome.result.LatestVersion))
+	if u.homebrew {
+		fmt.Fprintf(stderr, "To upgrade, run: %s\n", outcome.result.Upgrade.Homebrew)
+	} else {
+		fmt.Fprintf(stderr, "To upgrade, run: %s\n", outcome.result.Upgrade.Other)
+	}
+	fmt.Fprintf(stderr, "%s\n", outcome.result.ReleaseURL)
+	_ = u.checker.MarkNotified(outcome.result.LatestVersion)
+}
+
+func automaticUpdatesEnabled(currentVersion string, args []string, stdout, stderr *os.File) bool {
+	isTTY := term.IsTerminal(int(stdout.Fd())) && term.IsTerminal(int(stderr.Fd()))
+	format := config.ResolveOutputFormat(requestedOutputFormat(args), true)
+	return automaticUpdatesAllowed(currentVersion, args, isTTY && format == config.FormatHuman, os.Getenv)
+}
+
+func automaticUpdatesAllowed(currentVersion string, args []string, interactiveHuman bool, getenv func(string) string) bool {
+	if len(args) == 0 || !updatecheck.IsReleaseVersion(currentVersion) || getenv("OMNI_NO_UPDATE_NOTIFIER") != "" || getenv("CI") != "" || !interactiveHuman {
+		return false
+	}
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" || arg == "--version" {
+			return false
+		}
+	}
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "update" && args[i+1] == "check" {
+			return false
+		}
+	}
+	return true
+}
+
+func requestedOutputFormat(args []string) string {
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "--format=") {
+			return strings.TrimPrefix(arg, "--format=")
+		}
+		if (arg == "--format" || arg == "-o") && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func isHomebrewInstall() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	path := filepath.ToSlash(exe)
+	return strings.Contains(path, "/Cellar/omni/") || strings.Contains(path, "/Homebrew/Cellar/omni/")
+}

--- a/cmd/omni/update_notice.go
+++ b/cmd/omni/update_notice.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/exploreomni/omni-cli/internal/config"
 	"github.com/exploreomni/omni-cli/internal/updatecheck"
+	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
 type automaticReleaseChecker interface {
-	Check(ctx context.Context, currentVersion string, force bool) (updatecheck.Result, error)
-	NotificationDue(updatecheck.Result) bool
-	MarkNotified(version string) error
+	CheckAutomatic(ctx context.Context, currentVersion string) (updatecheck.Result, error)
+	ClaimNotification(updatecheck.Result) bool
 }
 
 type updateOutcome struct {
@@ -35,14 +35,18 @@ type automaticUpdate struct {
 	now      func() time.Time
 }
 
-func startAutomaticUpdate(checker automaticReleaseChecker, currentVersion string, args []string, stdout, stderr *os.File) automaticUpdate {
-	if !automaticUpdatesEnabled(currentVersion, args, stdout, stderr) {
+// startAutomaticUpdate begins a background check alongside the command the user
+// asked for. It runs from the root's PersistentPreRunE, so cmd is the command
+// cobra resolved and its flags are parsed: eligibility can look at the real
+// command and the resolved --format rather than guessing from raw os.Args.
+func startAutomaticUpdate(checker automaticReleaseChecker, currentVersion string, cmd *cobra.Command, stdout, stderr *os.File) automaticUpdate {
+	if !automaticUpdatesEnabled(currentVersion, cmd, stdout, stderr) {
 		return automaticUpdate{}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	result := make(chan updateOutcome, 1)
 	go func() {
-		r, err := checker.Check(ctx, currentVersion, false)
+		r, err := checker.CheckAutomatic(ctx, currentVersion)
 		result <- updateOutcome{result: r, err: err}
 	}()
 	return automaticUpdate{
@@ -57,56 +61,81 @@ func (u automaticUpdate) finish(success bool, stderr io.Writer) {
 	}
 	u.cancel()
 	outcome := <-u.result
-	if !success || outcome.err != nil || !u.checker.NotificationDue(outcome.result) {
+	if !success || outcome.err != nil || !outcome.result.UpdateAvailable {
 		return
 	}
 
 	if u.homebrew && recentHomebrewRelease(outcome.result, u.now()) {
 		return
 	}
-	fmt.Fprintf(stderr, "\nA newer Omni CLI is available: %s -> %s\n", displayVersion(u.version), displayVersion(outcome.result.LatestVersion))
-	if u.homebrew {
-		fmt.Fprintf(stderr, "To upgrade, run: %s\n", outcome.result.Upgrade.Homebrew)
-	} else {
-		fmt.Fprintf(stderr, "To upgrade, run: %s\n", outcome.result.Upgrade.Other)
+	// Claim before printing: the claim is what makes concurrent commands
+	// announce a release once between them.
+	if !u.checker.ClaimNotification(outcome.result) {
+		return
 	}
+	fmt.Fprintf(stderr, "\nA newer Omni CLI is available: %s -> %s\n", displayVersion(u.version), displayVersion(outcome.result.LatestVersion))
+	fmt.Fprintf(stderr, "To upgrade, %s\n", upgradeHint(outcome.result.Upgrade, u.homebrew))
 	fmt.Fprintf(stderr, "%s\n", outcome.result.ReleaseURL)
-	_ = u.checker.MarkNotified(outcome.result.LatestVersion)
 }
 
-func automaticUpdatesEnabled(currentVersion string, args []string, stdout, stderr *os.File) bool {
+// upgradeHint phrases the advice for the platform it's given on. Homebrew is
+// empty where Homebrew isn't an option (Windows), and there "other" is already
+// a sentence — install.sh refuses to run there — rather than a command to run.
+func upgradeHint(u updatecheck.UpgradeInstructions, homebrew bool) string {
+	if homebrew && u.Homebrew != "" {
+		return "run: " + u.Homebrew
+	}
+	if u.Homebrew == "" {
+		return u.Other
+	}
+	return "run: " + u.Other
+}
+
+func automaticUpdatesEnabled(currentVersion string, cmd *cobra.Command, stdout, stderr *os.File) bool {
 	isTTY := term.IsTerminal(int(stdout.Fd())) && term.IsTerminal(int(stderr.Fd()))
-	format := config.ResolveOutputFormat(requestedOutputFormat(args), true)
-	return automaticUpdatesAllowed(currentVersion, args, isTTY && format == config.FormatHuman, os.Getenv)
+	return automaticUpdatesAllowed(currentVersion, cmd, interactiveHumanOutput(cmd, isTTY), os.Getenv)
 }
 
-func automaticUpdatesAllowed(currentVersion string, args []string, interactiveHuman bool, getenv func(string) string) bool {
-	if len(args) == 0 || !updatecheck.IsReleaseVersion(currentVersion) || getenv("OMNI_NO_UPDATE_NOTIFIER") != "" || getenv("CI") != "" || !interactiveHuman {
+// interactiveHumanOutput reports whether this invocation is a human sitting at
+// a terminal reading human-formatted output — the only audience a notice on
+// stderr is meant for. The format comes from the parsed flag, so every spelling
+// cobra accepts (-o json, -ojson, --format=json, --FORMAT json) is honoured.
+func interactiveHumanOutput(cmd *cobra.Command, isTTY bool) bool {
+	if !isTTY || cmd == nil {
 		return false
 	}
-	for _, arg := range args {
-		if arg == "--help" || arg == "-h" || arg == "--version" {
-			return false
-		}
+	formatFlag, _ := cmd.Flags().GetString("format")
+	return config.ResolveOutputFormat(formatFlag, isTTY) == config.FormatHuman
+}
+
+func automaticUpdatesAllowed(currentVersion string, cmd *cobra.Command, interactiveHuman bool, getenv func(string) string) bool {
+	if cmd == nil || !interactiveHuman || !updatecheck.IsReleaseVersion(currentVersion) ||
+		getenv("OMNI_NO_UPDATE_NOTIFIER") != "" || getenv("CI") != "" {
+		return false
 	}
-	for i := 0; i+1 < len(args); i++ {
-		if args[i] == "update" && args[i+1] == "check" {
-			return false
-		}
+	// `omni help ...` prints a command's usage, not its output; --help and
+	// --version never reach this hook, cobra answers them first.
+	if cmd.Name() == "help" {
+		return false
+	}
+	// The explicit `omni update check` does its own reporting, and shell
+	// completion output is consumed by the shell. Match on the top-level
+	// group so an API command that happens to be named "update" (say
+	// `omni dashboards update`) still gets a notice.
+	switch topLevelCommand(cmd).Name() {
+	case "update", "completion":
+		return false
 	}
 	return true
 }
 
-func requestedOutputFormat(args []string) string {
-	for i, arg := range args {
-		if strings.HasPrefix(arg, "--format=") {
-			return strings.TrimPrefix(arg, "--format=")
-		}
-		if (arg == "--format" || arg == "-o") && i+1 < len(args) {
-			return args[i+1]
-		}
+// topLevelCommand returns cmd's ancestor directly below the root, or cmd
+// itself when it is the root or one of the root's own children.
+func topLevelCommand(cmd *cobra.Command) *cobra.Command {
+	for cmd.Parent() != nil && cmd.Parent().Parent() != nil {
+		cmd = cmd.Parent()
 	}
-	return ""
+	return cmd
 }
 
 func isHomebrewInstall() bool {

--- a/cmd/omni/update_notice.go
+++ b/cmd/omni/update_notice.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/exploreomni/omni-cli/internal/config"
+	"github.com/exploreomni/omni-cli/internal/openapi"
 	"github.com/exploreomni/omni-cli/internal/updatecheck"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -26,14 +27,16 @@ type updateOutcome struct {
 }
 
 type automaticUpdate struct {
-	cancel   context.CancelFunc
-	result   <-chan updateOutcome
-	checker  automaticReleaseChecker
-	enabled  bool
-	version  string
-	homebrew bool
-	now      func() time.Time
+	cancel     context.CancelFunc
+	result     <-chan updateOutcome
+	checker    automaticReleaseChecker
+	enabled    bool
+	version    string
+	isHomebrew func() bool
+	now        func() time.Time
 }
+
+const machineOutputAnnotation = "omni.machine-output"
 
 // startAutomaticUpdate begins a background check alongside the command the user
 // asked for. It runs from the root's PersistentPreRunE, so cmd is the command
@@ -51,7 +54,7 @@ func startAutomaticUpdate(checker automaticReleaseChecker, currentVersion string
 	}()
 	return automaticUpdate{
 		cancel: cancel, result: result, checker: checker, enabled: true,
-		version: currentVersion, homebrew: isHomebrewInstall(), now: time.Now,
+		version: currentVersion, isHomebrew: isHomebrewInstall, now: time.Now,
 	}
 }
 
@@ -60,12 +63,21 @@ func (u automaticUpdate) finish(success bool, stderr io.Writer) {
 		return
 	}
 	u.cancel()
-	outcome := <-u.result
-	if !success || outcome.err != nil || !outcome.result.UpdateAvailable {
+	if !success {
+		return
+	}
+	var outcome updateOutcome
+	select {
+	case outcome = <-u.result:
+	default:
+		return
+	}
+	if outcome.err != nil || !outcome.result.UpdateAvailable {
 		return
 	}
 
-	if u.homebrew && recentHomebrewRelease(outcome.result, u.now()) {
+	homebrew := u.isHomebrew != nil && u.isHomebrew()
+	if homebrew && recentHomebrewRelease(outcome.result, u.now()) {
 		return
 	}
 	// Claim before printing: the claim is what makes concurrent commands
@@ -74,7 +86,7 @@ func (u automaticUpdate) finish(success bool, stderr io.Writer) {
 		return
 	}
 	fmt.Fprintf(stderr, "\nA newer Omni CLI is available: %s -> %s\n", displayVersion(u.version), displayVersion(outcome.result.LatestVersion))
-	fmt.Fprintf(stderr, "To upgrade, %s\n", upgradeHint(outcome.result.Upgrade, u.homebrew))
+	fmt.Fprintf(stderr, "To upgrade, %s\n", upgradeHint(outcome.result.Upgrade, homebrew))
 	fmt.Fprintf(stderr, "%s\n", outcome.result.ReleaseURL)
 }
 
@@ -101,11 +113,15 @@ func automaticUpdatesEnabled(currentVersion string, cmd *cobra.Command, stdout, 
 // stderr is meant for. The format comes from the parsed flag, so every spelling
 // cobra accepts (-o json, -ojson, --format=json, --FORMAT json) is honoured.
 func interactiveHumanOutput(cmd *cobra.Command, isTTY bool) bool {
-	if !isTTY || cmd == nil {
+	if !isTTY || cmd == nil || commandUsesMachineOutput(cmd) {
 		return false
 	}
 	formatFlag, _ := cmd.Flags().GetString("format")
 	return config.ResolveOutputFormat(formatFlag, isTTY) == config.FormatHuman
+}
+
+func commandUsesMachineOutput(cmd *cobra.Command) bool {
+	return cmd.Annotations[machineOutputAnnotation] == "true" || openapi.IsSchemaRequest(cmd)
 }
 
 func automaticUpdatesAllowed(currentVersion string, cmd *cobra.Command, interactiveHuman bool, getenv func(string) string) bool {

--- a/cmd/omni/update_notice_test.go
+++ b/cmd/omni/update_notice_test.go
@@ -8,27 +8,64 @@ import (
 	"testing"
 	"time"
 
+	"github.com/exploreomni/omni-cli/internal/openapi"
 	"github.com/exploreomni/omni-cli/internal/updatecheck"
+	"github.com/spf13/cobra"
 )
 
 type fakeAutomaticChecker struct {
-	result          updatecheck.Result
-	err             error
-	notificationDue bool
-	marked          string
+	result   updatecheck.Result
+	err      error
+	claim    bool
+	claimed  string
+	checks   int
+	claimAsk int
 }
 
-func (f *fakeAutomaticChecker) Check(context.Context, string, bool) (updatecheck.Result, error) {
+func (f *fakeAutomaticChecker) CheckAutomatic(context.Context, string) (updatecheck.Result, error) {
+	f.checks++
 	return f.result, f.err
 }
-func (f *fakeAutomaticChecker) NotificationDue(updatecheck.Result) bool { return f.notificationDue }
-func (f *fakeAutomaticChecker) MarkNotified(version string) error {
-	f.marked = version
-	return nil
+
+func (f *fakeAutomaticChecker) ClaimNotification(r updatecheck.Result) bool {
+	f.claimAsk++
+	if !f.claim {
+		return false
+	}
+	f.claimed = r.LatestVersion
+	return true
 }
 
 func getenv(values map[string]string) func(string) string {
 	return func(key string) string { return values[key] }
+}
+
+// resolveCommand runs args through a root shaped like the real one and returns
+// the command cobra resolved, which is what the update hook is handed.
+func resolveCommand(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "omni", SilenceUsage: true, SilenceErrors: true}
+	addGlobalFlags(root)
+	root.SetGlobalNormalizationFunc(openapi.NormalizeFlagName)
+
+	models := &cobra.Command{Use: "models"}
+	models.AddCommand(&cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }})
+	root.AddCommand(models)
+	root.AddCommand(&cobra.Command{Use: "agent-help", RunE: func(*cobra.Command, []string) error { return nil }})
+	addUpdateCommand(root, &fakeReleaseChecker{}, "v1.2.0")
+
+	var resolved *cobra.Command
+	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		resolved = cmd
+		return nil
+	}
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("executing %v: %v", args, err)
+	}
+	return resolved
 }
 
 func TestAutomaticUpdatesAllowed(t *testing.T) {
@@ -42,41 +79,72 @@ func TestAutomaticUpdatesAllowed(t *testing.T) {
 	}{
 		{"interactive release", "v1.2.0", []string{"models", "list"}, true, nil, true},
 		{"development build", "dev", []string{"models", "list"}, true, nil, false},
-		{"bare help", "v1.2.0", nil, true, nil, false},
 		{"redirected", "v1.2.0", []string{"models", "list"}, false, nil, false},
-		{"JSON output", "v1.2.0", []string{"models", "list", "--format", "json"}, false, nil, false},
 		{"CI", "v1.2.0", []string{"models", "list"}, true, map[string]string{"CI": "true"}, false},
 		{"disabled", "v1.2.0", []string{"models", "list"}, true, map[string]string{"OMNI_NO_UPDATE_NOTIFIER": "1"}, false},
-		{"help", "v1.2.0", []string{"models", "--help"}, true, nil, false},
-		{"version", "v1.2.0", []string{"--version"}, true, nil, false},
-		{"explicit check", "v1.2.0", []string{"--format", "human", "update", "check"}, true, nil, false},
+		{"explicit check", "v1.2.0", []string{"update", "check", "--format", "human"}, true, nil, false},
+		{"help command", "v1.2.0", []string{"help", "models"}, true, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := automaticUpdatesAllowed(tt.version, tt.args, tt.human, getenv(tt.env)); got != tt.want {
+			cmd := resolveCommand(t, tt.args...)
+			if got := automaticUpdatesAllowed(tt.version, cmd, tt.human, getenv(tt.env)); got != tt.want {
 				t.Fatalf("automaticUpdatesAllowed() = %v, want %v", got, tt.want)
 			}
 		})
 	}
+
+	if automaticUpdatesAllowed("v1.2.0", nil, true, getenv(nil)) {
+		t.Fatal("an unresolved command should never start a check")
+	}
 }
 
-func TestRequestedOutputFormat(t *testing.T) {
-	for _, tt := range []struct {
+// TestInteractiveHumanOutputHonoursEveryFormatSpelling covers the flag forms a
+// raw os.Args scan used to miss: -ojson and the normalized --FORMAT.
+func TestInteractiveHumanOutputHonoursEveryFormatSpelling(t *testing.T) {
+	t.Setenv("OMNI_OUTPUT_FORMAT", "auto")
+	tests := []struct {
 		args []string
-		want string
+		want bool
 	}{
-		{[]string{"models", "list", "--format", "json"}, "json"},
-		{[]string{"--format=human", "models", "list"}, "human"},
-		{[]string{"models", "list", "-o", "auto"}, "auto"},
+		{[]string{"models", "list"}, true},
+		{[]string{"models", "list", "--format", "human"}, true},
+		{[]string{"models", "list", "--format", "json"}, false},
+		{[]string{"models", "list", "--format=json"}, false},
+		{[]string{"models", "list", "-o", "json"}, false},
+		{[]string{"models", "list", "-ojson"}, false},
+		{[]string{"models", "list", "--FORMAT", "json"}, false},
+		{[]string{"models", "list", "--Format=json"}, false},
+	}
+	for _, tt := range tests {
+		cmd := resolveCommand(t, tt.args...)
+		if got := interactiveHumanOutput(cmd, true); got != tt.want {
+			t.Errorf("interactiveHumanOutput(%v) = %v, want %v", tt.args, got, tt.want)
+		}
+		if interactiveHumanOutput(cmd, false) {
+			t.Errorf("interactiveHumanOutput(%v, notTTY) = true", tt.args)
+		}
+	}
+}
+
+// TestUpdateCommandNeverStartsAnAutomaticCheck pins the case where the format
+// flag sits between the command words: `omni update --format human check`.
+func TestUpdateCommandNeverStartsAnAutomaticCheck(t *testing.T) {
+	t.Setenv("OMNI_OUTPUT_FORMAT", "auto")
+	for _, args := range [][]string{
+		{"update", "check"},
+		{"update", "--format", "human", "check"},
+		{"update", "check", "--format", "human"},
 	} {
-		if got := requestedOutputFormat(tt.args); got != tt.want {
-			t.Errorf("requestedOutputFormat(%v) = %q, want %q", tt.args, got, tt.want)
+		cmd := resolveCommand(t, args...)
+		if automaticUpdatesAllowed("v1.2.0", cmd, true, getenv(nil)) {
+			t.Errorf("automaticUpdatesAllowed(%v) = true", args)
 		}
 	}
 }
 
 func TestAutomaticUpdateNotice(t *testing.T) {
-	checker := &fakeAutomaticChecker{notificationDue: true}
+	checker := &fakeAutomaticChecker{claim: true}
 	result := updatecheck.Result{
 		UpdateAvailable: true,
 		LatestVersion:   "v1.3.0",
@@ -91,31 +159,58 @@ func TestAutomaticUpdateNotice(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 	u.finish(true, &stderr)
-	if got := stderr.String(); !strings.Contains(got, "v1.2.0 -> v1.3.0") || !strings.Contains(got, "install command") {
+	if got := stderr.String(); !strings.Contains(got, "v1.2.0 -> v1.3.0") || !strings.Contains(got, "run: install command") {
 		t.Fatalf("stderr = %q", got)
 	}
-	if checker.marked != "v1.3.0" {
-		t.Fatalf("marked = %q", checker.marked)
+	if checker.claimed != "v1.3.0" {
+		t.Fatalf("claimed = %q", checker.claimed)
+	}
+}
+
+// A notice is printed only by the process that won the claim.
+func TestAutomaticUpdateNoticeRequiresAClaim(t *testing.T) {
+	checker := &fakeAutomaticChecker{claim: false}
+	ch := make(chan updateOutcome, 1)
+	ch <- updateOutcome{result: updatecheck.Result{UpdateAvailable: true, LatestVersion: "v1.3.0"}}
+	u := automaticUpdate{cancel: func() {}, result: ch, checker: checker, enabled: true, version: "v1.2.0", now: time.Now}
+	var stderr bytes.Buffer
+	u.finish(true, &stderr)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
 	}
 }
 
 func TestAutomaticUpdateIsSilentOnFailure(t *testing.T) {
-	checker := &fakeAutomaticChecker{notificationDue: true}
-	for _, outcome := range []updateOutcome{{err: errors.New("offline")}, {result: updatecheck.Result{UpdateAvailable: true}}} {
-		ch := make(chan updateOutcome, 1)
-		ch <- outcome
-		u := automaticUpdate{cancel: func() {}, result: ch, checker: checker, enabled: true, version: "v1.2.0", now: time.Now}
-		var stderr bytes.Buffer
-		u.finish(false, &stderr)
-		if stderr.Len() != 0 {
-			t.Fatalf("stderr = %q", stderr.String())
-		}
+	checker := &fakeAutomaticChecker{claim: true}
+	cases := []struct {
+		name    string
+		outcome updateOutcome
+		success bool
+	}{
+		{"failed command", updateOutcome{result: updatecheck.Result{UpdateAvailable: true, LatestVersion: "v1.3.0"}}, false},
+		{"check error", updateOutcome{err: errors.New("offline")}, true},
+		{"already current", updateOutcome{result: updatecheck.Result{UpdateAvailable: false}}, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan updateOutcome, 1)
+			ch <- tt.outcome
+			u := automaticUpdate{cancel: func() {}, result: ch, checker: checker, enabled: true, version: "v1.2.0", now: time.Now}
+			var stderr bytes.Buffer
+			u.finish(tt.success, &stderr)
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q", stderr.String())
+			}
+			if checker.claimed != "" {
+				t.Fatalf("claimed = %q, want no claim", checker.claimed)
+			}
+		})
 	}
 }
 
 func TestRecentHomebrewReleaseIsSuppressed(t *testing.T) {
 	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
-	checker := &fakeAutomaticChecker{notificationDue: true}
+	checker := &fakeAutomaticChecker{claim: true}
 	ch := make(chan updateOutcome, 1)
 	ch <- updateOutcome{result: updatecheck.Result{
 		UpdateAvailable: true, LatestVersion: "v1.3.0",
@@ -127,7 +222,25 @@ func TestRecentHomebrewReleaseIsSuppressed(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 	u.finish(true, &stderr)
-	if stderr.Len() != 0 || checker.marked != "" {
+	if stderr.Len() != 0 || checker.claimed != "" {
 		t.Fatalf("recent Homebrew release was announced: %q", stderr.String())
+	}
+}
+
+func TestUpgradeHint(t *testing.T) {
+	unix := updatecheck.UpgradeInstructions{Homebrew: "brew upgrade omni", Other: "curl ... | sh"}
+	if got := upgradeHint(unix, true); got != "run: brew upgrade omni" {
+		t.Errorf("homebrew hint = %q", got)
+	}
+	if got := upgradeHint(unix, false); got != "run: curl ... | sh" {
+		t.Errorf("unix hint = %q", got)
+	}
+	// Windows has no Homebrew and no install.sh, so the advice is prose.
+	windows := updatecheck.UpgradeInstructions{Other: "download the latest release from https://example.test/latest"}
+	if got := upgradeHint(windows, false); got != windows.Other {
+		t.Errorf("windows hint = %q", got)
+	}
+	if got := upgradeHint(windows, true); got != windows.Other {
+		t.Errorf("windows homebrew hint = %q", got)
 	}
 }

--- a/cmd/omni/update_notice_test.go
+++ b/cmd/omni/update_notice_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/exploreomni/omni-cli/internal/updatecheck"
+)
+
+type fakeAutomaticChecker struct {
+	result          updatecheck.Result
+	err             error
+	notificationDue bool
+	marked          string
+}
+
+func (f *fakeAutomaticChecker) Check(context.Context, string, bool) (updatecheck.Result, error) {
+	return f.result, f.err
+}
+func (f *fakeAutomaticChecker) NotificationDue(updatecheck.Result) bool { return f.notificationDue }
+func (f *fakeAutomaticChecker) MarkNotified(version string) error {
+	f.marked = version
+	return nil
+}
+
+func getenv(values map[string]string) func(string) string {
+	return func(key string) string { return values[key] }
+}
+
+func TestAutomaticUpdatesAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		args    []string
+		human   bool
+		env     map[string]string
+		want    bool
+	}{
+		{"interactive release", "v1.2.0", []string{"models", "list"}, true, nil, true},
+		{"development build", "dev", []string{"models", "list"}, true, nil, false},
+		{"bare help", "v1.2.0", nil, true, nil, false},
+		{"redirected", "v1.2.0", []string{"models", "list"}, false, nil, false},
+		{"JSON output", "v1.2.0", []string{"models", "list", "--format", "json"}, false, nil, false},
+		{"CI", "v1.2.0", []string{"models", "list"}, true, map[string]string{"CI": "true"}, false},
+		{"disabled", "v1.2.0", []string{"models", "list"}, true, map[string]string{"OMNI_NO_UPDATE_NOTIFIER": "1"}, false},
+		{"help", "v1.2.0", []string{"models", "--help"}, true, nil, false},
+		{"version", "v1.2.0", []string{"--version"}, true, nil, false},
+		{"explicit check", "v1.2.0", []string{"--format", "human", "update", "check"}, true, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := automaticUpdatesAllowed(tt.version, tt.args, tt.human, getenv(tt.env)); got != tt.want {
+				t.Fatalf("automaticUpdatesAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestedOutputFormat(t *testing.T) {
+	for _, tt := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"models", "list", "--format", "json"}, "json"},
+		{[]string{"--format=human", "models", "list"}, "human"},
+		{[]string{"models", "list", "-o", "auto"}, "auto"},
+	} {
+		if got := requestedOutputFormat(tt.args); got != tt.want {
+			t.Errorf("requestedOutputFormat(%v) = %q, want %q", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestAutomaticUpdateNotice(t *testing.T) {
+	checker := &fakeAutomaticChecker{notificationDue: true}
+	result := updatecheck.Result{
+		UpdateAvailable: true,
+		LatestVersion:   "v1.3.0",
+		ReleaseURL:      "https://example.test/v1.3.0",
+		Upgrade:         updatecheck.UpgradeInstructions{Homebrew: "brew upgrade omni", Other: "install command"},
+	}
+	ch := make(chan updateOutcome, 1)
+	ch <- updateOutcome{result: result}
+	u := automaticUpdate{
+		cancel: func() {}, result: ch, checker: checker, enabled: true,
+		version: "v1.2.0", now: time.Now,
+	}
+	var stderr bytes.Buffer
+	u.finish(true, &stderr)
+	if got := stderr.String(); !strings.Contains(got, "v1.2.0 -> v1.3.0") || !strings.Contains(got, "install command") {
+		t.Fatalf("stderr = %q", got)
+	}
+	if checker.marked != "v1.3.0" {
+		t.Fatalf("marked = %q", checker.marked)
+	}
+}
+
+func TestAutomaticUpdateIsSilentOnFailure(t *testing.T) {
+	checker := &fakeAutomaticChecker{notificationDue: true}
+	for _, outcome := range []updateOutcome{{err: errors.New("offline")}, {result: updatecheck.Result{UpdateAvailable: true}}} {
+		ch := make(chan updateOutcome, 1)
+		ch <- outcome
+		u := automaticUpdate{cancel: func() {}, result: ch, checker: checker, enabled: true, version: "v1.2.0", now: time.Now}
+		var stderr bytes.Buffer
+		u.finish(false, &stderr)
+		if stderr.Len() != 0 {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+	}
+}
+
+func TestRecentHomebrewReleaseIsSuppressed(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	checker := &fakeAutomaticChecker{notificationDue: true}
+	ch := make(chan updateOutcome, 1)
+	ch <- updateOutcome{result: updatecheck.Result{
+		UpdateAvailable: true, LatestVersion: "v1.3.0",
+		PublishedAt: now.Add(-time.Hour),
+	}}
+	u := automaticUpdate{
+		cancel: func() {}, result: ch, checker: checker, enabled: true,
+		version: "v1.2.0", homebrew: true, now: func() time.Time { return now },
+	}
+	var stderr bytes.Buffer
+	u.finish(true, &stderr)
+	if stderr.Len() != 0 || checker.marked != "" {
+		t.Fatalf("recent Homebrew release was announced: %q", stderr.String())
+	}
+}

--- a/cmd/omni/update_notice_test.go
+++ b/cmd/omni/update_notice_test.go
@@ -49,8 +49,15 @@ func resolveCommand(t *testing.T, args ...string) *cobra.Command {
 	root.SetGlobalNormalizationFunc(openapi.NormalizeFlagName)
 
 	models := &cobra.Command{Use: "models"}
-	models.AddCommand(&cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }})
+	list := &cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }}
+	openapi.RegisterSchemaFlag(list, func(*cobra.Command, openapi.SchemaFlags) error { return nil })
+	models.AddCommand(list)
 	root.AddCommand(models)
+	configCmd := &cobra.Command{Use: "config"}
+	show := configShowCmd()
+	show.RunE = func(*cobra.Command, []string) error { return nil }
+	configCmd.AddCommand(show)
+	root.AddCommand(configCmd)
 	root.AddCommand(&cobra.Command{Use: "agent-help", RunE: func(*cobra.Command, []string) error { return nil }})
 	addUpdateCommand(root, &fakeReleaseChecker{}, "v1.2.0")
 
@@ -115,6 +122,10 @@ func TestInteractiveHumanOutputHonoursEveryFormatSpelling(t *testing.T) {
 		{[]string{"models", "list", "-ojson"}, false},
 		{[]string{"models", "list", "--FORMAT", "json"}, false},
 		{[]string{"models", "list", "--Format=json"}, false},
+		{[]string{"models", "list", "--schema"}, false},
+		{[]string{"models", "list", "--schema", "--format", "human"}, false},
+		{[]string{"config", "show"}, false},
+		{[]string{"config", "show", "--format", "human"}, false},
 	}
 	for _, tt := range tests {
 		cmd := resolveCommand(t, tt.args...)
@@ -180,6 +191,49 @@ func TestAutomaticUpdateNoticeRequiresAClaim(t *testing.T) {
 	}
 }
 
+func TestAutomaticUpdateFinishDoesNotWaitForTheCheck(t *testing.T) {
+	cancelled := make(chan struct{})
+	result := make(chan updateOutcome, 1)
+	u := automaticUpdate{
+		cancel: func() { close(cancelled) }, result: result,
+		checker: &fakeAutomaticChecker{}, enabled: true, version: "v1.2.0", now: time.Now,
+	}
+	done := make(chan struct{})
+	go func() {
+		u.finish(true, &bytes.Buffer{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		// Let a blocking implementation exit before failing the test.
+		result <- updateOutcome{}
+		<-done
+		t.Fatal("finish waited for the best-effort update check")
+	}
+	select {
+	case <-cancelled:
+	default:
+		t.Fatal("finish did not cancel the update check")
+	}
+}
+
+func TestHomebrewDetectionIsLazy(t *testing.T) {
+	checker := &fakeAutomaticChecker{claim: true}
+	ch := make(chan updateOutcome, 1)
+	ch <- updateOutcome{result: updatecheck.Result{UpdateAvailable: false}}
+	called := false
+	u := automaticUpdate{
+		cancel: func() {}, result: ch, checker: checker, enabled: true,
+		version: "v1.2.0", isHomebrew: func() bool { called = true; return true }, now: time.Now,
+	}
+	u.finish(true, &bytes.Buffer{})
+	if called {
+		t.Fatal("Homebrew detection ran without a ready update notice")
+	}
+}
+
 func TestAutomaticUpdateIsSilentOnFailure(t *testing.T) {
 	checker := &fakeAutomaticChecker{claim: true}
 	cases := []struct {
@@ -218,7 +272,7 @@ func TestRecentHomebrewReleaseIsSuppressed(t *testing.T) {
 	}}
 	u := automaticUpdate{
 		cancel: func() {}, result: ch, checker: checker, enabled: true,
-		version: "v1.2.0", homebrew: true, now: func() time.Time { return now },
+		version: "v1.2.0", isHomebrew: func() bool { return true }, now: func() time.Time { return now },
 	}
 	var stderr bytes.Buffer
 	u.finish(true, &stderr)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.6
 require (
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/gofrs/flock v0.13.0
 	github.com/pb33f/libopenapi v0.34.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/openapi/schema.go
+++ b/internal/openapi/schema.go
@@ -17,6 +17,11 @@ import (
 // recursing.
 const maxSchemaDepth = 8
 
+// schemaFlagAnnotation records the actual name of a command's schema-discovery
+// flag. The preferred --schema name can be occupied by an API parameter, in
+// which case RegisterSchemaFlag chooses a collision-free fallback.
+const schemaFlagAnnotation = "omni.openapi.schema-flag"
+
 // depthNote replaces a schema node that sits past the expansion budget. Both the
 // spec describer and the depth limiter for hand-written commands' static
 // documents emit it, so truncation reads identically everywhere.
@@ -112,6 +117,10 @@ func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command, SchemaFlag
 		Field:  freeFlagName(cmd, "field", "schema-field"),
 		Depth:  freeFlagName(cmd, "depth", "schema-depth"),
 	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[schemaFlagAnnotation] = names.Schema
 
 	cmd.Flags().Bool(names.Schema, false,
 		renameNote("print this command's args, flags, request body and response shape, then exit (no API call)", "schema", names.Schema))
@@ -158,6 +167,17 @@ func RegisterSchemaFlag(cmd *cobra.Command, emit func(*cobra.Command, SchemaFlag
 	}
 
 	return names
+}
+
+// IsSchemaRequest reports whether cmd is handling its local, JSON-only schema
+// discovery mode. RegisterSchemaFlag records the resolved flag name so this
+// remains correct when an API parameter forces --schema to --schema-doc.
+func IsSchemaRequest(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	name, ok := cmd.Annotations[schemaFlagAnnotation]
+	return ok && schemaRequested(cmd, name)
 }
 
 // freeFlagName returns preferred if no flag owns it, otherwise fallback, and

--- a/internal/openapi/schema_test.go
+++ b/internal/openapi/schema_test.go
@@ -815,6 +815,19 @@ func TestSchema_ParamNameCollisionFallsBackToPrefixedFlags(t *testing.T) {
 	}
 }
 
+func TestIsSchemaRequestTracksTheResolvedFlagName(t *testing.T) {
+	sub := subcommand(t, collidingParamsSpec, "list")
+	if IsSchemaRequest(sub) {
+		t.Fatal("schema mode reported before its flag was set")
+	}
+	if err := sub.Flags().Set("schema-doc", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if !IsSchemaRequest(sub) {
+		t.Fatal("renamed --schema-doc flag was not recognized as schema mode")
+	}
+}
+
 // The renamed refinement flags must work, and the renaming must be visible in
 // --help so a reader can find them.
 func TestSchema_RenamedRefinementFlagsWork(t *testing.T) {

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -516,4 +516,3 @@ func humanizeKey(s string) string {
 	}
 	return strings.Join(fields, " ")
 }
-

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -4,12 +4,15 @@ package updatecheck
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -17,7 +20,20 @@ import (
 
 const (
 	defaultEndpoint = "https://api.github.com/repos/exploreomni/cli/releases/latest"
-	checkInterval   = 24 * time.Hour
+	releasesPage    = "https://github.com/exploreomni/cli/releases/latest"
+	installCommand  = "curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh"
+
+	// checkInterval is the throttle between successful checks, failureBackoff
+	// the much shorter one applied after a failed or abandoned attempt, and
+	// leaseDuration the window in which the process that claimed a check is
+	// expected to finish it (comfortably longer than the HTTP timeout).
+	checkInterval  = 24 * time.Hour
+	failureBackoff = 15 * time.Minute
+	leaseDuration  = 30 * time.Second
+
+	// defaultLockStale is how long a lock file is honoured before it is
+	// treated as abandoned by a process that died while holding it.
+	defaultLockStale = 30 * time.Second
 )
 
 // Release is the subset of a GitHub release used by the updater.
@@ -28,8 +44,9 @@ type Release struct {
 }
 
 // UpgradeInstructions lists supported ways to install the newest release.
+// Homebrew is empty on platforms Homebrew doesn't serve.
 type UpgradeInstructions struct {
-	Homebrew string `json:"homebrew"`
+	Homebrew string `json:"homebrew,omitempty"`
 	Other    string `json:"other"`
 }
 
@@ -43,8 +60,17 @@ type Result struct {
 	PublishedAt     time.Time           `json:"-"`
 }
 
+// state is the durable scheduler behind the automatic check. NextCheckAt alone
+// decides whether a check may run, and it is written *before* any networking,
+// so a cancelled or killed process still leaves a throttle behind.
+// LeaseID/LeaseUntil name the process currently allowed to record a result:
+// the ID stops a slow owner from clobbering state claimed by a newer one, and
+// the deadline lets a crashed owner's claim be reclaimed.
 type state struct {
-	CheckedAt       time.Time `json:"checkedAt"`
+	CheckedAt       time.Time `json:"checkedAt,omitempty"`
+	NextCheckAt     time.Time `json:"nextCheckAt,omitempty"`
+	LeaseID         string    `json:"leaseId,omitempty"`
+	LeaseUntil      time.Time `json:"leaseUntil,omitempty"`
 	LatestRelease   Release   `json:"latestRelease"`
 	NotifiedVersion string    `json:"notifiedVersion,omitempty"`
 	NotifiedAt      time.Time `json:"notifiedAt,omitempty"`
@@ -56,6 +82,11 @@ type Checker struct {
 	Endpoint  string
 	StatePath string
 	Now       func() time.Time
+
+	// lockStale overrides defaultLockStale in tests. It is compared against
+	// the lock file's modification time, so it is measured on the real clock
+	// rather than on Now.
+	lockStale time.Duration
 }
 
 // New returns a checker suitable for CLI use.
@@ -78,45 +109,195 @@ func DefaultStatePath() string {
 	return filepath.Join(dir, "omni-cli", "update.json")
 }
 
-// Check returns the newest stable release. Unless force is true, a result
-// fetched during the previous 24 hours is reused.
-func (c *Checker) Check(ctx context.Context, currentVersion string, force bool) (Result, error) {
-	now := c.now()
-	s, _ := c.readState()
-	release := s.LatestRelease
-	if force || s.CheckedAt.IsZero() || now.Sub(s.CheckedAt) >= checkInterval {
-		var err error
-		release, err = c.fetch(ctx, currentVersion)
-		if err != nil {
-			return Result{}, err
-		}
-		s.CheckedAt = now
-		s.LatestRelease = release
-		if err := c.writeState(s); err != nil {
-			return Result{}, err
-		}
+// Check performs an explicit, user-requested check. It always contacts the
+// release endpoint and returns what it fetched; caching is best-effort, so a
+// broken or read-only cache never turns a successful check into a failure.
+func (c *Checker) Check(ctx context.Context, currentVersion string) (Result, error) {
+	release, err := c.fetch(ctx, currentVersion)
+	if err != nil {
+		return Result{}, err
 	}
-
+	c.recordCheck(release)
 	return result(currentVersion, release), nil
 }
 
-// NotificationDue reports whether this release has not been announced in the
-// previous 24 hours.
-func (c *Checker) NotificationDue(r Result) bool {
+// CheckAutomatic is the background check run alongside an interactive command.
+// It makes at most one request per checkInterval across every process sharing
+// the state file, and falls back to the cached release whenever a check isn't
+// due, the state is claimed elsewhere, or the request fails.
+func (c *Checker) CheckAutomatic(ctx context.Context, currentVersion string) (Result, error) {
+	cached, _ := c.readState()
+	lease, claimed := c.claimCheck()
+	if !claimed {
+		return result(currentVersion, cached.LatestRelease), nil
+	}
+
+	release, err := c.fetch(ctx, currentVersion)
+	c.finishCheck(lease, release, err)
+	if err != nil {
+		if validVersion(cached.LatestRelease.Version) {
+			// A stale but valid answer is still worth reporting; the throttle
+			// claimCheck wrote keeps the failed attempt from retrying.
+			return result(currentVersion, cached.LatestRelease), nil
+		}
+		return Result{}, err
+	}
+	return result(currentVersion, release), nil
+}
+
+// ClaimNotification atomically decides whether this process should print a
+// notice for r, recording the claim before it returns true. Deciding and
+// recording under one lock is what stops concurrent commands from each
+// announcing the same release.
+func (c *Checker) ClaimNotification(r Result) bool {
 	if !r.UpdateAvailable {
 		return false
 	}
+	unlock, ok := c.tryLock()
+	if !ok {
+		return false
+	}
+	defer unlock()
+
 	s, _ := c.readState()
-	return s.NotifiedVersion != r.LatestVersion || s.NotifiedAt.IsZero() || c.now().Sub(s.NotifiedAt) >= checkInterval
+	now := c.now()
+	if s.NotifiedVersion == r.LatestVersion && !s.NotifiedAt.IsZero() && now.Sub(s.NotifiedAt) < checkInterval {
+		return false
+	}
+	s.NotifiedVersion = r.LatestVersion
+	s.NotifiedAt = now
+	return c.writeState(s) == nil
 }
 
-// MarkNotified records that a notice was displayed. Notification failures are
-// deliberately allowed to be ignored by callers.
-func (c *Checker) MarkNotified(version string) error {
+// claimCheck reports whether this process may perform the next check, taking
+// the lease that makes it the only one allowed to record the outcome.
+func (c *Checker) claimCheck() (string, bool) {
+	unlock, ok := c.tryLock()
+	if !ok {
+		return "", false
+	}
+	defer unlock()
+
 	s, _ := c.readState()
-	s.NotifiedVersion = version
-	s.NotifiedAt = c.now()
-	return c.writeState(s)
+	now := c.now()
+	if !s.NextCheckAt.IsZero() && now.Before(s.NextCheckAt) {
+		return "", false
+	}
+	if s.LeaseID != "" && now.Before(s.LeaseUntil) {
+		return "", false
+	}
+	id, err := newLeaseID()
+	if err != nil {
+		return "", false
+	}
+	s.LeaseID = id
+	s.LeaseUntil = now.Add(leaseDuration)
+	// Written before any networking: if this process is cancelled or killed
+	// mid-request, the next invocation still waits out the short backoff
+	// instead of retrying straight away.
+	s.NextCheckAt = now.Add(failureBackoff)
+	if err := c.writeState(s); err != nil {
+		return "", false
+	}
+	return id, true
+}
+
+// finishCheck records the outcome of the check claimed under lease. A failure
+// leaves the short backoff claimCheck already wrote in place.
+func (c *Checker) finishCheck(lease string, release Release, fetchErr error) {
+	unlock, ok := c.tryLock()
+	if !ok {
+		return
+	}
+	defer unlock()
+
+	s, err := c.readState()
+	if err != nil || s.LeaseID != lease {
+		// This lease expired and another process claimed the state; its result
+		// is the newer one, so leave it alone.
+		return
+	}
+	s.LeaseID = ""
+	s.LeaseUntil = time.Time{}
+	if fetchErr == nil {
+		now := c.now()
+		s.LatestRelease = release
+		s.CheckedAt = now
+		s.NextCheckAt = now.Add(checkInterval)
+	}
+	_ = c.writeState(s)
+}
+
+// recordCheck stores an explicitly fetched release, ignoring cache failures.
+func (c *Checker) recordCheck(release Release) {
+	unlock, ok := c.tryLock()
+	if !ok {
+		return
+	}
+	defer unlock()
+
+	s, _ := c.readState()
+	now := c.now()
+	s.LatestRelease = release
+	s.CheckedAt = now
+	s.NextCheckAt = now.Add(checkInterval)
+	_ = c.writeState(s)
+}
+
+// tryLock takes the update lock without blocking, returning false when another
+// process holds it — the requested command must never wait on the updater.
+//
+// The lock is a stable, separate file: writeState replaces update.json with a
+// rename, so locking update.json itself would let a second process lock the
+// replacement while the first still held the old inode. An O_EXCL create is
+// atomic on Unix and Windows alike, which keeps this free of build-tagged
+// implementations; a lock left behind by a killed process is reclaimed once it
+// is older than lockStale.
+func (c *Checker) tryLock() (func(), bool) {
+	if c.StatePath == "" {
+		return nil, false
+	}
+	if err := os.MkdirAll(filepath.Dir(c.StatePath), 0o700); err != nil {
+		return nil, false
+	}
+	path := c.lockPath()
+	for attempt := 0; attempt < 2; attempt++ {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = f.Close()
+			return func() { _ = os.Remove(path) }, true
+		}
+		if !os.IsExist(err) {
+			return nil, false
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil || time.Since(info.ModTime()) < c.lockStaleAfter() {
+			return nil, false
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, false
+		}
+	}
+	return nil, false
+}
+
+func (c *Checker) lockPath() string {
+	return strings.TrimSuffix(c.StatePath, ".json") + ".lock"
+}
+
+func (c *Checker) lockStaleAfter() time.Duration {
+	if c.lockStale > 0 {
+		return c.lockStale
+	}
+	return defaultLockStale
+}
+
+func newLeaseID() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
 }
 
 func (c *Checker) fetch(ctx context.Context, currentVersion string) (Release, error) {
@@ -154,11 +335,18 @@ func result(current string, release Release) Result {
 		LatestVersion:   release.Version,
 		ReleaseURL:      release.URL,
 		PublishedAt:     release.PublishedAt,
-		Upgrade: UpgradeInstructions{
-			Homebrew: "brew upgrade omni",
-			Other:    "curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh",
-		},
+		Upgrade:         upgradeInstructions(runtime.GOOS),
 	}
+}
+
+// upgradeInstructions keeps the advice runnable on the platform being advised:
+// install.sh refuses to run on Windows, so Windows users are pointed at the
+// release downloads instead.
+func upgradeInstructions(goos string) UpgradeInstructions {
+	if goos == "windows" {
+		return UpgradeInstructions{Other: "download the latest release from " + releasesPage}
+	}
+	return UpgradeInstructions{Homebrew: "brew upgrade omni", Other: installCommand}
 }
 
 func (c *Checker) readState() (state, error) {

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -1,0 +1,311 @@
+// Package updatecheck discovers newer Omni CLI releases without affecting the
+// command the user actually asked to run.
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultEndpoint = "https://api.github.com/repos/exploreomni/cli/releases/latest"
+	checkInterval   = 24 * time.Hour
+)
+
+// Release is the subset of a GitHub release used by the updater.
+type Release struct {
+	Version     string    `json:"tag_name"`
+	URL         string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// UpgradeInstructions lists supported ways to install the newest release.
+type UpgradeInstructions struct {
+	Homebrew string `json:"homebrew"`
+	Other    string `json:"other"`
+}
+
+// Result is the stable, machine-readable result of an update check.
+type Result struct {
+	UpdateAvailable bool                `json:"updateAvailable"`
+	CurrentVersion  string              `json:"currentVersion"`
+	LatestVersion   string              `json:"latestVersion"`
+	ReleaseURL      string              `json:"releaseUrl"`
+	Upgrade         UpgradeInstructions `json:"upgrade"`
+	PublishedAt     time.Time           `json:"-"`
+}
+
+type state struct {
+	CheckedAt       time.Time `json:"checkedAt"`
+	LatestRelease   Release   `json:"latestRelease"`
+	NotifiedVersion string    `json:"notifiedVersion,omitempty"`
+	NotifiedAt      time.Time `json:"notifiedAt,omitempty"`
+}
+
+// Checker fetches releases and persists the throttling state.
+type Checker struct {
+	Client    *http.Client
+	Endpoint  string
+	StatePath string
+	Now       func() time.Time
+}
+
+// New returns a checker suitable for CLI use.
+func New() *Checker {
+	return &Checker{
+		Client:    &http.Client{Timeout: 2 * time.Second},
+		Endpoint:  defaultEndpoint,
+		StatePath: DefaultStatePath(),
+		Now:       time.Now,
+	}
+}
+
+// DefaultStatePath returns the per-user update-check state file.
+func DefaultStatePath() string {
+	dir, err := os.UserCacheDir()
+	if err != nil || dir == "" {
+		home, _ := os.UserHomeDir()
+		dir = filepath.Join(home, ".cache")
+	}
+	return filepath.Join(dir, "omni-cli", "update.json")
+}
+
+// Check returns the newest stable release. Unless force is true, a result
+// fetched during the previous 24 hours is reused.
+func (c *Checker) Check(ctx context.Context, currentVersion string, force bool) (Result, error) {
+	now := c.now()
+	s, _ := c.readState()
+	release := s.LatestRelease
+	if force || s.CheckedAt.IsZero() || now.Sub(s.CheckedAt) >= checkInterval {
+		var err error
+		release, err = c.fetch(ctx, currentVersion)
+		if err != nil {
+			return Result{}, err
+		}
+		s.CheckedAt = now
+		s.LatestRelease = release
+		if err := c.writeState(s); err != nil {
+			return Result{}, err
+		}
+	}
+
+	return result(currentVersion, release), nil
+}
+
+// NotificationDue reports whether this release has not been announced in the
+// previous 24 hours.
+func (c *Checker) NotificationDue(r Result) bool {
+	if !r.UpdateAvailable {
+		return false
+	}
+	s, _ := c.readState()
+	return s.NotifiedVersion != r.LatestVersion || s.NotifiedAt.IsZero() || c.now().Sub(s.NotifiedAt) >= checkInterval
+}
+
+// MarkNotified records that a notice was displayed. Notification failures are
+// deliberately allowed to be ignored by callers.
+func (c *Checker) MarkNotified(version string) error {
+	s, _ := c.readState()
+	s.NotifiedVersion = version
+	s.NotifiedAt = c.now()
+	return c.writeState(s)
+}
+
+func (c *Checker) fetch(ctx context.Context, currentVersion string) (Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.Endpoint, nil)
+	if err != nil {
+		return Release{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "omni-cli/"+currentVersion)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return Release{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return Release{}, fmt.Errorf("checking latest release: unexpected HTTP %d", resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
+		return Release{}, fmt.Errorf("decoding latest release: %w", err)
+	}
+	if !validVersion(release.Version) || release.URL == "" {
+		return Release{}, fmt.Errorf("latest release response is missing a valid version or URL")
+	}
+	return release, nil
+}
+
+func result(current string, release Release) Result {
+	return Result{
+		UpdateAvailable: validVersion(current) && compareVersions(release.Version, current) > 0,
+		CurrentVersion:  current,
+		LatestVersion:   release.Version,
+		ReleaseURL:      release.URL,
+		PublishedAt:     release.PublishedAt,
+		Upgrade: UpgradeInstructions{
+			Homebrew: "brew upgrade omni",
+			Other:    "curl -fsSL https://raw.githubusercontent.com/exploreomni/cli/main/install.sh | sh",
+		},
+	}
+}
+
+func (c *Checker) readState() (state, error) {
+	data, err := os.ReadFile(c.StatePath)
+	if err != nil {
+		return state{}, err
+	}
+	var s state
+	if err := json.Unmarshal(data, &s); err != nil {
+		return state{}, err
+	}
+	return s, nil
+}
+
+func (c *Checker) writeState(s state) error {
+	dir := filepath.Dir(c.StatePath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dir, ".update-*.json")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp)
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		return err
+	}
+	if err := json.NewEncoder(f).Encode(s); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, c.StatePath); err == nil {
+		return nil
+	}
+	// Windows does not replace an existing destination with Rename. This cache
+	// is disposable, so a remove-and-retry is preferable to disabling checks.
+	if err := os.Remove(c.StatePath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(tmp, c.StatePath)
+}
+
+func (c *Checker) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+type parsedVersion struct {
+	major, minor, patch int
+	prerelease          []string
+}
+
+func validVersion(v string) bool {
+	_, ok := parseVersion(v)
+	return ok
+}
+
+// IsReleaseVersion reports whether v is a semantic release version.
+func IsReleaseVersion(v string) bool {
+	return validVersion(v)
+}
+
+func compareVersions(a, b string) int {
+	av, aok := parseVersion(a)
+	bv, bok := parseVersion(b)
+	if !aok || !bok {
+		return 0
+	}
+	for _, pair := range [][2]int{{av.major, bv.major}, {av.minor, bv.minor}, {av.patch, bv.patch}} {
+		if pair[0] < pair[1] {
+			return -1
+		}
+		if pair[0] > pair[1] {
+			return 1
+		}
+	}
+	if len(av.prerelease) == 0 && len(bv.prerelease) > 0 {
+		return 1
+	}
+	if len(av.prerelease) > 0 && len(bv.prerelease) == 0 {
+		return -1
+	}
+	for i := 0; i < len(av.prerelease) && i < len(bv.prerelease); i++ {
+		aa, aerr := strconv.Atoi(av.prerelease[i])
+		bb, berr := strconv.Atoi(bv.prerelease[i])
+		switch {
+		case aerr == nil && berr == nil && aa != bb:
+			if aa < bb {
+				return -1
+			}
+			return 1
+		case aerr == nil && berr != nil:
+			return -1
+		case aerr != nil && berr == nil:
+			return 1
+		case av.prerelease[i] < bv.prerelease[i]:
+			return -1
+		case av.prerelease[i] > bv.prerelease[i]:
+			return 1
+		}
+	}
+	if len(av.prerelease) < len(bv.prerelease) {
+		return -1
+	}
+	if len(av.prerelease) > len(bv.prerelease) {
+		return 1
+	}
+	return 0
+}
+
+func parseVersion(v string) (parsedVersion, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	v = strings.SplitN(v, "+", 2)[0]
+	parts := strings.SplitN(v, "-", 2)
+	core := strings.Split(parts[0], ".")
+	if len(core) != 3 {
+		return parsedVersion{}, false
+	}
+	nums := make([]int, 3)
+	for i, part := range core {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
+			return parsedVersion{}, false
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return parsedVersion{}, false
+		}
+		nums[i] = n
+	}
+	p := parsedVersion{major: nums[0], minor: nums[1], patch: nums[2]}
+	if len(parts) == 2 {
+		if parts[1] == "" {
+			return parsedVersion{}, false
+		}
+		p.prerelease = strings.Split(parts[1], ".")
+		for _, id := range p.prerelease {
+			if id == "" {
+				return parsedVersion{}, false
+			}
+		}
+	}
+	return p, true
+}

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gofrs/flock"
 )
 
 const (
@@ -30,10 +32,6 @@ const (
 	checkInterval  = 24 * time.Hour
 	failureBackoff = 15 * time.Minute
 	leaseDuration  = 30 * time.Second
-
-	// defaultLockStale is how long a lock file is honoured before it is
-	// treated as abandoned by a process that died while holding it.
-	defaultLockStale = 30 * time.Second
 )
 
 // Release is the subset of a GitHub release used by the updater.
@@ -60,9 +58,9 @@ type Result struct {
 	PublishedAt     time.Time           `json:"-"`
 }
 
-// state is the durable scheduler behind the automatic check. NextCheckAt alone
-// decides whether a check may run, and it is written *before* any networking,
-// so a cancelled or killed process still leaves a throttle behind.
+// state is the durable scheduler behind the automatic check. NextCheckAt is the
+// persistent throttle, and it is written *before* any networking, so a
+// cancelled or killed process still leaves a delay behind.
 // LeaseID/LeaseUntil name the process currently allowed to record a result:
 // the ID stops a slow owner from clobbering state claimed by a newer one, and
 // the deadline lets a crashed owner's claim be reclaimed.
@@ -82,11 +80,6 @@ type Checker struct {
 	Endpoint  string
 	StatePath string
 	Now       func() time.Time
-
-	// lockStale overrides defaultLockStale in tests. It is compared against
-	// the lock file's modification time, so it is measured on the real clock
-	// rather than on Now.
-	lockStale time.Duration
 }
 
 // New returns a checker suitable for CLI use.
@@ -99,12 +92,17 @@ func New() *Checker {
 	}
 }
 
-// DefaultStatePath returns the per-user update-check state file.
+// DefaultStatePath returns the per-user update-check state file, or an empty
+// path when the platform cache directory is unavailable. An empty path disables
+// automatic checks while leaving explicit checks usable.
 func DefaultStatePath() string {
 	dir, err := os.UserCacheDir()
-	if err != nil || dir == "" {
-		home, _ := os.UserHomeDir()
-		dir = filepath.Join(home, ".cache")
+	return statePathFromCacheDir(dir, err)
+}
+
+func statePathFromCacheDir(dir string, err error) string {
+	if err != nil || dir == "" || !filepath.IsAbs(dir) {
+		return ""
 	}
 	return filepath.Join(dir, "omni-cli", "update.json")
 }
@@ -122,11 +120,18 @@ func (c *Checker) Check(ctx context.Context, currentVersion string) (Result, err
 }
 
 // CheckAutomatic is the background check run alongside an interactive command.
-// It makes at most one request per checkInterval across every process sharing
-// the state file, and falls back to the cached release whenever a check isn't
-// due, the state is claimed elsewhere, or the request fails.
+// It waits checkInterval after a successful request and failureBackoff after a
+// failed one across every process sharing the state file. It falls back to the
+// cached release whenever a check isn't due, the state is claimed elsewhere,
+// or the request fails.
 func (c *Checker) CheckAutomatic(ctx context.Context, currentVersion string) (Result, error) {
-	cached, _ := c.readState()
+	if c.StatePath == "" {
+		return result(currentVersion, Release{}), nil
+	}
+	cached, readErr := c.readState()
+	if readErr == nil && automaticCheckDeferred(cached, c.now()) {
+		return result(currentVersion, cached.LatestRelease), nil
+	}
 	lease, claimed := c.claimCheck()
 	if !claimed {
 		return result(currentVersion, cached.LatestRelease), nil
@@ -150,7 +155,12 @@ func (c *Checker) CheckAutomatic(ctx context.Context, currentVersion string) (Re
 // recording under one lock is what stops concurrent commands from each
 // announcing the same release.
 func (c *Checker) ClaimNotification(r Result) bool {
-	if !r.UpdateAvailable {
+	if !r.UpdateAvailable || c.StatePath == "" {
+		return false
+	}
+	cached, readErr := c.readState()
+	now := c.now()
+	if readErr == nil && notificationRecentlyClaimed(cached, r, now) {
 		return false
 	}
 	unlock, ok := c.tryLock()
@@ -160,8 +170,8 @@ func (c *Checker) ClaimNotification(r Result) bool {
 	defer unlock()
 
 	s, _ := c.readState()
-	now := c.now()
-	if s.NotifiedVersion == r.LatestVersion && !s.NotifiedAt.IsZero() && now.Sub(s.NotifiedAt) < checkInterval {
+	now = c.now()
+	if notificationRecentlyClaimed(s, r, now) {
 		return false
 	}
 	s.NotifiedVersion = r.LatestVersion
@@ -180,10 +190,7 @@ func (c *Checker) claimCheck() (string, bool) {
 
 	s, _ := c.readState()
 	now := c.now()
-	if !s.NextCheckAt.IsZero() && now.Before(s.NextCheckAt) {
-		return "", false
-	}
-	if s.LeaseID != "" && now.Before(s.LeaseUntil) {
+	if automaticCheckDeferred(s, now) {
 		return "", false
 	}
 	id, err := newLeaseID()
@@ -200,6 +207,16 @@ func (c *Checker) claimCheck() (string, bool) {
 		return "", false
 	}
 	return id, true
+}
+
+func automaticCheckDeferred(s state, now time.Time) bool {
+	return (!s.NextCheckAt.IsZero() && now.Before(s.NextCheckAt)) ||
+		(s.LeaseID != "" && now.Before(s.LeaseUntil))
+}
+
+func notificationRecentlyClaimed(s state, r Result, now time.Time) bool {
+	return s.NotifiedVersion == r.LatestVersion &&
+		!s.NotifiedAt.IsZero() && now.Sub(s.NotifiedAt) < checkInterval
 }
 
 // finishCheck records the outcome of the check claimed under lease. A failure
@@ -249,10 +266,9 @@ func (c *Checker) recordCheck(release Release) {
 //
 // The lock is a stable, separate file: writeState replaces update.json with a
 // rename, so locking update.json itself would let a second process lock the
-// replacement while the first still held the old inode. An O_EXCL create is
-// atomic on Unix and Windows alike, which keeps this free of build-tagged
-// implementations; a lock left behind by a killed process is reclaimed once it
-// is older than lockStale.
+// replacement while the first still held the old inode. The file itself is
+// never removed; an OS-backed advisory lock provides ownership and is released
+// automatically if its process exits.
 func (c *Checker) tryLock() (func(), bool) {
 	if c.StatePath == "" {
 		return nil, false
@@ -260,36 +276,16 @@ func (c *Checker) tryLock() (func(), bool) {
 	if err := os.MkdirAll(filepath.Dir(c.StatePath), 0o700); err != nil {
 		return nil, false
 	}
-	path := c.lockPath()
-	for attempt := 0; attempt < 2; attempt++ {
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-		if err == nil {
-			_ = f.Close()
-			return func() { _ = os.Remove(path) }, true
-		}
-		if !os.IsExist(err) {
-			return nil, false
-		}
-		info, statErr := os.Stat(path)
-		if statErr != nil || time.Since(info.ModTime()) < c.lockStaleAfter() {
-			return nil, false
-		}
-		if err := os.Remove(path); err != nil {
-			return nil, false
-		}
+	lock := flock.New(c.lockPath(), flock.SetPermissions(0o600))
+	locked, err := lock.TryLock()
+	if err != nil || !locked {
+		return nil, false
 	}
-	return nil, false
+	return func() { _ = lock.Unlock() }, true
 }
 
 func (c *Checker) lockPath() string {
 	return strings.TrimSuffix(c.StatePath, ".json") + ".lock"
-}
-
-func (c *Checker) lockStaleAfter() time.Duration {
-	if c.lockStale > 0 {
-		return c.lockStale
-	}
-	return defaultLockStale
 }
 
 func newLeaseID() (string, error) {

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -59,7 +60,6 @@ func newTestChecker(t *testing.T, statePath string, clk *clock, rt roundTripFunc
 		Endpoint:  "https://example.test/latest",
 		StatePath: statePath,
 		Now:       clk.Now,
-		lockStale: 50 * time.Millisecond,
 	}
 }
 
@@ -140,6 +140,43 @@ func TestAutomaticCheckIsThrottled(t *testing.T) {
 	}
 	if requests != 2 {
 		t.Fatalf("requests = %d, want a second request after 24 hours", requests)
+	}
+}
+
+func TestAutomaticCheckFastPathDoesNotCreateTheLock(t *testing.T) {
+	clk := newClock()
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, func(*http.Request) (*http.Response, error) {
+		t.Fatal("a throttled check must not make a request")
+		return nil, nil
+	})
+	wantRelease := Release{Version: "v1.3.0", URL: "https://example.test/v1.3.0"}
+	if err := checker.writeState(state{
+		NextCheckAt:   clk.Now().Add(checkInterval),
+		LatestRelease: wantRelease,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := checker.CheckAutomatic(context.Background(), "v1.2.0")
+	if err != nil || got.LatestVersion != wantRelease.Version {
+		t.Fatalf("result = %+v, err = %v", got, err)
+	}
+	if _, err := os.Stat(checker.lockPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("throttled fast path touched the lock file: %v", err)
+	}
+}
+
+func TestAutomaticCheckIsDisabledWithoutAStatePath(t *testing.T) {
+	clk := newClock()
+	var requests int
+	checker := newTestChecker(t, "", clk, func(*http.Request) (*http.Response, error) {
+		requests++
+		return releaseResponse(200, releaseBody), nil
+	})
+
+	got, err := checker.CheckAutomatic(context.Background(), "v1.2.0")
+	if err != nil || got.UpdateAvailable || requests != 0 {
+		t.Fatalf("result = %+v, err = %v, requests = %d", got, err, requests)
 	}
 }
 
@@ -348,6 +385,25 @@ func TestNotificationThrottle(t *testing.T) {
 	}
 }
 
+func TestNotificationFastPathDoesNotCreateTheLock(t *testing.T) {
+	clk := newClock()
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, nil)
+	r := result("v1.2.0", Release{Version: "v1.3.0", URL: "https://example.test/release"})
+	if err := checker.writeState(state{
+		NotifiedVersion: r.LatestVersion,
+		NotifiedAt:      clk.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if checker.ClaimNotification(r) {
+		t.Fatal("a recently claimed notification should stay suppressed")
+	}
+	if _, err := os.Stat(checker.lockPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("notification fast path touched the lock file: %v", err)
+	}
+}
+
 func TestAutomaticCheckFallsBackToTheCachedRelease(t *testing.T) {
 	clk := newClock()
 	statePath := filepath.Join(t.TempDir(), "update.json")
@@ -382,23 +438,72 @@ func TestLockIsSeparateFromTheStateFile(t *testing.T) {
 	if !ok {
 		t.Fatal("expected to take the lock")
 	}
-	if _, ok := checker.tryLock(); ok {
+	contender := newTestChecker(t, statePath, clk, nil)
+	if _, ok := contender.tryLock(); ok {
 		t.Fatal("the lock should not be handed out twice")
 	}
 	unlock()
-	unlock2, ok := checker.tryLock()
+	before, err := os.Stat(checker.lockPath())
+	if err != nil {
+		t.Fatalf("the stable lock file was removed on unlock: %v", err)
+	}
+
+	unlock2, ok := contender.tryLock()
 	if !ok {
 		t.Fatal("expected the released lock to be available")
 	}
-	unlock2()
-
-	// A lock left behind by a killed process is eventually reclaimed.
-	if _, ok := checker.tryLock(); !ok {
-		t.Fatal("expected to take the lock")
+	after, err := os.Stat(checker.lockPath())
+	if err != nil || !os.SameFile(before, after) {
+		t.Fatalf("lock acquisition replaced the stable lock file: %v", err)
 	}
-	time.Sleep(2 * checker.lockStaleAfter())
-	if _, ok := checker.tryLock(); !ok {
-		t.Fatal("expected the stale lock to be reclaimed")
+	unlock2()
+}
+
+func TestLockIsReleasedWhenOwnerExits(t *testing.T) {
+	const childStatePathEnv = "OMNI_UPDATECHECK_TEST_LOCK_CHILD_STATE"
+	if statePath := os.Getenv(childStatePathEnv); statePath != "" {
+		checker := &Checker{StatePath: statePath}
+		if _, ok := checker.tryLock(); !ok {
+			os.Exit(2)
+		}
+		// Simulate abrupt process termination: do not call the unlock callback.
+		os.Exit(0)
+	}
+
+	statePath := filepath.Join(t.TempDir(), "update.json")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLockIsReleasedWhenOwnerExits$")
+	cmd.Env = append(os.Environ(), childStatePathEnv+"="+statePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("lock-owner subprocess: %v\n%s", err, output)
+	}
+
+	checker := &Checker{StatePath: statePath}
+	unlock, ok := checker.tryLock()
+	if !ok {
+		t.Fatal("the OS did not release the lock when its owner exited")
+	}
+	unlock()
+}
+
+func TestStatePathFromCacheDir(t *testing.T) {
+	cacheDir := t.TempDir()
+	if got, want := statePathFromCacheDir(cacheDir, nil), filepath.Join(cacheDir, "omni-cli", "update.json"); got != want {
+		t.Fatalf("statePathFromCacheDir() = %q, want %q", got, want)
+	}
+	for _, tc := range []struct {
+		name string
+		dir  string
+		err  error
+	}{
+		{name: "empty", dir: ""},
+		{name: "relative", dir: filepath.Join("relative", "cache")},
+		{name: "error", dir: cacheDir, err: errors.New("cache unavailable")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statePathFromCacheDir(tc.dir, tc.err); got != "" {
+				t.Fatalf("statePathFromCacheDir() = %q, want disabled", got)
+			}
+		})
 	}
 }
 

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -2,10 +2,15 @@ package updatecheck
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -22,66 +27,402 @@ func releaseResponse(status int, body string) *http.Response {
 	}
 }
 
-func TestCheckFetchesAndCachesLatestRelease(t *testing.T) {
-	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
-	requests := 0
-	checker := &Checker{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			requests++
-			if got := req.Header.Get("User-Agent"); got != "omni-cli/v1.2.0" {
-				t.Errorf("User-Agent = %q", got)
-			}
-			return releaseResponse(200, `{"tag_name":"v1.3.0","html_url":"https://example.test/v1.3.0","published_at":"2026-08-30T12:00:00Z"}`), nil
-		})},
-		Endpoint:  "https://example.test/latest",
-		StatePath: filepath.Join(t.TempDir(), "update.json"),
-		Now:       func() time.Time { return now },
-	}
+// clock is a test clock that is safe to read and advance from several
+// goroutines, which the concurrency tests below need.
+type clock struct {
+	mu  sync.Mutex
+	now time.Time
+}
 
-	got, err := checker.Check(context.Background(), "v1.2.0", false)
+func newClock() *clock {
+	return &clock{now: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *clock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *clock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+const releaseBody = `{"tag_name":"v1.3.0","html_url":"https://example.test/v1.3.0","published_at":"2026-08-30T12:00:00Z"}`
+
+func newTestChecker(t *testing.T, statePath string, clk *clock, rt roundTripFunc) *Checker {
+	t.Helper()
+	return &Checker{
+		Client:    &http.Client{Transport: rt},
+		Endpoint:  "https://example.test/latest",
+		StatePath: statePath,
+		Now:       clk.Now,
+		lockStale: 50 * time.Millisecond,
+	}
+}
+
+func TestCheckAlwaysFetchesAndCaches(t *testing.T) {
+	clk := newClock()
+	var requests int
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, func(req *http.Request) (*http.Response, error) {
+		requests++
+		if got := req.Header.Get("User-Agent"); got != "omni-cli/v1.2.0" {
+			t.Errorf("User-Agent = %q", got)
+		}
+		return releaseResponse(200, releaseBody), nil
+	})
+
+	got, err := checker.Check(context.Background(), "v1.2.0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.UpdateAvailable || got.LatestVersion != "v1.3.0" || got.Upgrade.Homebrew != "brew upgrade omni" {
+	if !got.UpdateAvailable || got.LatestVersion != "v1.3.0" {
 		t.Fatalf("result = %+v", got)
 	}
 
-	now = now.Add(time.Hour)
-	got, err = checker.Check(context.Background(), "v1.2.0", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if requests != 1 {
-		t.Fatalf("requests = %d, want cached result after one request", requests)
-	}
-	if got.LatestVersion != "v1.3.0" {
-		t.Fatalf("cached result = %+v", got)
-	}
-
-	if _, err := checker.Check(context.Background(), "v1.2.0", true); err != nil {
+	// An explicit check is never served from the cache.
+	if _, err := checker.Check(context.Background(), "v1.2.0"); err != nil {
 		t.Fatal(err)
 	}
 	if requests != 2 {
-		t.Fatalf("requests = %d after forced check, want 2", requests)
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+
+	// It does record the result, so the automatic path stays throttled.
+	clk.advance(time.Hour)
+	if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want the automatic check to reuse the cached release", requests)
+	}
+}
+
+func TestCheckSucceedsWhenTheCacheIsUnwritable(t *testing.T) {
+	clk := newClock()
+	// A path under a file (rather than a directory) can never be created.
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocked, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checker := newTestChecker(t, filepath.Join(blocked, "update.json"), clk, func(*http.Request) (*http.Response, error) {
+		return releaseResponse(200, releaseBody), nil
+	})
+	got, err := checker.Check(context.Background(), "v1.2.0")
+	if err != nil || got.LatestVersion != "v1.3.0" {
+		t.Fatalf("result = %+v, err = %v", got, err)
+	}
+}
+
+func TestAutomaticCheckIsThrottled(t *testing.T) {
+	clk := newClock()
+	var requests int
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, func(*http.Request) (*http.Response, error) {
+		requests++
+		return releaseResponse(200, releaseBody), nil
+	})
+
+	for i := 0; i < 3; i++ {
+		if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+			t.Fatal(err)
+		}
+		clk.advance(time.Hour)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want one request within 24 hours", requests)
+	}
+
+	clk.advance(checkInterval)
+	if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want a second request after 24 hours", requests)
+	}
+}
+
+func TestConcurrentAutomaticChecksMakeOneRequest(t *testing.T) {
+	clk := newClock()
+	statePath := filepath.Join(t.TempDir(), "update.json")
+	var requests atomic.Int64
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		started <- struct{}{}
+		<-release
+		return releaseResponse(200, releaseBody), nil
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		checker := newTestChecker(t, statePath, clk, transport)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no check was started")
+	}
+	close(release)
+	wg.Wait()
+
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want exactly one outbound check", got)
+	}
+}
+
+func TestFailedCheckDoesNotRetryImmediately(t *testing.T) {
+	clk := newClock()
+	var requests int
+	fail := true
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, func(*http.Request) (*http.Response, error) {
+		requests++
+		if fail {
+			return nil, errors.New("offline")
+		}
+		return releaseResponse(200, releaseBody), nil
+	})
+
+	if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err == nil {
+		t.Fatal("expected the first check to fail")
+	}
+	for i := 0; i < 3; i++ {
+		_, _ = checker.CheckAutomatic(context.Background(), "v1.2.0")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want the failed attempt to back off", requests)
+	}
+
+	fail = false
+	clk.advance(failureBackoff + time.Minute)
+	if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want a retry after the backoff", requests)
+	}
+}
+
+func TestCancelledCheckDoesNotRetryImmediately(t *testing.T) {
+	clk := newClock()
+	var requests int
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, func(req *http.Request) (*http.Response, error) {
+		requests++
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+
+	// The command finished before the check did, exactly as the CLI does.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := checker.CheckAutomatic(ctx, "v1.2.0"); err == nil {
+		t.Fatal("expected a cancelled check to fail")
+	}
+	got, err := checker.CheckAutomatic(context.Background(), "v1.2.0")
+	if err != nil || got.UpdateAvailable {
+		t.Fatalf("throttled check = %+v, err = %v", got, err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want the cancelled attempt to back off", requests)
+	}
+}
+
+func TestExpiredLeaseIsReclaimed(t *testing.T) {
+	clk := newClock()
+	var requests int
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, func(*http.Request) (*http.Response, error) {
+		requests++
+		return releaseResponse(200, releaseBody), nil
+	})
+
+	// A process that died holding the lease: the lease is never released and
+	// only the short backoff was written.
+	lease, ok := checker.claimCheck()
+	if !ok || lease == "" {
+		t.Fatal("expected the first claim to succeed")
+	}
+	if _, claimed := checker.claimCheck(); claimed {
+		t.Fatal("a live lease should not be reclaimed")
+	}
+
+	clk.advance(failureBackoff + leaseDuration)
+	if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want the abandoned lease to be reclaimed", requests)
+	}
+	s, err := checker.readState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.LeaseID != "" || s.LatestRelease.Version != "v1.3.0" {
+		t.Fatalf("state = %+v", s)
+	}
+}
+
+func TestStaleLeaseOwnerCannotOverwriteNewerState(t *testing.T) {
+	clk := newClock()
+	statePath := filepath.Join(t.TempDir(), "update.json")
+	checker := newTestChecker(t, statePath, clk, nil)
+
+	stale, ok := checker.claimCheck()
+	if !ok {
+		t.Fatal("expected the first claim to succeed")
+	}
+
+	// The owner stalls past its lease; a second process claims and records a
+	// newer release.
+	clk.advance(failureBackoff + leaseDuration)
+	fresh, ok := checker.claimCheck()
+	if !ok {
+		t.Fatal("expected the expired lease to be reclaimed")
+	}
+	checker.finishCheck(fresh, Release{Version: "v1.4.0", URL: "https://example.test/v1.4.0"}, nil)
+
+	// The stale owner finally returns with an older answer.
+	checker.finishCheck(stale, Release{Version: "v1.3.0", URL: "https://example.test/v1.3.0"}, nil)
+
+	s, err := checker.readState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.LatestRelease.Version != "v1.4.0" {
+		t.Fatalf("stale owner overwrote the state: %+v", s)
+	}
+	if !s.NextCheckAt.Equal(clk.Now().Add(checkInterval)) {
+		t.Fatalf("NextCheckAt = %v", s.NextCheckAt)
+	}
+}
+
+func TestConcurrentNotificationClaimsProduceOneNotice(t *testing.T) {
+	clk := newClock()
+	statePath := filepath.Join(t.TempDir(), "update.json")
+	r := result("v1.2.0", Release{Version: "v1.3.0", URL: "https://example.test/release"})
+
+	var claims atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		checker := newTestChecker(t, statePath, clk, nil)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if checker.ClaimNotification(r) {
+				claims.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := claims.Load(); got != 1 {
+		t.Fatalf("claims = %d, want exactly one notice", got)
 	}
 }
 
 func TestNotificationThrottle(t *testing.T) {
-	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
-	checker := &Checker{StatePath: filepath.Join(t.TempDir(), "update.json"), Now: func() time.Time { return now }}
+	clk := newClock()
+	checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), clk, nil)
 	r := result("v1.2.0", Release{Version: "v1.3.0", URL: "https://example.test/release"})
-	if !checker.NotificationDue(r) {
-		t.Fatal("new release should be due before its first notification")
+	if !checker.ClaimNotification(r) {
+		t.Fatal("a new release should be claimable before its first notification")
 	}
-	if err := checker.MarkNotified(r.LatestVersion); err != nil {
-		t.Fatal(err)
-	}
-	if checker.NotificationDue(r) {
+	if checker.ClaimNotification(r) {
 		t.Fatal("notification should be suppressed for 24 hours")
 	}
-	now = now.Add(25 * time.Hour)
-	if !checker.NotificationDue(r) {
+	clk.advance(25 * time.Hour)
+	if !checker.ClaimNotification(r) {
 		t.Fatal("notification should be due again after 24 hours")
+	}
+	if checker.ClaimNotification(result("v1.3.0", Release{Version: "v1.3.0"})) {
+		t.Fatal("an up-to-date result should never be claimed")
+	}
+}
+
+func TestAutomaticCheckFallsBackToTheCachedRelease(t *testing.T) {
+	clk := newClock()
+	statePath := filepath.Join(t.TempDir(), "update.json")
+	offline := false
+	checker := newTestChecker(t, statePath, clk, func(*http.Request) (*http.Response, error) {
+		if offline {
+			return nil, errors.New("offline")
+		}
+		return releaseResponse(200, releaseBody), nil
+	})
+	if _, err := checker.CheckAutomatic(context.Background(), "v1.2.0"); err != nil {
+		t.Fatal(err)
+	}
+
+	offline = true
+	clk.advance(checkInterval + time.Hour)
+	got, err := checker.CheckAutomatic(context.Background(), "v1.2.0")
+	if err != nil || got.LatestVersion != "v1.3.0" {
+		t.Fatalf("result = %+v, err = %v", got, err)
+	}
+}
+
+func TestLockIsSeparateFromTheStateFile(t *testing.T) {
+	clk := newClock()
+	statePath := filepath.Join(t.TempDir(), "update.json")
+	checker := newTestChecker(t, statePath, clk, nil)
+	if got := checker.lockPath(); got != filepath.Join(filepath.Dir(statePath), "update.lock") {
+		t.Fatalf("lockPath() = %q", got)
+	}
+
+	unlock, ok := checker.tryLock()
+	if !ok {
+		t.Fatal("expected to take the lock")
+	}
+	if _, ok := checker.tryLock(); ok {
+		t.Fatal("the lock should not be handed out twice")
+	}
+	unlock()
+	unlock2, ok := checker.tryLock()
+	if !ok {
+		t.Fatal("expected the released lock to be available")
+	}
+	unlock2()
+
+	// A lock left behind by a killed process is eventually reclaimed.
+	if _, ok := checker.tryLock(); !ok {
+		t.Fatal("expected to take the lock")
+	}
+	time.Sleep(2 * checker.lockStaleAfter())
+	if _, ok := checker.tryLock(); !ok {
+		t.Fatal("expected the stale lock to be reclaimed")
+	}
+}
+
+func TestUpgradeInstructionsArePlatformSpecific(t *testing.T) {
+	windows := upgradeInstructions("windows")
+	if windows.Homebrew != "" || strings.Contains(windows.Other, "install.sh") {
+		t.Fatalf("windows instructions = %+v, want no Homebrew and no install.sh", windows)
+	}
+	if !strings.Contains(windows.Other, releasesPage) {
+		t.Fatalf("windows instructions = %+v, want the releases page", windows)
+	}
+	for _, goos := range []string{"darwin", "linux"} {
+		got := upgradeInstructions(goos)
+		if got.Homebrew != "brew upgrade omni" || got.Other != installCommand {
+			t.Fatalf("%s instructions = %+v", goos, got)
+		}
+	}
+	// The JSON contract keeps "other" even when Homebrew is unavailable.
+	data, err := json.Marshal(windows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "homebrew") || !strings.Contains(string(data), `"other"`) {
+		t.Fatalf("windows JSON = %s", data)
 	}
 }
 
@@ -118,14 +459,10 @@ func TestCheckRejectsBadResponses(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			checker := &Checker{
-				Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-					return tt.resp, nil
-				})},
-				Endpoint:  "https://example.test/latest",
-				StatePath: filepath.Join(t.TempDir(), "update.json"),
-			}
-			if _, err := checker.Check(context.Background(), "v1.2.0", true); err == nil {
+			checker := newTestChecker(t, filepath.Join(t.TempDir(), "update.json"), newClock(), func(*http.Request) (*http.Response, error) {
+				return tt.resp, nil
+			})
+			if _, err := checker.Check(context.Background(), "v1.2.0"); err == nil {
 				t.Fatal("expected an error")
 			}
 		})

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,133 @@
+package updatecheck
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func releaseResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestCheckFetchesAndCachesLatestRelease(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	requests := 0
+	checker := &Checker{
+		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			if got := req.Header.Get("User-Agent"); got != "omni-cli/v1.2.0" {
+				t.Errorf("User-Agent = %q", got)
+			}
+			return releaseResponse(200, `{"tag_name":"v1.3.0","html_url":"https://example.test/v1.3.0","published_at":"2026-08-30T12:00:00Z"}`), nil
+		})},
+		Endpoint:  "https://example.test/latest",
+		StatePath: filepath.Join(t.TempDir(), "update.json"),
+		Now:       func() time.Time { return now },
+	}
+
+	got, err := checker.Check(context.Background(), "v1.2.0", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.UpdateAvailable || got.LatestVersion != "v1.3.0" || got.Upgrade.Homebrew != "brew upgrade omni" {
+		t.Fatalf("result = %+v", got)
+	}
+
+	now = now.Add(time.Hour)
+	got, err = checker.Check(context.Background(), "v1.2.0", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want cached result after one request", requests)
+	}
+	if got.LatestVersion != "v1.3.0" {
+		t.Fatalf("cached result = %+v", got)
+	}
+
+	if _, err := checker.Check(context.Background(), "v1.2.0", true); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d after forced check, want 2", requests)
+	}
+}
+
+func TestNotificationThrottle(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	checker := &Checker{StatePath: filepath.Join(t.TempDir(), "update.json"), Now: func() time.Time { return now }}
+	r := result("v1.2.0", Release{Version: "v1.3.0", URL: "https://example.test/release"})
+	if !checker.NotificationDue(r) {
+		t.Fatal("new release should be due before its first notification")
+	}
+	if err := checker.MarkNotified(r.LatestVersion); err != nil {
+		t.Fatal(err)
+	}
+	if checker.NotificationDue(r) {
+		t.Fatal("notification should be suppressed for 24 hours")
+	}
+	now = now.Add(25 * time.Hour)
+	if !checker.NotificationDue(r) {
+		t.Fatal("notification should be due again after 24 hours")
+	}
+}
+
+func TestVersionComparison(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.2.3", "v1.2.2", 1},
+		{"1.2.3", "v1.2.3", 0},
+		{"v2.0.0", "v10.0.0", -1},
+		{"v1.0.0", "v1.0.0-rc.1", 1},
+		{"v1.0.0-beta.2", "v1.0.0-beta.11", -1},
+		{"v1.0.0+build.2", "v1.0.0+build.1", 0},
+	}
+	for _, tt := range tests {
+		if got := compareVersions(tt.a, tt.b); got != tt.want {
+			t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+	if IsReleaseVersion("dev") || IsReleaseVersion("v1.2") || !IsReleaseVersion("v1.2.3") {
+		t.Fatal("release version validation returned unexpected results")
+	}
+}
+
+func TestCheckRejectsBadResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *http.Response
+	}{
+		{"http status", releaseResponse(500, `{}`)},
+		{"malformed json", releaseResponse(200, `{`)},
+		{"invalid release", releaseResponse(200, `{"tag_name":"latest"}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &Checker{
+				Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return tt.resp, nil
+				})},
+				Endpoint:  "https://example.test/latest",
+				StatePath: filepath.Join(t.TempDir(), "update.json"),
+			}
+			if _, err := checker.Check(context.Background(), "v1.2.0", true); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Notify humans, and let agents ask, when a newer Omni CLI release exists — without ever slowing down or corrupting the output of the command the user actually ran.

### The automatic path is a durable scheduler

`update.json` is not a passive cache; it is a small persistent scheduler shared by every process on the machine:

```go
type state struct {
    CheckedAt       time.Time
    NextCheckAt     time.Time
    LeaseID         string
    LeaseUntil      time.Time
    LatestRelease   Release
    NotifiedVersion string
    NotifiedAt      time.Time
}
```

`NextCheckAt` alone decides whether a check may run, and `claimCheck` writes it **before any networking** — a short 15-minute backoff. A process that is cancelled, killed, offline, or rate-limited therefore still leaves a throttle behind, so the next invocation does not retry immediately. Only on success does `finishCheck` promote it to `now + 24h`.

`LeaseID`/`LeaseUntil` name the one process allowed to record an outcome: the ID stops a slow owner from clobbering state claimed by a newer one, and the 30s deadline lets a crashed owner's claim be reclaimed.

Locking is a stable, separate `update.lock` — never `update.json`, which `writeState` replaces by rename, so locking it would let a second process lock the replacement while the first still held the old inode. It is an `O_EXCL` create, atomic on Unix and Windows alike, so there are no build-tagged implementations and no Unix-only `flock` to break the Windows build. It is acquired non-blockingly: if another process holds it the check is skipped, and the requested command never waits on the updater. A lock orphaned by a killed process is reclaimed once stale.

Notification claiming goes through a single `ClaimNotification(result) bool` that locks, re-reads, decides and persists atomically, so concurrent commands announce a release once between them rather than racing a check-then-mark.

If the cache directory or lock cannot be created, automatic checking skips silently. The explicit `omni update check` still returns its fetched result even when caching fails.

### Eligibility comes from the parsed command

The check starts from the root's `PersistentPreRunE`, so `cmd` is the command cobra resolved and its flags are parsed. Format is read from the parsed flag, which means every spelling cobra accepts — `-o json`, `-ojson`, `--format=json`, `--FORMAT json` — is honoured, and a JSON invocation in a PTY can no longer receive a human banner on stderr. `omni help ...` and the `update`/`completion` groups are excluded by the resolved command, matched at the top level so an API command that happens to be named `update` (`omni dashboards update`) still gets a notice.

Notices are also suppressed for non-release builds, `CI`, and `OMNI_NO_UPDATE_NOTIFIER`.

### Platform-correct upgrade advice

Homebrew installs are detected and get `brew upgrade omni`, with a 24-hour grace period after publication so the notice doesn't arrive before the formula does. `install.sh` explicitly refuses to run on Windows, so Windows users are pointed at the release downloads instead of a command that would fail.

### Agent-facing check

`omni update check` returns structured JSON. It resolves the requested format *before* checking, so a failure is reported as the normal structured error envelope on stderr with cobra's duplicate `Error: ...` line silenced — the JSON contract holds on the failure path too. The explicit check is documented in `omni agent-help`.

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./...` all clean
- Concurrency tests run multiple `Checker` instances against one state path with a barrier-controlled transport and a mutex-guarded fake clock, proving: two simultaneous due checks make one outbound request; a failed or cancelled attempt does not retry immediately; an expired lease is reclaimed; a stale lease owner cannot overwrite newer state; concurrent notification claims produce one notice; the lock is a separate file from the state
- Coverage for every `--format` spelling, the JSON and human failure paths, the unknown-subcommand path, Homebrew suppression, and platform-specific upgrade instructions

Closes #90
